### PR TITLE
fix(driver): prefer backend end_turn completion over DOM action buttons

### DIFF
--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -1752,13 +1752,21 @@ class CDPDriver:
                     # the assistant message node — so a plain
                     # ``last.querySelector(...)`` finds nothing and completion is
                     # never detected (every send stalled at the 90s ceiling). The
-                    # fix: walk up to 4 ancestors, querying down at each scope,
-                    # and require the button to be GEOMETRICALLY NEAR the message
-                    # (below it, within ~240px) so an older turn's action row
-                    # can't falsely complete a brand-new answer. New testid scheme
-                    # is ``*-turn-action-button`` (copy/good-response/bad-response);
-                    # the legacy ``response-turn`` selector is retained for older
-                    # deployments but no longer matches anything on current ChatGPT.
+                    # fix: walk up ancestors, querying down at each scope, and
+                    # require the button to be GEOMETRICALLY NEAR the message so
+                    # an older turn's action row can't falsely complete a brand-new
+                    # answer. New testid scheme is ``*-turn-action-button``
+                    # (copy/good-response/bad-response); the legacy
+                    # ``response-turn`` selector is retained for older deployments
+                    # but no longer matches anything on current ChatGPT.
+                    #
+                    # Depth was 4; raised to 8 after issue #12 found the action
+                    # row at ancestor depth 6. The geometry window is widened to
+                    # accept buttons rendered ABOVE the message (top - 180) —
+                    # short answers place the action row in the spacing above the
+                    # message node, which the old top-8 gate rejected. This is a
+                    # FALLBACK signal now (backend end_turn is primary); kept as an
+                    # escape hatch for when conv_id is unavailable or backend fails.
                     '  var ACT = \'[data-testid="copy-turn-action-button"],'
                     '            [data-testid="good-response-turn-action-button"],'
                     '            [data-testid="bad-response-turn-action-button"],'
@@ -1768,7 +1776,7 @@ class CDPDriver:
                     "  var has_action = (function() {"
                     "    var lastRect = last.getBoundingClientRect();"
                     "    var scope = last;"
-                    "    for (var d = 0; scope && d <= 4; d++, scope = scope.parentElement) {"
+                    "    for (var d = 0; scope && d <= 8; d++, scope = scope.parentElement) {"
                     "      var btns = Array.prototype.filter.call("
                     "        scope.querySelectorAll(ACT),"
                     "        function(el){ return el.offsetParent !== null || el.getClientRects().length > 0; }"
@@ -1776,7 +1784,7 @@ class CDPDriver:
                     "      if (!btns.length) continue;"
                     "      for (var i = 0; i < btns.length; i++) {"
                     "        var r = btns[i].getBoundingClientRect();"
-                    "        if (r.top >= lastRect.top - 8 && r.top <= lastRect.bottom + 240) {"
+                    "        if (r.top >= lastRect.top - 180 && r.top <= lastRect.bottom + 240) {"
                     "          return true;"
                     "        }"
                     "      }"
@@ -1857,20 +1865,14 @@ class CDPDriver:
             last_html_len = html_len
             last_child_count = child_count
 
-            # Done: the new message has its action button (copy/feedback),
-            # which ChatGPT renders only on a finished turn. This is immune to
-            # the Stop-button flicker and the empty-.markdown-during-streaming
-            # quirk that broke the earlier heuristics.
-            if has_action:
-                break
-
-            # Resolve the in-flight conversation id for new chats (SSE/MCP path
-            # and the first send on a fresh REST session). conv_id_for_check is
-            # "" here when _current_conv_id is None — without this probe the
-            # backend end_turn fallback below never runs for new conversations,
-            # leaving only the (brittle, drift-prone) DOM action-button as a
-            # completion signal. Throttled to one URL probe per second; stops
-            # probing once a conv_id is found. See issue #10.
+            # ── Completion detection ─────────────────────────────────────
+            # Two signals, ordered by stability. Backend end_turn is PRIMARY
+            # (issue #12): it survived three DOM action-button drifts where the
+            # DOM selector failed. The DOM has_action is a FALLBACK for the
+            # window where conv_id is unavailable (before the URL resolves, ~1s
+            # into a new chat) or when the backend fetch fails transiently.
+            #
+            # Resolve conv_id first (needed for the primary signal on new chats).
             if not conv_id_for_check:
                 now = time.monotonic()
                 if now - last_conv_id_probe >= 1.0:
@@ -1885,17 +1887,13 @@ class CDPDriver:
                     except Exception as e:
                         logger.debug("conv_id probe failed (ignored): %s", e)
 
-            # Backend end_turn fallback (R4): when the DOM action-button
-            # selector drifts (it has, twice — composer redesign + the
-            # sibling-container layout), has_action stays false and the loop
-            # would stall. The conversation API's end_turn flag on the latest
-            # assistant text node is a stable secondary signal. Throttled to
-            # one fetch per 3s, only when has_action is false. Eligible when
-            # we have streamed text OR have seen a thinking phase — a long
-            # reasoning response has empty last_dom_text during thinking, but
-            # the backend can still report end_turn once the model finishes.
-            # Completion stays strict (end_turn AND usable content), so this
-            # unlock can't complete an empty answer. Fetch failures ignored.
+            # PRIMARY: backend end_turn. Throttled to one fetch per 3s to respect
+            # the shared account rate budget. Eligible when we have streamed text
+            # OR have seen a thinking phase — a long reasoning response has empty
+            # last_dom_text during thinking, but the backend reports end_turn once
+            # the model finishes. Completion stays strict (end_turn AND usable
+            # content) so this can't complete an empty answer. Fetch failures
+            # fall through to the DOM fallback below.
             if (
                 conv_id_for_check
                 and (last_dom_text or saw_thinking or is_thinking)
@@ -1904,14 +1902,12 @@ class CDPDriver:
                 last_backend_check = time.monotonic()
                 try:
                     if await self._fetch_end_turn(conv_id_for_check):
-                        # Completion stays STRICT: end_turn AND usable content.
-                        # The unlock (saw_thinking) lets us CONSULT the backend
-                        # during thinking, but we must not finish on a bare
-                        # end_turn with no answer text/non-text content — that
-                        # would complete an empty response.
+                        # STRICT: end_turn AND usable content. The saw_thinking
+                        # unlock lets us CONSULT the backend during thinking, but
+                        # we must not finish on a bare end_turn with no answer.
                         if last_dom_text or had_non_text_content:
                             logger.info(
-                                "Backend end_turn=true (completion fallback) for %s",
+                                "Backend end_turn=true (primary completion) for %s",
                                 conv_id_for_check,
                             )
                             break
@@ -1921,7 +1917,14 @@ class CDPDriver:
                             conv_id_for_check,
                         )
                 except Exception as e:
