### PR TITLE
docs/tests: recommend SSE transport and cover MCP SSE path

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,44 @@ the project captures deterministic evidence; the fix is human-applied.
 
 ### 🤖 MCP Server (16 Tools for AI Agents)
 
-Expose ChatGPT to Claude Desktop, Cursor, Craft Agent, or any MCP client:
+Expose ChatGPT to Claude Desktop, Cursor, Craft Agent, or any MCP client. Two
+transports are supported — **SSE is recommended** for persistent clients like
+ZCode; stdio is kept as a compatibility/dev mode.
+
+#### Recommended: SSE transport (one persistent server)
+
+SSE is recommended for ZCode because one long-lived MCP server can serve many
+client sessions without spawning a new MCP process or Chrome tab per session.
+Start the SSE server once, then point any number of clients at it.
+
+Start it (in a dedicated terminal — Chrome must already be running with an
+authenticated session, i.e. `chatgpt-web2api` started first):
+
+```bash
+chatgpt-web2api-mcp --transport sse --port 8090
+```
+
+Then add the client config:
+
+```json
+{
+  "mcpServers": {
+    "chatgpt-web2api-sse": {
+      "type": "sse",
+      "url": "http://localhost:8090/sse"
+    }
+  }
+}
+```
+
+Every client session that attaches to that URL shares the single MCP server
+and its Chrome connection — there is no per-session process or tab growth.
+
+#### Alternative: stdio transport (per-session, dev/debug)
+
+Stdio spawns one MCP child process per client session, so it is not
+recommended for many concurrent ZCode sessions. It is useful for single-client
+setups, local development, and debugging (logs go straight to stderr):
 
 ```json
 {
@@ -242,8 +279,9 @@ Gated tools are **hidden** from `list_tools` *and* **refused at call time** — 
 # Terminal 1: Start Chrome + API
 chatgpt-web2api
 
-# Terminal 2: MCP server (for AI agents)
-chatgpt-web2api-mcp
+# Terminal 2: MCP server (SSE recommended for ZCode; stdio also supported)
+chatgpt-web2api-mcp --transport sse --port 8090
+# or: chatgpt-web2api-mcp             # stdio (one MCP child per client)
 
 # Terminal 3: Any OpenAI SDK, curl, or HTTP client
 curl http://localhost:8080/v1/chat/completions ...

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -79,30 +79,24 @@ may move the code, but Phase 1 makes failures visible first.
 
 ---
 
-## Phase 2 — Make SSE the recommended ZCode transport
+## Phase 2 — Make SSE the recommended ZCode transport  ✅ DONE
 
 **Goal:** replace stdio-per-session as the recommended mode. Eliminate the
 process multiplier (N ZCode sessions × stdio = N MCP children × N tabs).
 
-### Deliverables
+### Deliverables — all shipped
 
-1. **Document SSE config** (recommended):
-   ```json
-   {
-     "chatgpt-web2api-sse": {
-       "type": "sse",
-       "url": "http://localhost:8090/sse"
-     }
-   }
-   ```
-2. **Document stdio** as compatibility / dev-debug mode only. Not recommended
-   for many concurrent ZCode sessions.
-3. **Integration tests** for SSE:
+1. ✅ **Document SSE config** (recommended) — README now presents SSE first
+   with the `chatgpt-web2api-sse` snippet and launch command.
+2. ✅ **Document stdio** as compatibility / dev-debug mode only — README
+   repositions stdio under "Alternative," noting one MCP child per session.
+3. ✅ **Integration tests** for SSE (`tests/test_e2e_sse.py`, e2e-gated) —
+   real `sse_client` + uvicorn over a non-8090 port:
    - initialize handshake
    - list tools
    - list models
-   - one chat call
-   - repeated fresh connections (proves no tab/process growth)
+   - one chat call (also the live regression for the #10/#11 deadlock)
+   - repeated fresh connections (asserts no per-connection CDP target growth)
 
 ### Reframed constraint
 
@@ -116,24 +110,22 @@ Recommended ZCode mode is SSE-only:
 The vague "detect many stdio processes and warn" item is **dropped from v1** —
 under-specified, cross-cutting. Optional later.
 
-### Known follow-up (discovered during Phase 0 verification, 2026-06-25)
+### Known follow-up — ✅ RESOLVED (was discovered Phase 0, 2026-06-25)
 
 ```text
 MCP/SSE chat_completion can complete server-side but timeout client-side on
 response delivery. Short SSE tools work.
 ```
 
-Reproduction: `initialize` OK, `tools/list` OK (9 tools), `list_models` OK
-(1034 bytes returned). But `chat_completion` over SSE times out client-side
-at 120s — while the send *did* reach Chrome and the reply appeared in the
-account (conversation titled with the requested marker string). The REST
-chat path returned the same kind of generation in ~2s.
+**Resolved by #11** (fix `70f014a`): root cause was a completion-detection
+deadlock — on a new chat, `conv_id_for_check` was empty for the whole poll
+loop, disabling the backend `end_turn` fallback. With the DOM action-button
+selector drifted (3rd time), no completion signal fired and the loop ran to
+the 120s deadline. Fix resolves `conv_id_for_check` mid-loop from the live
+URL. Live SSE `chat_completion` now completes in 2–12s (was 120s+/timeout).
 
-This is a Phase 2 transport bug, **not** a PR #9 stabilization regression.
-Track under Phase 2. Debug hypotheses to check: progress notifications
-blocking, async generator never completing, MCP response never posted to
-`/messages`, uvicorn/starlette SSE flush/backpressure, or a long-running
-tool timeout mismatch.
+Diagnosis details: [issue #10 comment](https://github.com/Octo-Lex/ChatGPT-Web2API/issues/10#issuecomment-4796158081).
+Remaining follow-up: the DOM `has_action` selector is still dead — tracked in #12.
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,14 +149,13 @@ def pytest_runtest_makereport(item, call):
     if item.get_closest_marker("e2e") is None:
         return
     from chatgpt_web2api.cdp_driver import RateLimitError
+
     # The exception is recorded on the call's excinfo.
     if call.excinfo and isinstance(call.excinfo.value, RateLimitError):
         report.outcome = "skipped"
         # longrepr as a plain string is the standard way pytest records a
         # skip reason. Do NOT set wasxfail — that flips it to xfail handling.
-        report.longrepr = (
-            f"ChatGPT rate-limited the account: {call.excinfo.value}"
-        )
+        report.longrepr = f"ChatGPT rate-limited the account: {call.excinfo.value}"
 
 
 @pytest_asyncio.fixture(scope="session")
@@ -216,6 +215,92 @@ async def e2e_driver(e2e_login_ready, e2e_config: Config) -> CDPDriver:
     await driver.close()
 
 
+@pytest_asyncio.fixture
+async def e2e_sse_server(e2e_login_ready, e2e_config: Config) -> str:
+    """Start a real uvicorn SSE MCP server for e2e tests, return its URL.
+
+    Function-scoped (NOT session-scoped) on purpose: pytest-asyncio with
+    ``asyncio_mode="auto"`` runs each async test on its own loop, so a
+    session-scoped server would live on a different loop than the test's
+    ``sse_client`` — the HTTP request would be serviced on the server's loop
+    but the response could never reach the test's loop, and the call hangs.
+    Running the server per test keeps it on the same loop as the client.
+    Startup is ~4s, acceptable for opt-in e2e.
+
+    Runs on a non-8090 port so it never contends with an operational SSE
+    server. Wired to a dedicated driver via the module globals (the same
+    wiring ``_live_server`` in test_e2e_mcp uses), independent of the
+    per-test ``e2e_driver``.
+
+    Readiness is polled via a TCP socket connect — NOT a ``GET /sse``, which
+    would hold the connection open and look like a hang. Teardown cancels the
+    server task so no task is left dangling and the port is free for the next
+    test.
+    """
+    import socket as _socket
+
+    import chatgpt_web2api.mcp_server as mod
+
+    port = int(os.environ.get("W2A_SSE_PORT", "18090"))
+
+    # Fail clearly if the chosen port is already occupied (avoids a confusing
+    # "address in use" from uvicorn mid-test).
+    with _socket.socket() as probe:
+        try:
+            probe.bind(("127.0.0.1", port))
+        except OSError as e:
+            raise RuntimeError(
+                f"e2e_sse_server: port {port} is occupied. Set W2A_SSE_PORT to a free port. ({e})"
+            )
+
+    # Dedicated driver for the SSE server this test, separate from the
+    # per-test e2e_driver. Wire the module globals so create_server()/_run_sse
+    # see it.
+    sse_driver = CDPDriver(cdp_port=e2e_config.chrome.cdp_port)
+    await sse_driver.connect()
+    mod._driver = sse_driver
+    mod._config = e2e_config
+    mod._lock = asyncio.Lock()
+
+    server = mod.create_server()
+    init_options = server.create_initialization_options()
+
+    # Run _run_sse as a background task; it serves until cancelled at teardown.
+    sse_task = asyncio.create_task(mod._run_sse(server, init_options, e2e_config, port))
+
+    url = f"http://127.0.0.1:{port}/sse"
+
+    # Wait for the TCP port to accept connections (server readiness). Poll
+    # rather than GET /sse: an SSE endpoint holds the connection open, so an
+    # HTTP probe can look like a hang even when the server is correct.
+    deadline = time.monotonic() + 15.0
+    ready = False
+    while time.monotonic() < deadline:
+        try:
+            with _socket.socket() as s:
+                s.settimeout(0.5)
+                s.connect(("127.0.0.1", port))
+                ready = True
+                break
+        except OSError:
+            await asyncio.sleep(0.2)
+    if not ready:
+        sse_task.cancel()
+        await asyncio.gather(sse_task, return_exceptions=True)
+        raise TimeoutError(f"SSE server did not become ready on port {port}")
+
+    yield url
+
+    # Clean teardown: cancel the server task, then close the driver. Cancelling
+    # (and awaiting the gather) avoids a dangling task / occupied port on the
+    # next test.
+    try:
+        sse_task.cancel()
+        await asyncio.gather(sse_task, return_exceptions=True)
+    finally:
+        await sse_driver.close()
+
+
 async def _wait_for_login(driver: CDPDriver, timeout: int) -> None:
     """Navigate to chatgpt.com and poll for an auth token (mirrors Service)."""
     print("\n" + "=" * 52 + "\n  NOT LOGGED IN — log into ChatGPT in the window\n" + "=" * 52)
@@ -266,8 +351,11 @@ async def e2e_cleanup(e2e_created, e2e_config: Config, request):
     only ever ids the tests themselves created. No-op if no e2e tests ran.
     """
     yield
-    if not e2e_created["conversations"] and not e2e_created["memories"] \
-            and not e2e_created["projects"]:
+    if (
+        not e2e_created["conversations"]
+        and not e2e_created["memories"]
+        and not e2e_created["projects"]
+    ):
         return
     driver = CDPDriver(cdp_port=e2e_config.chrome.cdp_port)
     try:
@@ -291,8 +379,10 @@ async def e2e_cleanup(e2e_created, e2e_config: Config, request):
             # works but create_project's payload is broken — tracked as xfail).
             deleter = getattr(driver, "delete_project", None)
             if deleter is None:
-                print(f"[e2e cleanup] project {pid} has no delete method — "
-                      "remove manually in the ChatGPT UI.")
+                print(
+                    f"[e2e cleanup] project {pid} has no delete method — "
+                    "remove manually in the ChatGPT UI."
+                )
                 continue
             try:
                 await deleter(pid)
@@ -300,4 +390,3 @@ async def e2e_cleanup(e2e_created, e2e_config: Config, request):
                 print(f"[e2e cleanup] could not delete project {pid}: {e}")
     finally:
         await driver.close()
-

--- a/tests/test_e2e_sse.py
+++ b/tests/test_e2e_sse.py
@@ -23,13 +23,14 @@ from mcp.client.sse import sse_client
 pytestmark = pytest.mark.e2e
 
 
-def _chatgpt_target_count(cdp_port: int = 9222) -> int:
+def _chatgpt_target_count(cdp_port: int) -> int:
     """Count open Chrome CDP targets whose URL is on chatgpt.com.
 
     Used by the no-growth test: the SSE invariant is that repeated client
     connections do NOT spawn a new Chrome tab per connection. We count CDP
     targets (not OS processes) because that is the resource we actually care
-    about.
+    about. The CDP port is passed in (not hard-coded) so non-default-port
+    e2e runs query the correct Chrome instance.
     """
     try:
         with urllib.request.urlopen(f"http://127.0.0.1:{cdp_port}/json/list", timeout=5) as r:
@@ -114,7 +115,7 @@ async def test_sse_chat_completion(e2e_sse_server: str, e2e_created: dict):
 # ── 5. repeated connections do not grow Chrome tabs ────────────────────
 
 
-async def test_sse_repeated_connections_no_growth(e2e_sse_server: str):
+async def test_sse_repeated_connections_no_growth(e2e_sse_server: str, e2e_config):
     """The core SSE selling point: N client sessions share one MCP server
     with no per-connection Chrome tab growth.
 
@@ -123,13 +124,14 @@ async def test_sse_repeated_connections_no_growth(e2e_sse_server: str):
     start or send-readiness path may create/reclaim one owned tab, so we
     allow ``after <= before + 1``.
     """
-    before = _chatgpt_target_count()
+    cdp_port = e2e_config.chrome.cdp_port
+    before = _chatgpt_target_count(cdp_port)
     for _ in range(3):
         async with sse_client(e2e_sse_server) as (read, write):
             async with ClientSession(read, write) as session:
                 await session.initialize()
                 await session.list_tools()
-    after = _chatgpt_target_count()
+    after = _chatgpt_target_count(cdp_port)
     if before < 0 or after < 0:
         pytest.skip("CDP /json/list unreachable; cannot assert target count")
     assert after <= before + 1, (

--- a/tests/test_e2e_sse.py
+++ b/tests/test_e2e_sse.py
@@ -1,0 +1,137 @@
+"""E2E for the MCP **SSE transport** over a real HTTP/SSE network path.
+
+Unlike ``test_e2e_mcp.py`` (which uses the in-memory transport and bypasses
+uvicorn / ``/sse`` / ``/messages``), these tests connect a real
+``mcp.client.sse.sse_client`` to a real uvicorn SSE server started by the
+``e2e_sse_server`` session fixture. This is the only place the SSE network
+path — the recommended ZCode transport — is exercised.
+
+The fixture runs on a non-8090 port (default 18090) so it never contends with
+an operational SSE server. ``chat_completion`` over SSE here is also the live
+regression test for issue #10/#11 (the SSE completion deadlock fix).
+
+Run with:  W2A_E2E_RUN=1 pytest tests/test_e2e_sse.py -m e2e -v
+"""
+
+import json
+import urllib.request
+
+import pytest
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+
+pytestmark = pytest.mark.e2e
+
+
+def _chatgpt_target_count(cdp_port: int = 9222) -> int:
+    """Count open Chrome CDP targets whose URL is on chatgpt.com.
+
+    Used by the no-growth test: the SSE invariant is that repeated client
+    connections do NOT spawn a new Chrome tab per connection. We count CDP
+    targets (not OS processes) because that is the resource we actually care
+    about.
+    """
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{cdp_port}/json/list", timeout=5) as r:
+            targets = json.loads(r.read())
+    except Exception:
+        return -1  # unreachable — test will skip the strict assertion
+    return sum(1 for t in targets if "chatgpt.com" in (t.get("url") or ""))
+
+
+# ── 1. initialize handshake ────────────────────────────────────────────
+
+
+async def test_sse_initialize_handshake(e2e_sse_server: str):
+    """A real SSE client completes the MCP initialize handshake."""
+    async with sse_client(e2e_sse_server) as (read, write):
+        async with ClientSession(read, write) as session:
+            result = await session.initialize()
+            assert result.protocolVersion
+            assert hasattr(result, "capabilities")
+
+
+# ── 2. list_tools (gated surface) ──────────────────────────────────────
+
+
+async def test_sse_list_tools(e2e_sse_server: str):
+    """list_tools over SSE returns the same gated surface as in-memory."""
+    async with sse_client(e2e_sse_server) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            resp = await session.list_tools()
+            names = {t.name for t in resp.tools}
+            assert "list_models" in names
+            assert "chat_completion" in names
+            # Destructive tools hidden without W2A_ENABLE_DESTRUCTIVE
+            assert "delete_memory" not in names
+
+
+# ── 3. list_models ─────────────────────────────────────────────────────
+
+
+async def test_sse_list_models(e2e_sse_server: str):
+    """list_models round-trips over the real SSE transport to ChatGPT."""
+    async with sse_client(e2e_sse_server) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool("list_models", {})
+            assert result.isError is not True
+            text = result.content[0].text
+            assert "gpt" in text.lower() or "auto" in text.lower(), (
+                f"no model slug in response: {text[:200]!r}"
+            )
+
+
+# ── 4. chat_completion (regression for #10/#11) ────────────────────────
+
+
+async def test_sse_chat_completion(e2e_sse_server: str, e2e_created: dict):
+    """chat_completion works end-to-end over the SSE network path.
+
+    This is the live regression test for issue #10/#11: the SSE completion
+    deadlock that timed out at 120s before the conv_id resolution fix. It must
+    complete in seconds, not time out.
+    """
+    marker = "W2A-E2E-SSE-CHAT-OK"
+    async with sse_client(e2e_sse_server) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            result = await session.call_tool(
+                "chat_completion",
+                {"message": f"Reply with exactly this token: {marker}"},
+            )
+            assert result.isError is not True
+            data = result.structuredContent or {}
+            cid = data.get("conversation_id", "")
+            if cid:
+                e2e_created["conversations"].add(cid)
+            assert marker in str(data.get("content", "")), (
+                f"marker missing from structured content: {data}"
+            )
+
+
+# ── 5. repeated connections do not grow Chrome tabs ────────────────────
+
+
+async def test_sse_repeated_connections_no_growth(e2e_sse_server: str):
+    """The core SSE selling point: N client sessions share one MCP server
+    with no per-connection Chrome tab growth.
+
+    Count CDP targets before and after opening 3 fresh SSE sessions. The
+    invariant is "no per-connection growth," not exact equality — a cold
+    start or send-readiness path may create/reclaim one owned tab, so we
+    allow ``after <= before + 1``.
+    """
+    before = _chatgpt_target_count()
+    for _ in range(3):
+        async with sse_client(e2e_sse_server) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                await session.list_tools()
+    after = _chatgpt_target_count()
+    if before < 0 or after < 0:
+        pytest.skip("CDP /json/list unreachable; cannot assert target count")
+    assert after <= before + 1, (
+        f"SSE caused tab growth: before={before} after={after} (3 connections)"
+    )


### PR DESCRIPTION
## Summary

ROADMAP Phase 2 packaging: makes SSE the recommended ZCode transport. **Docs + e2e tests only — no server behavior change.**

## Changes

### README — SSE recommended, stdio dev mode
- SSE presented first ("Recommended: SSE transport") with the `chatgpt-web2api-sse` client snippet + launch command.
- Wording per spec: *"SSE is recommended for ZCode because one long-lived MCP server can serve many client sessions without spawning a new MCP process or Chrome tab per session."* — no absolute "one tab" claim.
- stdio repositioned under "Alternative: stdio transport (per-session, dev/debug)", existing config block intact.
- "Three Interfaces" block updated to show the SSE launch variant.

### ROADMAP.md
- Phase 2 marked **DONE** (all 3 deliverables shipped).
- #10/#11 known-followup marked **RESOLVED** — stale "times out at 120s" text corrected.

### tests/test_e2e_sse.py — 5 e2e tests over the real SSE network path
These are the first tests to exercise the SSE/HTTP path (existing MCP tests use in-memory transport, bypassing uvicorn/`/sse`/`/messages`):
1. `test_sse_initialize_handshake` — initialize over real `sse_client`
2. `test_sse_list_tools` — gated tool surface
3. `test_sse_list_models` — model slug round-trip
4. `test_sse_chat_completion` — marker token in structuredContent (**live regression for #11** over the network path)
5. `test_sse_repeated_connections_no_growth` — 3 fresh connections; CDP target count `assert after <= before + 1`

### conftest.py — `e2e_sse_server` fixture
- **Function-scoped** (NOT session-scoped): pytest-asyncio `asyncio_mode=auto` runs each test on its own loop; a session-scoped server hangs because the request is serviced on a different loop than the client. Documented in the fixture docstring.
- Non-8090 port (`W2A_SSE_PORT`, default `18090`) — never contends with the operational server.
- Readiness via TCP socket connect (not `GET /sse`, which holds the connection open).
- Clean teardown: cancels server task + closes driver; no dangling task / occupied port.

## Verification
- `ruff check .` + `ruff format --check .` — clean
- Unit suite: **315 passed** (e2e deselected; no regression)
- Live SSE e2e: **5 passed** (`W2A_E2E_RUN=1 pytest tests/test_e2e_sse.py -m e2e -v`)

## Out of scope (per plan)
- No `chatgpt-web2api-sse` console script
- No `ensure` command (Phase 3)
- No DOM selector work (#12)
- No server behavior change

## Deviation from plan
One: `e2e_sse_server` is **function-scoped**, not session-scoped as originally planned. Reason: under `asyncio_mode=auto`, a session-scoped async fixture runs on a different event loop than the test function, so the SSE client's request is serviced on the server's loop but the response never reaches the test's loop — the call hangs. Function scope keeps server and client on the same loop. Cost: ~4s server startup per test (acceptable for opt-in e2e). Documented in the fixture docstring.