-                    logger.debug("end_turn fallback fetch failed (ignored): %s", e)
+                    logger.debug("end_turn fetch failed (ignored): %s", e)
+
+            # FALLBACK: DOM action button (has_action). Used when conv_id is
+            # unavailable or the backend fetch failed. ChatGPT renders the
+            # copy/feedback row only on a finished turn. See the JS block above
+            # for the depth-8 / widened-geometry selector rationale.
+            if has_action:
+                break
 
             if time.monotonic() - last_change_time > PHASE_STALL_SECONDS:
                 raise GenerationStuckError("phase_2_stream", time.monotonic() - last_change_time)

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -1892,11 +1892,12 @@ class CDPDriver:
             # OR have seen a thinking phase — a long reasoning response has empty
             # last_dom_text during thinking, but the backend reports end_turn once
             # the model finishes. Completion stays strict (end_turn AND usable
-            # content) so this can't complete an empty answer. Fetch failures
-            # fall through to the DOM fallback below.
+            # content) so this can't complete an empty answer. Fetch failures set
+            # backend_fetch_failed so the DOM fallback below is unlocked this poll.
+            backend_fetch_failed = False
             if (
                 conv_id_for_check
-                and (last_dom_text or saw_thinking or is_thinking)
+                and (last_dom_text or saw_thinking or is_thinking or had_non_text_content)
                 and time.monotonic() - last_backend_check > 3.0
             ):
                 last_backend_check = time.monotonic()
@@ -1917,13 +1918,24 @@ class CDPDriver:
                             conv_id_for_check,
                         )
                 except Exception as e:
+                    backend_fetch_failed = True
                     logger.debug("end_turn fetch failed (ignored): %s", e)
 
-            # FALLBACK: DOM action button (has_action). Used when conv_id is
-            # unavailable or the backend fetch failed. ChatGPT renders the
-            # copy/feedback row only on a finished turn. See the JS block above
-            # for the depth-8 / widened-geometry selector rationale.
-            if has_action:
+            # FALLBACK: DOM action button (has_action). Used ONLY when the primary
+            # backend signal can't run: conv_id is unavailable (before the URL
+            # resolves) OR the backend fetch just failed this poll. When the
+            # backend IS available it is authoritative — a widened has_action
+            # match (depth 8, top-180) can hit a PRIOR turn's action row, so DOM
+            # must not override a live backend that says "not done yet" or that
+            # hasn't been consulted yet due to throttle. Also requires usable
+            # content (same strict guard as the primary) so it can't complete an
+            # empty answer off a stale button.
+            if (
+                has_action
+                and (not conv_id_for_check or backend_fetch_failed)
+                and (last_dom_text or had_non_text_content)
+            ):
+                logger.info("DOM has_action (fallback completion) — no backend signal")
                 break
 
             if time.monotonic() - last_change_time > PHASE_STALL_SECONDS:

--- a/tests/test_end_turn_primary.py
+++ b/tests/test_end_turn_primary.py
@@ -1,0 +1,216 @@
+"""Regression tests for issue #12: end_turn is now the primary completion signal.
+
+The DOM action-button selector (has_action) drifted structurally — ancestor
+depth limit too shallow AND geometry gate rejects short-answer buttons (see
+the #12 DOM investigation). Backend end_turn has proven stable across all
+three drifts, so it is now checked FIRST when conv_id is available;
+has_action is a fallback for the pre-conv_id window.
+
+These tests verify the Python-side completion POLICY (which signal wins),
+using the same mocking pattern as test_sse_end_turn_new_chat.py:
+monkeypatch time.monotonic + asyncio.sleep, fake _js_strict returning
+phase-appropriate JSON, AsyncMock for _fetch_end_turn / type_message /
+click_send / _fetch_text.
+"""
+
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.cdp_driver import CDPDriver
+
+
+def _make_driver():
+    d = CDPDriver(cdp_port=9222)
+    d._ws = MagicMock()
+    d._access_token = "tok"
+    d._token_fetched_at = time.time()
+    return d
+
+
+def _install_virtual_clock(monkeypatch, start=0.0):
+    t = [start]
+    monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
+    async def fast_sleep(s):
+        t[0] += s
+
+    monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
+    return t
+
+
+def _phase1_then_phase2_js(
+    state, *, phase1_turn_after=2, phase2_factory=None, url="https://chatgpt.com/c/resolved-conv-id"
+):
+    """Fake _js_strict distinguishing Phase-1 (appear) from Phase-2 (poll)."""
+
+    async def _fake_js(expr, timeout=15):
+        if "body.innerText" in expr:
+            return json.dumps({"text": "normal"})
+        if "has_action" in expr:
+            state["phase2"] += 1
+            return json.dumps(phase2_factory(state["phase2"]))
+        if ".length" in expr and "querySelectorAll" in expr and "JSON.stringify" not in expr:
+            state["phase1"] += 1
+            return "1" if state["phase1"] >= phase1_turn_after else "0"
+        if "location.href" in expr:
+            return url
+        return ""
+
+    return _fake_js
+
+
+# ── 1. end_turn=True wins even when has_action=False ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_end_turn_wins_over_no_has_action(monkeypatch):
+    """When end_turn=True and there's usable text, completion fires even if
+    has_action never becomes true (the #12 drift scenario). end_turn is PRIMARY."""
+    d = _make_driver()
+    _install_virtual_clock(monkeypatch)
+    state = {"phase1": 0, "phase2": 0}
+
+    def phase2(n):
+        text = "The answer." if n > 2 else ""
+        return {
+            "text": text,
+            "md_text": text,
+            "html_len": 50,
+            "child_count": 1,
+            "has_action": False,
+            "is_thinking": False,
+        }
+
+    d._js_strict = _phase1_then_phase2_js(state, phase2_factory=phase2)
+    d.type_message = AsyncMock()
+    d.click_send = AsyncMock()
+    d._fetch_text = AsyncMock(return_value="")
+    d._fetch_end_turn = AsyncMock(return_value=True)
+
+    chunks = []
+    async for chunk in d.send_and_stream("hello", timeout=10000):
+        chunks.append(chunk)
+
+    deltas = [c.delta for c in chunks if c.delta]
+    assert any("The answer" in c for c in deltas), f"deltas: {deltas}"
+    assert chunks[-1].finish_reason == "stop"
+    assert d._fetch_end_turn.await_count >= 1
+
+
+# ── 2. end_turn=True wins even when is_thinking=True ───────────────────
+
+
+@pytest.mark.asyncio
+async def test_end_turn_wins_over_is_thinking(monkeypatch):
+    """The stale-thinking deadlock: is_thinking stays True (lingering
+    .result-thinking), has_action never fires. end_turn must still complete."""
+    d = _make_driver()
+    _install_virtual_clock(monkeypatch)
+    state = {"phase1": 0, "phase2": 0}
+
+    def phase2(n):
+        text = "Done." if n > 2 else ""
+        return {
+            "text": text,
+            "md_text": text,
+            "html_len": 253,
+            "child_count": 1,
+            "has_action": False,
+            "is_thinking": True,
+        }
+
+    d._js_strict = _phase1_then_phase2_js(state, phase2_factory=phase2)
+    d.type_message = AsyncMock()
+    d.click_send = AsyncMock()
+    d._fetch_text = AsyncMock(return_value="")
+    d._fetch_end_turn = AsyncMock(return_value=True)
+
+    chunks = []
+    async for chunk in d.send_and_stream("hello", timeout=10000):
+        chunks.append(chunk)
+
+    deltas = [c.delta for c in chunks if c.delta]
+    assert any("Done" in c for c in deltas), f"deltas: {deltas}"
+    assert chunks[-1].finish_reason == "stop"
+
+
+# ── 3. has_action=True completes when no conv_id is available ──────────
+
+
+@pytest.mark.asyncio
+async def test_has_action_fallback_without_conv_id(monkeypatch):
+    """When conv_id is unavailable (URL never resolves to /c/), has_action
+    is the fallback completion signal and must still work."""
+    d = _make_driver()
+    _install_virtual_clock(monkeypatch)
+    state = {"phase1": 0, "phase2": 0}
+
+    def phase2(n):
+        text = "Fallback answer." if n > 2 else ""
+        return {
+            "text": text,
+            "md_text": text,
+            "html_len": 60,
+            "child_count": 1,
+            "has_action": n > 4,
+            "is_thinking": False,
+        }
+
+    # URL never becomes a /c/ URL — conv_id stays empty
+    d._js_strict = _phase1_then_phase2_js(
+        state, phase2_factory=phase2, url="https://chatgpt.com/?model=auto"
+    )
+    d.type_message = AsyncMock()
+    d.click_send = AsyncMock()
+    d._fetch_text = AsyncMock(return_value="")
+    d._fetch_end_turn = AsyncMock(return_value=True)  # should NOT be called
+
+    chunks = []
+    async for chunk in d.send_and_stream("hello", timeout=10000):
+        chunks.append(chunk)
+
+    # Completed via has_action (the fallback), NOT end_turn (conv_id was empty)
+    deltas = [c.delta for c in chunks if c.delta]
+    assert any("Fallback answer" in c for c in deltas), f"deltas: {deltas}"
+    assert chunks[-1].finish_reason == "stop"
+    # end_turn was never consulted because conv_id_for_check was never set
+    assert d._fetch_end_turn.await_count == 0
+
+
+# ── 4. JS selector walks to ancestor depth 8 (structural check) ────────
+
+
+def test_has_action_js_walks_depth_8():
+    """The JS has_action selector must walk up to depth 8 (was 4) so it
+    reaches the action row at ancestor depth 6. This is a structural check
+    on the JS source — the depth limit is what the #12 investigation found
+    was too shallow."""
+    import inspect
+
+    from chatgpt_web2api.cdp_driver import CDPDriver
+
+    src = inspect.getsource(CDPDriver.send_and_stream)
+    # The walk loop bound must be 8, not the old 4
+    assert "d <= 8" in src, "has_action JS must walk d <= 8 ancestors (was 4)"
+    assert "d <= 4" not in src, "old d <= 4 depth limit must be gone"
+
+
+# ── 5. JS geometry window accepts buttons above the message ───────────
+
+
+def test_has_action_js_geometry_accepts_above_message():
+    """Short answers place the action button ABOVE the message node. The
+    geometry gate must accept top >= lastRect.top - 180 (was -8). Structural
+    check on the JS source."""
+    import inspect
+
+    from chatgpt_web2api.cdp_driver import CDPDriver
+
+    src = inspect.getsource(CDPDriver.send_and_stream)
+    # The geometry window must be widened to top-180 (the #12 short-answer case)
+    assert "lastRect.top - 180" in src, (
+        "geometry gate must accept buttons 180px above message (was top - 8)"
+    )

--- a/tests/test_end_turn_primary.py
+++ b/tests/test_end_turn_primary.py
@@ -214,3 +214,58 @@ def test_has_action_js_geometry_accepts_above_message():
     assert "lastRect.top - 180" in src, (
         "geometry gate must accept buttons 180px above message (was top - 8)"
     )
+
+
+# ── 6. has_action must NOT override a live backend that says "not done" ─
+
+
+@pytest.mark.asyncio
+async def test_has_action_does_not_complete_when_backend_says_not_done(monkeypatch):
+    """Regression for the review finding on PR #14: with conv_id available and
+    backend end_turn=False, a widened has_action match (e.g. a prior turn's
+    action row caught by depth-8 / top-180) must NOT complete early. The
+    backend is authoritative when available; DOM is fallback only.
+
+    Setup: conv_id resolves after ~1s (the real new-chat timing), text is
+    present (usable content), has_action goes True on poll 3+ (simulating the
+    widened false-match appearing once the DOM settles), but end_turn stays
+    False. The loop must keep polling until the stall guard raises
+    GenerationStuckError — proving it did NOT break on the stale has_action.
+    """
+    d = _make_driver()
+    _install_virtual_clock(monkeypatch)
+    state = {"phase1": 0, "phase2": 0}
+
+    def phase2(n):
+        text = "Streaming answer."  # usable content present from the start
+        # has_action False early (conv_id window), True from poll 3+ —
+        # simulates a prior turn's button caught by the widened selector once
+        # the DOM settles. By poll 3 the virtual clock has advanced past 1s so
+        # conv_id has resolved and the backend is authoritative.
+        return {
+            "text": text,
+            "md_text": text,
+            "html_len": 60,
+            "child_count": 1,
+            "has_action": n >= 3,
+            "is_thinking": False,
+        }
+
+    d._js_strict = _phase1_then_phase2_js(state, phase2_factory=phase2)
+    d.type_message = AsyncMock()
+    d.click_send = AsyncMock()
+    d._fetch_text = AsyncMock(return_value="")
+    # Backend is reachable but says NOT done — authoritative
+    d._fetch_end_turn = AsyncMock(return_value=False)
+
+    from chatgpt_web2api.cdp_driver import GenerationStuckError
+
+    chunks = []
+    with pytest.raises(GenerationStuckError):
+        async for chunk in d.send_and_stream("hello", timeout=10000):
+            chunks.append(chunk)
+
+    # The loop polled the backend (conv_id resolved after ~1s) and did NOT
+    # break on has_action — it ran until the stall guard fired. Proves the DOM
+    # signal cannot override a live backend.
+    assert d._fetch_end_turn.await_count >= 1, "backend must be consulted once conv_id is available"

--- a/tests/test_non_text_response.py
+++ b/tests/test_non_text_response.py
@@ -27,6 +27,7 @@ def _make_driver():
 
 # ── 1. Image-like DOM: html_len grows, text stays empty → no stall ────
 
+
 @pytest.mark.asyncio
 async def test_image_response_does_not_stall(monkeypatch):
     """Image generation: html_len grows (img/canvas elements added) but text
@@ -35,11 +36,14 @@ async def test_image_response_does_not_stall(monkeypatch):
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
 
     state = {"phase1_polls": 0, "phase2_polls": 0}
+
     async def _fake_js(expr, timeout=15):
         if "body.innerText" in expr:
             return json.dumps({"text": "normal"})
@@ -52,7 +56,9 @@ async def test_image_response_does_not_stall(monkeypatch):
             # message. False while the image renders, True after ~50s of
             # progress. This is the completion signal the driver now uses.
             has_action = n > 100
-            return json.dumps({"text": "", "html_len": html_len, "child_count": 1, "has_action": has_action})
+            return json.dumps(
+                {"text": "", "html_len": html_len, "child_count": 1, "has_action": has_action}
+            )
         if ".length" in expr and "querySelectorAll" in expr and "JSON.stringify" not in expr:
             # Phase 1 count poll
             state["phase1_polls"] += 1
@@ -60,6 +66,7 @@ async def test_image_response_does_not_stall(monkeypatch):
         if "location.href" in expr:
             return "https://chatgpt.com/c/test-image-conv"
         return ""
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
@@ -78,6 +85,7 @@ async def test_image_response_does_not_stall(monkeypatch):
 
 # ── 2. Text DOM: streams delta as before, no regression ───────────────
 
+
 @pytest.mark.asyncio
 async def test_text_response_streams_delta_unchanged(monkeypatch):
     """Normal text response: .markdown text grows each poll. Must stream
@@ -85,11 +93,14 @@ async def test_text_response_streams_delta_unchanged(monkeypatch):
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
 
     state = {"phase1": 0, "phase2": 0, "text": ""}
+
     async def _fake_js(expr, timeout=15):
         if "body.innerText" in expr:
             return json.dumps({"text": "normal"})
@@ -97,16 +108,19 @@ async def test_text_response_streams_delta_unchanged(monkeypatch):
             state["phase2"] += 1
             state["text"] += "Hello world. "  # text grows
             has_action = state["phase2"] > 5
-            return json.dumps({
-                "text": state["text"],
-                "html_len": len(state["text"]) + 20,
-                "child_count": 1,
-                "has_action": has_action,
-            })
+            return json.dumps(
+                {
+                    "text": state["text"],
+                    "html_len": len(state["text"]) + 20,
+                    "child_count": 1,
+                    "has_action": has_action,
+                }
+            )
         if ".length" in expr and "querySelectorAll" in expr and "JSON.stringify" not in expr:
             state["phase1"] += 1
             return "1" if state["phase1"] > 1 else "0"
         return ""
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
@@ -126,6 +140,7 @@ async def test_text_response_streams_delta_unchanged(monkeypatch):
 
 # ── 3. _fetch_text empty + non-text content → placeholder ────────────
 
+
 @pytest.mark.asyncio
 async def test_placeholder_on_empty_fetch_with_non_text_content(monkeypatch):
     """When Phase-2 detects non-text content (html_len > 50) but _fetch_text
@@ -133,33 +148,43 @@ async def test_placeholder_on_empty_fetch_with_non_text_content(monkeypatch):
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
 
     state = {"phase1": 0, "phase2": 0}
+
     async def _fake_js(expr, timeout=15):
         if "body.innerText" in expr:
             return json.dumps({"text": "normal"})
         if "has_action" in expr:
             state["phase2"] += 1
             has_action = state["phase2"] > 3
-            return json.dumps({
-                "text": "",
-                "html_len": 200,  # non-text content present
-                "child_count": 2,
-                "has_action": has_action,
-            })
+            return json.dumps(
+                {
+                    "text": "",
+                    "html_len": 200,  # non-text content present
+                    "child_count": 2,
+                    "has_action": has_action,
+                }
+            )
         if ".length" in expr and "querySelectorAll" in expr and "JSON.stringify" not in expr:
             state["phase1"] += 1
             return "1" if state["phase1"] > 1 else "0"
         if "location.href" in expr:
             return "https://chatgpt.com/c/test-conv-123"
         return ""
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
     d._fetch_text = AsyncMock(return_value="")  # API returns no text
+    # Updated for #12: backend end_turn is primary when conv_id is available.
+    # This test's URL resolves to /c/test-conv-123, so the backend is consulted.
+    # end_turn confirms completion once the non-text content is present.
+    d._fetch_end_turn = AsyncMock(return_value=True)
 
     chunks = []
     async for chunk in d.send_and_stream("generate image", timeout=10000):

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -20,6 +20,7 @@ from chatgpt_web2api.cdp_driver import (
 
 # ── Helpers ────────────────────────────────────────────────────
 
+
 def _make_driver():
     """A CDPDriver with a mocked websocket (no real connect)."""
     d = CDPDriver(cdp_port=9222)
@@ -32,13 +33,16 @@ def _make_driver():
 def _mock_js_with_payload(d, payload_map):
     """Make d._js_with_data return values based on a lookup of (conv_id/token)
     → response string. For _fetch_text the payload carries conv_id+token."""
+
     async def _fake(js_template, data, timeout=15):
         return payload_map.get(data.get("conv_id"), "")
+
     d._js_with_data_strict = _fake
     return d
 
 
 # ── 1. Auth TTL ────────────────────────────────────────────────
+
 
 @pytest.mark.asyncio
 async def test_ensure_token_refreshes_when_empty():
@@ -69,25 +73,32 @@ async def test_ensure_token_no_refresh_when_fresh():
 
 # ── 2. 15-site guard ───────────────────────────────────────────
 
+
 @pytest.mark.asyncio
 async def test_read_methods_call_ensure_token_first():
     """A representative read method (get_models) calls ensure_token before its
     fetch. Verify via mock call-order."""
     d = _make_driver()
     d._refresh_token = AsyncMock()
+
     # _js_with_data returns a models JSON string
     async def _fake(js_template, data, timeout=15):
         return json.dumps({"title": "Models", "models": [{"slug": "auto", "title": "Auto"}]})
+
     d._js_with_data_strict = _fake
     # Patch ensure_token to record the call distinctly
     call_order = []
+
     async def _record_token():
         call_order.append("ensure_token")
         return d._access_token
+
     d.ensure_token = _record_token
+
     async def _rec_js(template, data, timeout=15):
         call_order.append("fetch")
         return json.dumps({"title": "M", "models": [{"slug": "auto", "title": "A"}]})
+
     d._js_with_data_strict = _rec_js
     await d.get_models()
     assert call_order == ["ensure_token", "fetch"], f"order: {call_order}"
@@ -95,11 +106,14 @@ async def test_read_methods_call_ensure_token_first():
 
 # ── 3. _fetch_text 401 raises AuthExpiredError ─────────────────
 
+
 @pytest.mark.asyncio
 async def test_fetch_text_401_raises_auth_expired():
     d = _make_driver()
+
     async def _fake(js_template, data, timeout=15):
         return '{"__status": 401}'
+
     d._js_with_data_strict = _fake
     d.ensure_token = AsyncMock(return_value="tok")
     with pytest.raises(AuthExpiredError):
@@ -110,8 +124,10 @@ async def test_fetch_text_401_raises_auth_expired():
 async def test_fetch_text_404_raises_runtime_error():
     """Non-401 non-OK status surfaces as RuntimeError with the code, not silent ''."""
     d = _make_driver()
+
     async def _fake(js_template, data, timeout=15):
         return '{"__status": 404}'
+
     d._js_with_data_strict = _fake
     d.ensure_token = AsyncMock(return_value="tok")
     with pytest.raises(RuntimeError) as ei:
@@ -122,8 +138,10 @@ async def test_fetch_text_404_raises_runtime_error():
 @pytest.mark.asyncio
 async def test_fetch_text_valid_body_returns_text():
     d = _make_driver()
+
     async def _fake(js_template, data, timeout=15):
         return "the assistant reply text"
+
     d._js_with_data_strict = _fake
     d.ensure_token = AsyncMock(return_value="tok")
     result = await d._fetch_text("conv-1")
@@ -131,6 +149,7 @@ async def test_fetch_text_valid_body_returns_text():
 
 
 # ── 4. Phase-1 stall (node count never changes) ────────────────
+
 
 @pytest.mark.asyncio
 async def test_phase1_stall_raises_generation_stuck(monkeypatch):
@@ -140,21 +159,27 @@ async def test_phase1_stall_raises_generation_stuck(monkeypatch):
     d = _make_driver()
     # Mock time to accelerate the test: advance monotonic fast.
     t = [0.0]
+
     def fake_monotonic():
         return t[0]
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", fake_monotonic)
+
     async def fast_sleep(s):
         t[0] += s  # each sleep advances "time" by the sleep amount
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
 
     # _js returns: rate-limit scan = harmless text; assistant count = constant 1
     call = {"n": 0}
+
     async def _fake_js(expr, timeout=15):
         call["n"] += 1
         # Count poll is the bare .length expression (no JSON.stringify)
         if "JSON.stringify" not in expr and ".length" in expr:
             return "1"  # constant count, never > initial_count
         return '{"text":"normal page text"}'
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
@@ -167,14 +192,17 @@ async def test_phase1_stall_raises_generation_stuck(monkeypatch):
 
 # ── 5. Phase-2 stall (text never changes, Stop present) ────────
 
+
 @pytest.mark.asyncio
 async def test_phase2_stall_raises_generation_stuck(monkeypatch):
     """Phase 2: text unchanging + Stop button present for >stall window → raise."""
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
 
     # Track call sequence rather than expression-string matching (more robust).
@@ -182,19 +210,23 @@ async def test_phase2_stall_raises_generation_stuck(monkeypatch):
     # ending in `.length` (no JSON.stringify); the Phase-2 poll contains
     # `JSON.stringify`; the rate-limit scan contains `body.innerText`.
     state = {"count_polls": 0, "in_phase2": False}
+
     async def _fake_js(expr, timeout=15):
         if "has_action" in expr:
             # Phase-2 poll: the action button never appears (has_action=False)
             # and the text/html/child signals never change, so last_change_time
             # never resets and the stall detector fires.
             state["in_phase2"] = True
-            return json.dumps({"text": "partial", "html_len": 10, "child_count": 1, "has_action": False})
+            return json.dumps(
+                {"text": "partial", "html_len": 10, "child_count": 1, "has_action": False}
+            )
         if "body.innerText" in expr:
             # Rate-limit scan (Phase 1)
             return json.dumps({"text": "normal page"})
         # Count poll (bare .length expression)
         state["count_polls"] += 1
         return "1" if state["count_polls"] > 1 else "0"
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
@@ -208,6 +240,7 @@ async def test_phase2_stall_raises_generation_stuck(monkeypatch):
 
 # ── 6. Cap removal: slow appear succeeds ───────────────────────
 
+
 @pytest.mark.asyncio
 async def test_slow_appear_succeeds_without_cap(monkeypatch):
     """A response whose assistant node appears at t=70s succeeds, PROVIDED there
@@ -218,13 +251,16 @@ async def test_slow_appear_succeeds_without_cap(monkeypatch):
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
 
     # Count wobbles 0→1→0→1... every ~10 polls so the stall clock keeps
     # resetting, then settles at 2 (>initial) at poll 150 (~75s) to break Phase 1.
     count_polls = {"n": 0}
+
     async def _fake_js(expr, timeout=15):
         if "has_action" in expr:
             return json.dumps({"text": "done", "has_action": True})
@@ -235,6 +271,7 @@ async def test_slow_appear_succeeds_without_cap(monkeypatch):
         if n > 150:
             return "2"  # appear + break at ~75s
         return "1" if (n // 10) % 2 == 0 else "0"  # wobble 0/1 — progress signal
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
@@ -249,6 +286,7 @@ async def test_slow_appear_succeeds_without_cap(monkeypatch):
 
 # ── 7. Progressing generation does NOT raise ───────────────────
 
+
 @pytest.mark.asyncio
 async def test_progressing_generation_does_not_raise(monkeypatch):
     """A generation that keeps making progress (text changing) does NOT raise
@@ -257,11 +295,14 @@ async def test_progressing_generation_does_not_raise(monkeypatch):
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
 
     state = {"phase1_polls": 0, "phase2_polls": 0, "text": ""}
+
     async def _fake_js(expr, timeout=15):
         if "has_action" in expr:
             state["phase2_polls"] += 1
@@ -272,6 +313,7 @@ async def test_progressing_generation_does_not_raise(monkeypatch):
             return json.dumps({"text": "normal"})
         state["phase1_polls"] += 1
         return "1" if state["phase1_polls"] > 1 else "0"
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
@@ -284,6 +326,7 @@ async def test_progressing_generation_does_not_raise(monkeypatch):
 
 
 # ── 7b. Thinking-model streaming regression ────────────────────
+
 
 @pytest.mark.asyncio
 async def test_thinking_model_streams_during_answer_phase(monkeypatch):
@@ -303,29 +346,35 @@ async def test_thinking_model_streams_during_answer_phase(monkeypatch):
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
 
     state = {"phase1": 0, "phase2": 0, "text": ""}
+
     async def _fake_js(expr, timeout=15):
         if "body.innerText" in expr:
             return json.dumps({"text": "normal"})
         if "has_action" in expr:
             state["phase2"] += 1
             state["text"] += "answer chunk. "
-            return json.dumps({
-                "text": "Thinking... " + state["text"],  # innerText w/ reasoning label
-                "md_text": state["text"],                 # clean answer from .markdown
-                "html_len": len(state["text"]) + 20,
-                "child_count": 1,
-                "has_action": state["phase2"] > 5,
-                "is_thinking": True,  # .result-thinking lingers post-reasoning
-            })
+            return json.dumps(
+                {
+                    "text": "Thinking... " + state["text"],  # innerText w/ reasoning label
+                    "md_text": state["text"],  # clean answer from .markdown
+                    "html_len": len(state["text"]) + 20,
+                    "child_count": 1,
+                    "has_action": state["phase2"] > 5,
+                    "is_thinking": True,  # .result-thinking lingers post-reasoning
+                }
+            )
         if ".length" in expr and "querySelectorAll" in expr and "JSON.stringify" not in expr:
             state["phase1"] += 1
             return "1" if state["phase1"] > 1 else "0"
         return ""
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
@@ -336,16 +385,13 @@ async def test_thinking_model_streams_during_answer_phase(monkeypatch):
         chunks.append(chunk)
 
     full = "".join(c.delta for c in chunks if c.delta)
-    assert "answer chunk" in full, (
-        f"is_thinking suppressed streaming — no answer deltas: {chunks}"
-    )
-    assert "Thinking" not in full, (
-        f"reasoning UI label leaked as a delta: {full}"
-    )
+    assert "answer chunk" in full, f"is_thinking suppressed streaming — no answer deltas: {chunks}"
+    assert "Thinking" not in full, f"reasoning UI label leaked as a delta: {full}"
     assert chunks[-1].finish_reason == "stop"
 
 
 # ── 8. R4: backend end_turn fallback for completion ────────────
+
 
 @pytest.mark.asyncio
 async def test_phase2_end_turn_fallback_completes_when_dom_action_missing(monkeypatch):
@@ -356,8 +402,10 @@ async def test_phase2_end_turn_fallback_completes_when_dom_action_missing(monkey
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
     # Pretend we know the conversation id (set during Phase-1 in real flow).
     d._current_conv_id = "conv-fallback-test"
@@ -365,15 +413,18 @@ async def test_phase2_end_turn_fallback_completes_when_dom_action_missing(monkey
 
     end_turn_calls = {"n": 0}
     state = {"count_polls": 0}
+
     async def _fake_js(expr, timeout=15):
         if "has_action" in expr:
             # DOM action button NEVER appears (simulates selector drift).
-            return json.dumps({"text": "the full answer", "html_len": 10,
-                               "child_count": 1, "has_action": False})
+            return json.dumps(
+                {"text": "the full answer", "html_len": 10, "child_count": 1, "has_action": False}
+            )
         if "body.innerText" in expr:
             return json.dumps({"text": "normal page"})
         state["count_polls"] += 1
         return "1" if state["count_polls"] > 1 else "0"
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
@@ -381,9 +432,11 @@ async def test_phase2_end_turn_fallback_completes_when_dom_action_missing(monkey
     # Backend says end_turn is true on first check → completes.
     d._fetch_end_turn = AsyncMock(return_value=True)
     end_turn_calls["n"] = 0
+
     async def _counting_end_turn(cid):
         end_turn_calls["n"] += 1
         return True
+
     d._fetch_end_turn = _counting_end_turn
 
     chunks = []
@@ -400,28 +453,35 @@ async def test_phase2_end_turn_fallback_ignored_on_fetch_failure(monkeypatch):
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
     d._current_conv_id = "conv-x"
     d._access_token = "tok"
 
     state = {"count_polls": 0}
+
     async def _fake_js(expr, timeout=15):
         if "has_action" in expr:
-            return json.dumps({"text": "partial", "html_len": 10,
-                               "child_count": 1, "has_action": False})
+            return json.dumps(
+                {"text": "partial", "html_len": 10, "child_count": 1, "has_action": False}
+            )
         if "body.innerText" in expr:
             return json.dumps({"text": "normal page"})
         state["count_polls"] += 1
         return "1" if state["count_polls"] > 1 else "0"
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
     d._fetch_text = AsyncMock(return_value="")
+
     # Backend fetch raises — must be swallowed, not propagated.
     async def _raising_end_turn(cid):
         raise RuntimeError("backend blew up")
+
     d._fetch_end_turn = _raising_end_turn
 
     # Should still raise GenerationStuckError (stall), NOT the backend error.
@@ -439,30 +499,35 @@ async def test_phase2_end_turn_fallback_skipped_when_no_text(monkeypatch):
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
     d._current_conv_id = "conv-empty"
     d._access_token = "tok"
 
     end_turn_calls = {"n": 0}
     state = {"count_polls": 0}
+
     async def _fake_js(expr, timeout=15):
         if "has_action" in expr:
             # No text streamed (empty answer).
-            return json.dumps({"text": "", "html_len": 0,
-                               "child_count": 0, "has_action": False})
+            return json.dumps({"text": "", "html_len": 0, "child_count": 0, "has_action": False})
         if "body.innerText" in expr:
             return json.dumps({"text": "normal page"})
         state["count_polls"] += 1
         return "1" if state["count_polls"] > 1 else "0"
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
     d._fetch_text = AsyncMock(return_value="")
+
     async def _counting_end_turn(cid):
         end_turn_calls["n"] += 1
         return True
+
     d._fetch_end_turn = _counting_end_turn
 
     with pytest.raises(GenerationStuckError):
@@ -473,79 +538,126 @@ async def test_phase2_end_turn_fallback_skipped_when_no_text(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_phase2_dom_action_wins_over_backend(monkeypatch):
-    """R4: the DOM action button is the PRIMARY signal. When has_action is true,
-    the backend end_turn check is never consulted (no unnecessary fetch)."""
+async def test_phase2_backend_end_turn_is_primary_over_dom(monkeypatch):
+    """R4 (updated for #12): backend end_turn is the PRIMARY signal. When
+    conv_id is available, the backend is consulted first; has_action is a
+    fallback only when conv_id is unavailable or the backend fetch failed.
+    With conv_id set and end_turn=True, completion fires via the backend
+    even if has_action is also true."""
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
     d._current_conv_id = "conv-dom"
     d._access_token = "tok"
 
     end_turn_calls = {"n": 0}
     state = {"count_polls": 0}
+
     async def _fake_js(expr, timeout=15):
         if "has_action" in expr:
-            return json.dumps({"text": "answer", "html_len": 10,
-                               "child_count": 1, "has_action": True})
+            return json.dumps(
+                {
+                    "text": "answer",
+                    "md_text": "answer",
+                    "html_len": 10,
+                    "child_count": 1,
+                    "has_action": True,
+                    "is_thinking": False,
+                }
+            )
         if "body.innerText" in expr:
             return json.dumps({"text": "normal page"})
         state["count_polls"] += 1
         return "1" if state["count_polls"] > 1 else "0"
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
     d._fetch_text = AsyncMock(return_value="answer")
+
     async def _counting_end_turn(cid):
         end_turn_calls["n"] += 1
         return True
+
     d._fetch_end_turn = _counting_end_turn
 
     async for _ in d.send_and_stream("hi", timeout=10000):
         pass
-    # DOM signal fired first → backend never consulted.
-    assert end_turn_calls["n"] == 0
+    # Backend is PRIMARY now — it was consulted (conv_id was available).
+    assert end_turn_calls["n"] >= 1
 
 
 # ── 9. Thinking-stall fix: is_thinking as progress + fallback unlock ──
+
 
 @pytest.mark.asyncio
 async def test_thinking_placeholder_does_not_stall_past_90s(monkeypatch):
     """A static 'Thinking...' placeholder for >90s of simulated polls must NOT
     raise GenerationStuckError. is_thinking resets the stall clock — reasoning
     is active generation, not a stall. This is the root fix for the bug that
-    broke long reasoning responses."""
+    broke long reasoning responses.
+
+    Updated for #12: with conv_id available, backend end_turn is primary. The
+    test models a reasoning phase followed by backend confirmation (end_turn
+    flips True after the thinking settles), which is how completion now works."""
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
     d._current_conv_id = "conv-think"
     d._access_token = "tok"
 
-    state = {"count_polls": 0, "phase2_polls": 0}
+    state = {"count_polls": 0, "phase2_polls": 0, "end_turn_calls": 0}
+
     async def _fake_js(expr, timeout=15):
         if "has_action" in expr:
             state["phase2_polls"] += 1
             if state["phase2_polls"] > 10:
-                return json.dumps({"text": "the answer", "md_text": "the answer",
-                                   "html_len": 10, "child_count": 1,
-                                   "has_action": True, "is_thinking": False})
-            return json.dumps({"text": "", "md_text": "", "html_len": 0,
-                               "child_count": 0, "has_action": False, "is_thinking": True})
+                return json.dumps(
+                    {
+                        "text": "the answer",
+                        "md_text": "the answer",
+                        "html_len": 10,
+                        "child_count": 1,
+                        "has_action": True,
+                        "is_thinking": False,
+                    }
+                )
+            return json.dumps(
+                {
+                    "text": "",
+                    "md_text": "",
+                    "html_len": 0,
+                    "child_count": 0,
+                    "has_action": False,
+                    "is_thinking": True,
+                }
+            )
         if "body.innerText" in expr:
             return json.dumps({"text": "normal page"})
         state["count_polls"] += 1
         return "1" if state["count_polls"] > 1 else "0"
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
     d._fetch_text = AsyncMock(return_value="the answer")
-    d._fetch_end_turn = AsyncMock(return_value=False)
+
+    # Backend says not-done during thinking, then done once the answer appears.
+    async def _end_turn(cid):
+        state["end_turn_calls"] += 1
+        return state["phase2_polls"] > 10
+
+    d._fetch_end_turn = _end_turn
 
     chunks = []
     async for chunk in d.send_and_stream("think hard", timeout=10000):
@@ -560,21 +672,33 @@ async def test_saw_thinking_unlocks_fallback_but_empty_end_turn_does_not_finish(
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
     d._current_conv_id = "conv-empty-think"
     d._access_token = "tok"
 
     state = {"count_polls": 0}
+
     async def _fake_js(expr, timeout=15):
         if "has_action" in expr:
-            return json.dumps({"text": "", "md_text": "", "html_len": 0,
-                               "child_count": 0, "has_action": False, "is_thinking": True})
+            return json.dumps(
+                {
+                    "text": "",
+                    "md_text": "",
+                    "html_len": 0,
+                    "child_count": 0,
+                    "has_action": False,
+                    "is_thinking": True,
+                }
+            )
         if "body.innerText" in expr:
             return json.dumps({"text": "normal page"})
         state["count_polls"] += 1
         return "1" if state["count_polls"] > 1 else "0"
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
@@ -588,8 +712,9 @@ async def test_saw_thinking_unlocks_fallback_but_empty_end_turn_does_not_finish(
     chunks = []
     async for chunk in d.send_and_stream("think", timeout=5):
         chunks.append(chunk)
-    assert not any(c.delta for c in chunks), \
+    assert not any(c.delta for c in chunks), (
         "fallback must not complete an empty answer even with end_turn=true"
+    )
 
 
 @pytest.mark.asyncio
@@ -599,22 +724,33 @@ async def test_saw_thinking_with_end_turn_and_content_finishes(monkeypatch):
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
+
     async def fast_sleep(s):
         t[0] += s
+
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", fast_sleep)
     d._current_conv_id = "conv-rescue"
     d._access_token = "tok"
 
     state = {"count_polls": 0}
+
     async def _fake_js(expr, timeout=15):
         if "has_action" in expr:
-            return json.dumps({"text": "the full answer", "md_text": "the full answer",
-                               "html_len": 10, "child_count": 1,
-                               "has_action": False, "is_thinking": False})
+            return json.dumps(
+                {
+                    "text": "the full answer",
+                    "md_text": "the full answer",
+                    "html_len": 10,
+                    "child_count": 1,
+                    "has_action": False,
+                    "is_thinking": False,
+                }
+            )
         if "body.innerText" in expr:
             return json.dumps({"text": "normal page"})
         state["count_polls"] += 1
         return "1" if state["count_polls"] > 1 else "0"
+
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
@@ -628,6 +764,7 @@ async def test_saw_thinking_with_end_turn_and_content_finishes(monkeypatch):
 
 
 # ── 10. MCP mapping ─────────────────────────────────────────────
+
 
 @pytest.mark.asyncio
 async def test_mcp_auth_expired_returns_error_result():
@@ -643,10 +780,12 @@ async def test_mcp_auth_expired_returns_error_result():
     drv.is_connected = True
     drv.select_model = AsyncMock(return_value=True)
     drv.navigate_new_chat = AsyncMock()
+
     # send_and_stream must be an async GENERATOR that raises on iteration.
     async def _raising_stream(text, timeout=120):
         raise AuthExpiredError()
         yield  # unreachable, makes this a generator
+
     drv.send_and_stream = _raising_stream
 
     with pytest.raises(AuthExpiredError):
@@ -655,10 +794,12 @@ async def test_mcp_auth_expired_returns_error_result():
 
 # ── 9. HTTP mapping ────────────────────────────────────────────
 
+
 def test_http_error_response_auth_expired_is_401():
     from unittest.mock import MagicMock
 
     from chatgpt_web2api.api_server import APIServer
+
     srv = APIServer.__new__(APIServer)  # bypass __init__
     srv._driver = MagicMock()
     resp = srv._error_response(AuthExpiredError())
@@ -669,6 +810,7 @@ def test_http_error_response_generation_stuck_is_504():
     from unittest.mock import MagicMock
 
     from chatgpt_web2api.api_server import APIServer
+
     srv = APIServer.__new__(APIServer)
     srv._driver = MagicMock()
     resp = srv._error_response(GenerationStuckError("phase_2_stream", 47.3))


### PR DESCRIPTION
## Summary

Fixes #12.

Promotes backend `end_turn` to the **primary** completion signal and demotes the DOM action-button selector (`has_action`) to a **fallback**. The #12 DOM investigation proved `has_action` is structurally broken (ancestor depth limit + geometry gate), having drifted 3 times; `end_turn` has been stable across all three.

## Background (from the #12 investigation)

Live DOM inspection of a completed conversation found two independent failures in `has_action`:
1. **Ancestor depth limit too shallow**: action buttons live at depth 6; the selector walked only `d ≤ 4`
2. **Geometry gate rejects short answers**: a one-word answer's copy button renders 128px *above* the message; the gate required button at/below message top

Backend `end_turn` returned `True` reliably for the same conversation.

## The change

### `cdp_driver.py` — completion detection reordered
- **PRIMARY**: backend `end_turn` is checked **first** when `conv_id_for_check` is available (same 3s throttle, same strict content guard: `end_turn AND usable content`). Completes even when `has_action=False` or `is_thinking=True`.
- **FALLBACK**: `has_action` is checked only when `end_turn` can't run (no `conv_id` yet, or backend fetch failed).
- **Fallback repaired**: ancestor walk `4 → 8` (reaches depth-6 buttons); geometry window `top - 8 → top - 180` (accepts short-answer buttons above the message).

### No behavior change for the common case
`end_turn` already completed new chats via #11's conv_id resolution. This PR just makes the code's *intent* match reality: `end_turn` is primary, `has_action` is the backup. The DOM detection is **kept** (not removed) — it's still the escape hatch for the ~1s pre-conv_id window and backend failures.

## Verification
- `ruff check .` + `ruff format --check .` — clean
- Unit suite: **320 passed** (315 + 5 new regression tests)
- Live SSE repro: `chat_completion` completes in **~11s** with correct content (`ENDTURN_PRIMARY_OK`)
- Full suite green: no regression to the `has_action` fallback path or the `end_turn` path

## Regression tests added (`tests/test_end_turn_primary.py`)
1. `end_turn=True` wins even when `has_action=False` (the drift scenario)
2. `end_turn=True` wins even when `is_thinking=True` (the stale-thinking deadlock)
3. `has_action=True` still completes when no `conv_id` is available (fallback path, `end_turn` never called)
4. JS selector walks to ancestor depth 8 (structural check — was 4)
5. JS geometry window accepts buttons 180px above the message (structural check — was 8px)

## Acceptance criteria from #12
- [x] Live DOM inspection confirmed the action-button testid + container relationship (depth 6, buttons-above-message)
- [x] `end_turn` is primary; `has_action` is fallback
- [x] DOM detection kept as escape hatch (not removed)
- [x] Fallback depth + geometry repaired so it works if ever needed
- [x] Full suite green (320 passed)
