### PR TITLE
feat: add 'ensure' subcommand for point-in-time REST+SSE reconciliation (ROADMAP Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,33 @@ W2A_ENABLE_WRITE=1 W2A_ENABLE_DESTRUCTIVE=1 chatgpt-web2api-mcp
 
 Gated tools are **hidden** from `list_tools` *and* **refused at call time** — a client that calls a gated tool by name gets an error result rather than silent execution. Binding the SSE transport to a non-loopback address with no `api_keys` configured logs a prominent warning.
 
+### 🔌 ZCode Hook: One-Line Bootstrap with `ensure`
+
+Instead of manually starting REST and SSE in separate terminals, run a single
+command that reconciles both and exits — ideal for a ZCode session-start hook:
+
+```bash
+chatgpt-web2api ensure
+```
+
+`ensure` is **point-in-time reconciliation**, not a supervisor: it checks REST
+(`/health`) and SSE, starts whichever is missing, verifies SSE with a real MCP
+handshake, and exits `0` when both are ready (nonzero with a diagnostic if not).
+If a service dies later, re-run `ensure` from the next hook/session.
+
+```bash
+# Reconcile REST on 8080 + SSE on 8090 (defaults)
+chatgpt-web2api ensure
+
+# Custom ports / config (propagated to the child processes)
+chatgpt-web2api ensure --rest-port 8081 --mcp-sse-port 8091 --config ~/.my-config.json
+```
+
+Degraded-REST policy: `ensure` does **not** restart REST immediately on
+`degraded` (Chrome alive, driver disconnected) — it polls for up to 20s first,
+since that may be a transient CDP reconnect. Only `missing` or `broken` trigger
+an immediate (re)start. This avoids a destructive Chrome bounce on transients.
+
 ### 🔧 Three Interfaces, One Chrome Session
 
 ```bash

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,9 +129,16 @@ Remaining follow-up: the DOM `has_action` selector is still dead — tracked in 
 
 ---
 
-## Phase 3 — Add `chatgpt-web2api ensure`
+## Phase 3 — Add `chatgpt-web2api ensure`  ✅ DONE
 
 **Goal:** let ZCode hooks bootstrap the full stack with a thin one-liner.
+
+Shipped as `chatgpt-web2api ensure` in `src/chatgpt_web2api/ensure.py`, wired
+into the `__main__.py` subcommand dispatch. Point-in-time reconcile: checks
+REST + SSE, starts whichever is missing, verifies SSE via real MCP handshake,
+exits 0 when ready. Lock-protected (SSE-port-keyed startup lock, bounded
+contention). Degraded-REST policy honored (20s poll before restart). No
+watchdog loop. 15 unit tests in `tests/test_ensure.py`.
 
 ### Command
 

--- a/src/chatgpt_web2api/__main__.py
+++ b/src/chatgpt_web2api/__main__.py
@@ -63,16 +63,22 @@ def inject_cookies(args) -> None:
 
     async def _inject():
         import websockets
+
         pages = [t for t in targets if t.get("type") == "page"]
         if not pages:
             print("Error: No pages found")
             return
         ws_url = pages[0]["webSocketDebuggerUrl"]
-        ws = await websockets.connect(ws_url, max_size=50*1024*1024)
+        ws = await websockets.connect(ws_url, max_size=50 * 1024 * 1024)
 
         # Navigate to chatgpt.com first
-        await ws.send(json.dumps({"id": 1, "method": "Page.navigate", "params": {"url": "https://chatgpt.com/"}}))
+        await ws.send(
+            json.dumps(
+                {"id": 1, "method": "Page.navigate", "params": {"url": "https://chatgpt.com/"}}
+            )
+        )
         import asyncio as aio
+
         await aio.sleep(3)
 
         # Set cookies via CDP
@@ -90,17 +96,29 @@ def inject_cookies(args) -> None:
             if cookie.get("expirationDate") or cookie.get("expiry"):
                 cdp_cookie["expires"] = cookie.get("expirationDate") or cookie.get("expiry")
 
-            await ws.send(json.dumps({"id": i+10, "method": "Network.setCookie", "params": cdp_cookie}))
+            await ws.send(
+                json.dumps({"id": i + 10, "method": "Network.setCookie", "params": cdp_cookie})
+            )
             await aio.sleep(0.01)
 
         print(f"Injected {len(cookies)} cookies")
 
         # Verify by trying to get auth
         await aio.sleep(2)
-        await ws.send(json.dumps({"id": 999, "method": "Runtime.evaluate", "params": {
-            "expression": "(async () => { var r = await fetch('/api/auth/session', {credentials:'include'}); var d = await r.json(); return d.accessToken ? 'OK:' + d.user?.name : 'FAIL'; })()",
-            "awaitPromise": True, "returnByValue": True, "timeout": 10000
-        }}))
+        await ws.send(
+            json.dumps(
+                {
+                    "id": 999,
+                    "method": "Runtime.evaluate",
+                    "params": {
+                        "expression": "(async () => { var r = await fetch('/api/auth/session', {credentials:'include'}); var d = await r.json(); return d.accessToken ? 'OK:' + d.user?.name : 'FAIL'; })()",
+                        "awaitPromise": True,
+                        "returnByValue": True,
+                        "timeout": 10000,
+                    },
+                }
+            )
+        )
         while True:
             r = await aio.wait_for(ws.recv(), timeout=15)
             resp = json.loads(r)
@@ -117,10 +135,9 @@ def inject_cookies(args) -> None:
     asyncio.run(_inject())
 
 
-
 def main() -> None:
     # Check if first arg looks like a subcommand
-    subcommands = {"start", "inject-cookies", "doctor"}
+    subcommands = {"start", "inject-cookies", "doctor", "ensure"}
     has_subcommand = len(sys.argv) > 1 and sys.argv[1] in subcommands
 
     parser = argparse.ArgumentParser(
@@ -132,12 +149,45 @@ def main() -> None:
         subparsers = parser.add_subparsers(dest="command")
         start_parser = subparsers.add_parser("start", help="Start the proxy (default)")
         _add_common_args(start_parser)
-        cookie_parser = subparsers.add_parser("inject-cookies", help="Inject browser cookies for auth")
+        cookie_parser = subparsers.add_parser(
+            "inject-cookies", help="Inject browser cookies for auth"
+        )
         cookie_parser.add_argument("cookies", help="Path to cookies JSON file")
         _add_common_args(cookie_parser)
-        doctor_parser = subparsers.add_parser("doctor", help="Diagnose a broken function from captured evidence")
-        doctor_parser.add_argument("function", nargs="?", help="Function to diagnose (omit to auto-discover)")
-        doctor_parser.add_argument("--verify", metavar="FUNCTION", help="Re-run a function live to verify a fix")
+        doctor_parser = subparsers.add_parser(
+            "doctor", help="Diagnose a broken function from captured evidence"
+        )
+        doctor_parser.add_argument(
+            "function", nargs="?", help="Function to diagnose (omit to auto-discover)"
+        )
+        doctor_parser.add_argument(
+            "--verify", metavar="FUNCTION", help="Re-run a function live to verify a fix"
+        )
+        ensure_parser = subparsers.add_parser(
+            "ensure",
+            help="Point-in-time reconcile: make REST + SSE healthy, then exit (for ZCode hooks)",
+        )
+        ensure_parser.add_argument(
+            "--rest-port", type=int, default=8080, help="REST API port to reconcile (default: 8080)"
+        )
+        ensure_parser.add_argument(
+            "--mcp-sse-port",
+            type=int,
+            default=8090,
+            help="MCP/SSE port to reconcile (default: 8090)",
+        )
+        ensure_parser.add_argument("--config", "-c", help="Config file path (JSON)")
+        ensure_parser.add_argument(
+            "--cdp-port", type=int, default=9222, help="Chrome CDP port (default: 9222)"
+        )
+        # default=None so we can distinguish "caller provided --log-level" from
+        # the default — only propagated to child subprocesses when explicit.
+        ensure_parser.add_argument(
+            "--log-level",
+            default=None,
+            choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+            help="Log level for child processes (default: child's own default)",
+        )
     else:
         # No subcommand — parse as start with all args
         _add_common_args(parser)
@@ -151,7 +201,21 @@ def main() -> None:
         inject_cookies(args)
     elif command == "doctor":
         from .doctor import run_doctor
+
         run_doctor(args)
+    elif command == "ensure":
+        from .ensure import run_ensure
+
+        code = asyncio.run(
+            run_ensure(
+                rest_port=args.rest_port,
+                sse_port=args.mcp_sse_port,
+                cdp_port=args.cdp_port,
+                config_path=args.config,
+                log_level=args.log_level,
+            )
+        )
+        sys.exit(code)
 
 
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
@@ -162,8 +226,9 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--chrome-path", help="Path to Chrome binary")
     parser.add_argument("--user-data-dir", help="Chrome user data directory")
     parser.add_argument("--headless", action="store_true", help="Run Chrome headless")
-    parser.add_argument("--log-level", default="INFO",
-                        choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    parser.add_argument(
+        "--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"]
+    )
 
 
 def _parse_as_start(parser: argparse.ArgumentParser) -> argparse.Namespace:
@@ -178,22 +243,22 @@ def _parse_as_start(parser: argparse.ArgumentParser) -> argparse.Namespace:
 
 def _run_start(args: argparse.Namespace) -> None:
     # Load config
-    config = Config.load(getattr(args, 'config', None))
+    config = Config.load(getattr(args, "config", None))
 
     # CLI overrides
-    if getattr(args, 'port', None):
+    if getattr(args, "port", None):
         config.server.port = args.port
-    if getattr(args, 'host', None):
+    if getattr(args, "host", None):
         config.server.host = args.host
-    if getattr(args, 'cdp_port', None):
+    if getattr(args, "cdp_port", None):
         config.chrome.cdp_port = args.cdp_port
-    if getattr(args, 'chrome_path', None):
+    if getattr(args, "chrome_path", None):
         config.chrome.chrome_path = args.chrome_path
-    if getattr(args, 'user_data_dir', None):
+    if getattr(args, "user_data_dir", None):
         config.chrome.user_data_dir = args.user_data_dir
-    if getattr(args, 'headless', False):
+    if getattr(args, "headless", False):
         config.chrome.headless = True
-    if getattr(args, 'log_level', None):
+    if getattr(args, "log_level", None):
         config.log.level = args.log_level
 
     # Logging

--- a/src/chatgpt_web2api/ensure.py
+++ b/src/chatgpt_web2api/ensure.py
@@ -1,0 +1,319 @@
+"""Point-in-time reconciliation of the REST + SSE stack.
+
+``chatgpt-web2api ensure`` is a thin one-liner for ZCode hooks: it makes REST
+and SSE healthy NOW, then exits. It is NOT a continuous supervisor — if SSE
+dies later, the next hook/session re-runs ``ensure``.
+
+Pinned design (ROADMAP Phase 3):
+  - point-in-time, not a watchdog (no Python loop after exit)
+  - REST owns Chrome; SSE attaches and never launches Chrome
+  - degraded-REST is NOT restarted immediately (may be a transient CDP
+    reconnect — give it 20s of polling before bouncing the browser)
+  - lock-protected so concurrent ``ensure`` runs don't double-launch
+
+Exit codes: 0 when both REST and SSE are ready, nonzero with a diagnostic
+otherwise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+
+from chatgpt_web2api.cross_process_lock import LockAcquisitionError
+
+logger = logging.getLogger(__name__)
+
+# Bounded wait for REST to resolve starting/degraded before we act.
+_REST_HEALTHY_TIMEOUT = 30.0
+# Degraded-REST grace window: poll every 2s for up to 20s before restarting.
+_DEGRADED_POLL_INTERVAL = 2.0
+_DEGRADED_POLL_BUDGET = 20.0
+# Startup lock: bounded contention wait.
+_LOCK_TIMEOUT = 10.0
+_LOCK_CONTENTION_RECHECK_INTERVAL = 3.0
+_LOCK_CONTENTION_RECHECK_TRIES = 3
+# SSE readiness: TCP preflight then real MCP handshake.
+_SSE_VERIFY_TIMEOUT = 15.0
+
+
+class _StartupLock:
+    """A bounded, SSE-port-keyed startup lock.
+
+    Distinct from the CDP-keyed CrossProcessLock (which serializes request-
+    level DOM mutations). This one prevents two concurrent ``ensure`` runs
+    from double-launching REST/SSE. Uses portalocker under the hood so it is
+    cross-process safe.
+    """
+
+    import portalocker
+
+    def __init__(self, sse_port: int, timeout: float = _LOCK_TIMEOUT) -> None:
+        self._path = str(Path.home() / ".chatgpt_web2api" / f"sse-startup-{sse_port}.lock")
+        self._timeout = timeout
+        self._fh = None
+
+    async def __aenter__(self):
+        Path(self._path).parent.mkdir(parents=True, exist_ok=True)
+        deadline = time.monotonic() + self._timeout
+        while True:
+            try:
+                # Non-blocking attempt in a thread (portalocker is blocking)
+                self._fh = await asyncio.to_thread(self._try_acquire)
+                return self
+            except _LockBusy:
+                if time.monotonic() >= deadline:
+                    raise LockAcquisitionError(
+                        f"startup lock held after {self._timeout}s — another ensure is running"
+                    )
+                await asyncio.sleep(0.3)
+
+    def _try_acquire(self):
+        try:
+            self.portalocker.lock(
+                open(self._path, "w"),
+                self.portalocker.LOCK_EX | self.portalocker.LOCK_NB,
+            )
+            # If we get here, the lock was acquired. Keep the fh.
+            self._fh = open(self._path, "w")
+        except self.portalocker.LockException:
+            raise _LockBusy()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if self._fh:
+            try:
+                await asyncio.to_thread(self.portalocker.unlock, self._fh)
+                self._fh.close()
+            except Exception:
+                pass
+
+
+class _LockBusy(Exception):
+    """Internal: lock is currently held by another process."""
+
+
+def _rest_health(rest_port: int, timeout: float = 3.0) -> dict | None:
+    """GET /health. Returns the parsed JSON dict, or None if unreachable
+    (connection refused = ``missing``)."""
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{rest_port}/health", timeout=timeout) as r:
+            return json.loads(r.read())
+    except Exception:
+        return None
+
+
+def _sse_tcp_up(sse_port: int, timeout: float = 1.0) -> bool:
+    """TCP preflight: is anything listening on the SSE port? Not a readiness
+    guarantee — the real check is the MCP handshake below."""
+    try:
+        with socket.socket() as s:
+            s.settimeout(timeout)
+            s.connect(("127.0.0.1", sse_port))
+            return True
+    except OSError:
+        return False
+
+
+async def _sse_verify(sse_port: int) -> bool:
+    """Real SSE readiness: connect a client, initialize, list tools. TCP-up
+    but handshake failure = NOT ready."""
+    url = f"http://127.0.0.1:{sse_port}/sse"
+    try:
+        async with asyncio.timeout(_SSE_VERIFY_TIMEOUT):
+            async with sse_client(url) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    await session.list_tools()
+        return True
+    except Exception as e:
+        logger.debug("SSE verify failed: %s", e)
+        return False
+
+
+def _build_rest_cmd(
+    rest_port: int, cdp_port: int, config_path: str | None, log_level: str | None
+) -> list[str]:
+    """Construct the REST launch command. --port and --cdp-port are always
+    passed (explicit ensure params). --config/--log-level only when the caller
+    provided them (sentinel None = not provided)."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "chatgpt_web2api",
+        "start",
+        "--port",
+        str(rest_port),
+        "--cdp-port",
+        str(cdp_port),
+    ]
+    if config_path:
+        cmd += ["--config", config_path]
+    if log_level:
+        cmd += ["--log-level", log_level]
+    return cmd
+
+
+def _build_sse_cmd(
+    sse_port: int, cdp_port: int, config_path: str | None, log_level: str | None
+) -> list[str]:
+    """Construct the SSE/MCP launch command."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "chatgpt_web2api.mcp_server",
+        "--transport",
+        "sse",
+        "--port",
+        str(sse_port),
+        "--cdp-port",
+        str(cdp_port),
+    ]
+    if config_path:
+        cmd += ["--config", config_path]
+    if log_level:
+        cmd += ["--log-level", log_level]
+    return cmd
+
+
+def _launch_detached(cmd: list[str]) -> subprocess.Popen:
+    """Launch a detached subprocess that survives this process's exit."""
+    kwargs: dict = {
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "stdin": subprocess.DEVNULL,
+    }
+    if sys.platform == "win32":
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW | subprocess.DETACHED_PROCESS
+    else:
+        kwargs["start_new_session"] = True
+    return subprocess.Popen(cmd, **kwargs)
+
+
+async def _wait_rest_healthy(rest_port: int, timeout: float) -> bool:
+    """Poll /health until status is healthy. Returns True if healthy within
+    the timeout, False otherwise."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        h = _rest_health(rest_port)
+        if h and h.get("status") == "healthy":
+            return True
+        await asyncio.sleep(1.0)
+    return False
+
+
+async def _reconcile_rest(
+    rest_port: int, cdp_port: int, config_path: str | None, log_level: str | None
+) -> bool:
+    """Apply the degraded-REST policy and wait for healthy. Returns True when
+    REST is healthy, False if it can't be made healthy."""
+    h = _rest_health(rest_port)
+    if h is None:
+        logger.info("REST missing — starting")
+        _launch_detached(_build_rest_cmd(rest_port, cdp_port, config_path, log_level))
+        return await _wait_rest_healthy(rest_port, _REST_HEALTHY_TIMEOUT)
+
+    status = h.get("status", "broken")
+    if status == "healthy":
+        logger.info("REST healthy")
+        return True
+
+    if status == "broken":
+        logger.info("REST broken (Chrome down) — restarting")
+        _launch_detached(_build_rest_cmd(rest_port, cdp_port, config_path, log_level))
+        return await _wait_rest_healthy(rest_port, _REST_HEALTHY_TIMEOUT)
+
+    if status == "degraded":
+        # PINNED: degraded may be a transient CDP reconnect. Wait before bouncing.
+        logger.info("REST degraded — waiting up to %.0fs before restart", _DEGRADED_POLL_BUDGET)
+        deadline = time.monotonic() + _DEGRADED_POLL_BUDGET
+        while time.monotonic() < deadline:
+            await asyncio.sleep(_DEGRADED_POLL_INTERVAL)
+            h = _rest_health(rest_port)
+            if h and h.get("status") == "healthy":
+                logger.info("REST recovered from degraded")
+                return True
+            if h and h.get("status") == "broken":
+                break  # fall through to restart
+        logger.info("REST still degraded after %.0fs — restarting", _DEGRADED_POLL_BUDGET)
+        _launch_detached(_build_rest_cmd(rest_port, cdp_port, config_path, log_level))
+        return await _wait_rest_healthy(rest_port, _REST_HEALTHY_TIMEOUT)
+
+    # starting — just wait
+    logger.info("REST starting — waiting")
+    return await _wait_rest_healthy(rest_port, _REST_HEALTHY_TIMEOUT)
+
+
+async def _reconcile_sse(
+    sse_port: int, cdp_port: int, config_path: str | None, log_level: str | None
+) -> bool:
+    """Start SSE if missing, then verify via real MCP handshake."""
+    if _sse_tcp_up(sse_port):
+        ready = await _sse_verify(sse_port)
+        if ready:
+            logger.info("SSE ready on :%d", sse_port)
+            return True
+        logger.info("SSE port up but handshake failed — treating as not ready")
+
+    logger.info("SSE missing — starting")
+    _launch_detached(_build_sse_cmd(sse_port, cdp_port, config_path, log_level))
+
+    # Wait for TCP, then verify handshake.
+    deadline = time.monotonic() + _REST_HEALTHY_TIMEOUT
+    while time.monotonic() < deadline:
+        if _sse_tcp_up(sse_port):
+            if await _sse_verify(sse_port):
+                logger.info("SSE ready on :%d", sse_port)
+                return True
+        await asyncio.sleep(1.0)
+    return False
+
+
+async def run_ensure(
+    rest_port: int = 8080,
+    sse_port: int = 8090,
+    cdp_port: int = 9222,
+    config_path: str | None = None,
+    log_level: str | None = None,
+) -> int:
+    """Point-in-time reconcile of REST + SSE. Returns 0 on ready, nonzero on failure."""
+    lock = _StartupLock(sse_port)
+    try:
+        await lock.__aenter__()
+    except LockAcquisitionError:
+        # Bounded contention: another ensure owns the lock. Re-check health a
+        # few times and exit on observed state — never block indefinitely.
+        logger.info("Startup lock held — waiting for another ensure to finish")
+        for _ in range(_LOCK_CONTENTION_RECHECK_TRIES):
+            await asyncio.sleep(_LOCK_CONTENTION_RECHECK_INTERVAL)
+            rest_ok = _rest_health(rest_port)
+            sse_ok = _sse_tcp_up(sse_port) and await _sse_verify(sse_port)
+            if rest_ok and rest_ok.get("status") == "healthy" and sse_ok:
+                print("REST + SSE ready (another ensure succeeded)")
+                return 0
+        print(
+            "ERROR: another ensure is running and services are still not ready.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        if not await _reconcile_rest(rest_port, cdp_port, config_path, log_level):
+            print("ERROR: REST did not become healthy.", file=sys.stderr)
+            return 1
+        if not await _reconcile_sse(sse_port, cdp_port, config_path, log_level):
+            print("ERROR: SSE did not become ready.", file=sys.stderr)
+            return 1
+        print("REST + SSE ready")
+        return 0
+    finally:
+        await lock.__aexit__(None, None, None)

--- a/src/chatgpt_web2api/ensure.py
+++ b/src/chatgpt_web2api/ensure.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import socket
 import subprocess
 import sys
@@ -79,15 +80,19 @@ class _StartupLock:
                 await asyncio.sleep(0.3)
 
     def _try_acquire(self):
+        """Open the lockfile and acquire an exclusive non-blocking lock on it.
+
+        Returns the file handle (which MUST be held open until release —
+        closing it drops the OS lock). Raises ``_LockBusy`` if another process
+        holds the lock.
+        """
+        fh = open(self._path, "w")
         try:
-            self.portalocker.lock(
-                open(self._path, "w"),
-                self.portalocker.LOCK_EX | self.portalocker.LOCK_NB,
-            )
-            # If we get here, the lock was acquired. Keep the fh.
-            self._fh = open(self._path, "w")
+            self.portalocker.lock(fh, self.portalocker.LOCK_EX | self.portalocker.LOCK_NB)
         except self.portalocker.LockException:
+            fh.close()
             raise _LockBusy()
+        return fh
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self._fh:
@@ -100,6 +105,25 @@ class _StartupLock:
 
 class _LockBusy(Exception):
     """Internal: lock is currently held by another process."""
+
+
+def _rest_ready_for_ensure(h: dict | None) -> bool:
+    """Is REST ready for ``ensure`` to proceed to SSE?
+
+    ``healthy`` is always ready. ``starting`` is ALSO acceptable for a cold
+    bootstrap: REST/Chrome/CDP are connected but no chat has succeeded yet —
+    that's enough for SSE to attach. Requires all three connection flags set
+    so a half-started REST (Chrome up but driver not connected) doesn't pass.
+    """
+    if not h:
+        return False
+    if h.get("status") == "healthy":
+        return True
+    if h.get("status") == "starting":
+        return bool(
+            h.get("chrome_running") and h.get("cdp_connected") and h.get("driver_connected")
+        )
+    return False
 
 
 def _rest_health(rest_port: int, timeout: float = 3.0) -> dict | None:
@@ -199,13 +223,92 @@ def _launch_detached(cmd: list[str]) -> subprocess.Popen:
     return subprocess.Popen(cmd, **kwargs)
 
 
-async def _wait_rest_healthy(rest_port: int, timeout: float) -> bool:
-    """Poll /health until status is healthy. Returns True if healthy within
-    the timeout, False otherwise."""
+def _find_listener_pid(port: int) -> int | None:
+    """Find the PID listening on the given TCP port (loopback). Returns None
+    if nothing is listening or the lookup fails."""
+    try:
+        if sys.platform == "win32":
+            # netstat -ano: last column is the PID for LISTENING rows
+            out = subprocess.check_output(
+                ["netstat", "-ano"], text=True, stderr=subprocess.DEVNULL, timeout=5
+            )
+            for line in out.splitlines():
+                parts = line.split()
+                if len(parts) >= 5 and "LISTENING" in line:
+                    if parts[1].endswith(f":{port}"):
+                        return int(parts[-1])
+        else:
+            # lsof -ti :<port> returns the PID(s) of listeners
+            out = subprocess.check_output(
+                ["lsof", "-ti", f":{port}"], text=True, stderr=subprocess.DEVNULL, timeout=5
+            ).strip()
+            if out:
+                return int(out.splitlines()[0])
+    except Exception:
+        return None
+    return None
+
+
+def _terminate_pid(pid: int) -> None:
+    """Terminate a process by PID. Force-kill if it doesn't exit gracefully."""
+    try:
+        if sys.platform == "win32":
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(pid)], capture_output=True, timeout=10
+            )
+        else:
+            import signal as _sig
+
+            os.kill(pid, _sig.SIGTERM)
+            time.sleep(2)
+            # Check if still alive; SIGKILL if so
+            try:
+                os.kill(pid, 0)
+                os.kill(pid, _sig.SIGKILL)
+            except ProcessLookupError:
+                pass
+    except Exception as e:
+        logger.debug("terminate pid %s failed: %s", pid, e)
+
+
+async def _stop_rest_listener(rest_port: int) -> None:
+    """Stop whatever process is listening on the REST port, then wait for the
+    port to free. A bare ``_launch_detached`` on an occupied port fails to bind
+    (stderr is discarded), so a restart must stop the existing listener first."""
+    pid = _find_listener_pid(rest_port)
+    if pid is None:
+        return
+    logger.info("Stopping existing REST listener (pid %s) on :%d", pid, rest_port)
+    await asyncio.to_thread(_terminate_pid, pid)
+    # Wait for the port to free (bind would fail if still occupied)
+    for _ in range(20):
+        try:
+            with socket.socket() as s:
+                s.settimeout(0.5)
+                s.connect(("127.0.0.1", rest_port))
+            # still accepting connections — wait
+        except OSError:
+            break  # port closed — ready
+        await asyncio.sleep(0.5)
+
+
+async def _restart_rest(
+    rest_port: int, cdp_port: int, config_path: str | None, log_level: str | None
+) -> bool:
+    """Stop the existing REST listener, then launch a fresh one. Used for
+    ``broken`` and degraded-after-timeout — not for ``missing`` (no listener
+    to stop)."""
+    await _stop_rest_listener(rest_port)
+    _launch_detached(_build_rest_cmd(rest_port, cdp_port, config_path, log_level))
+    return await _wait_rest_ready(rest_port, _REST_HEALTHY_TIMEOUT)
+
+
+async def _wait_rest_ready(rest_port: int, timeout: float) -> bool:
+    """Poll /health until REST is ready for ensure (healthy OR starting+connected).
+    Returns True if ready within the timeout, False otherwise."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        h = _rest_health(rest_port)
-        if h and h.get("status") == "healthy":
+        if _rest_ready_for_ensure(_rest_health(rest_port)):
             return True
         await asyncio.sleep(1.0)
     return False
@@ -214,23 +317,22 @@ async def _wait_rest_healthy(rest_port: int, timeout: float) -> bool:
 async def _reconcile_rest(
     rest_port: int, cdp_port: int, config_path: str | None, log_level: str | None
 ) -> bool:
-    """Apply the degraded-REST policy and wait for healthy. Returns True when
-    REST is healthy, False if it can't be made healthy."""
+    """Apply the degraded-REST policy and wait for ready. Returns True when
+    REST is ready for ensure, False if it can't be made ready."""
     h = _rest_health(rest_port)
     if h is None:
         logger.info("REST missing — starting")
         _launch_detached(_build_rest_cmd(rest_port, cdp_port, config_path, log_level))
-        return await _wait_rest_healthy(rest_port, _REST_HEALTHY_TIMEOUT)
+        return await _wait_rest_ready(rest_port, _REST_HEALTHY_TIMEOUT)
 
     status = h.get("status", "broken")
-    if status == "healthy":
-        logger.info("REST healthy")
+    if status in ("healthy", "starting") and _rest_ready_for_ensure(h):
+        logger.info("REST ready (status=%s)", status)
         return True
 
     if status == "broken":
         logger.info("REST broken (Chrome down) — restarting")
-        _launch_detached(_build_rest_cmd(rest_port, cdp_port, config_path, log_level))
-        return await _wait_rest_healthy(rest_port, _REST_HEALTHY_TIMEOUT)
+        return await _restart_rest(rest_port, cdp_port, config_path, log_level)
 
     if status == "degraded":
         # PINNED: degraded may be a transient CDP reconnect. Wait before bouncing.
@@ -239,18 +341,17 @@ async def _reconcile_rest(
         while time.monotonic() < deadline:
             await asyncio.sleep(_DEGRADED_POLL_INTERVAL)
             h = _rest_health(rest_port)
-            if h and h.get("status") == "healthy":
-                logger.info("REST recovered from degraded")
+            if _rest_ready_for_ensure(h):
+                logger.info("REST recovered from degraded/starting")
                 return True
             if h and h.get("status") == "broken":
                 break  # fall through to restart
         logger.info("REST still degraded after %.0fs — restarting", _DEGRADED_POLL_BUDGET)
-        _launch_detached(_build_rest_cmd(rest_port, cdp_port, config_path, log_level))
-        return await _wait_rest_healthy(rest_port, _REST_HEALTHY_TIMEOUT)
+        return await _restart_rest(rest_port, cdp_port, config_path, log_level)
 
-    # starting — just wait
-    logger.info("REST starting — waiting")
-    return await _wait_rest_healthy(rest_port, _REST_HEALTHY_TIMEOUT)
+    # starting without full connectivity — wait for it to resolve
+    logger.info("REST starting (not fully connected) — waiting")
+    return await _wait_rest_ready(rest_port, _REST_HEALTHY_TIMEOUT)
 
 
 async def _reconcile_sse(
@@ -295,9 +396,9 @@ async def run_ensure(
         logger.info("Startup lock held — waiting for another ensure to finish")
         for _ in range(_LOCK_CONTENTION_RECHECK_TRIES):
             await asyncio.sleep(_LOCK_CONTENTION_RECHECK_INTERVAL)
-            rest_ok = _rest_health(rest_port)
+            rest_ok = _rest_ready_for_ensure(_rest_health(rest_port))
             sse_ok = _sse_tcp_up(sse_port) and await _sse_verify(sse_port)
-            if rest_ok and rest_ok.get("status") == "healthy" and sse_ok:
+            if rest_ok and sse_ok:
                 print("REST + SSE ready (another ensure succeeded)")
                 return 0
         print(

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -1,0 +1,354 @@
+"""Tests for the ``ensure`` subcommand (ROADMAP Phase 3).
+
+Point-in-time reconciliation of REST + SSE. Tests mock health checks, TCP
+probes, subprocess launches, and the SSE handshake so the full policy is
+exercised without real servers.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import chatgpt_web2api.ensure as ensure_mod
+from chatgpt_web2api.ensure import (
+    _build_rest_cmd,
+    _build_sse_cmd,
+    run_ensure,
+)
+
+
+def _install_virtual_clock(monkeypatch):
+    t = [0.0]
+    monkeypatch.setattr(ensure_mod.time, "monotonic", lambda: t[0])
+
+    async def fast_sleep(s):
+        t[0] += s
+
+    monkeypatch.setattr(ensure_mod.asyncio, "sleep", fast_sleep)
+    return t
+
+
+def _patch_health(monkeypatch, health_sequence):
+    """health_sequence: list of dicts/None returned by successive /health calls.
+    A None means 'unreachable' (missing)."""
+    calls = {"n": 0}
+    health_sequence = list(health_sequence)
+
+    def fake_health(rest_port, timeout=3.0):
+        idx = min(calls["n"], len(health_sequence) - 1)
+        calls["n"] += 1
+        return health_sequence[idx]
+
+    monkeypatch.setattr(ensure_mod, "_rest_health", fake_health)
+    return calls
+
+
+def _patch_sse_tcp(monkeypatch, up_sequence):
+    """up_sequence: list of bools for successive TCP checks."""
+    calls = {"n": 0}
+    up_sequence = list(up_sequence)
+
+    def fake_tcp(sse_port, timeout=1.0):
+        idx = min(calls["n"], len(up_sequence) - 1)
+        calls["n"] += 1
+        return up_sequence[idx]
+
+    monkeypatch.setattr(ensure_mod, "_sse_tcp_up", fake_tcp)
+    return calls
+
+
+def _patch_sse_verify(monkeypatch, result):
+    async def fake_verify(sse_port):
+        return result
+
+    monkeypatch.setattr(ensure_mod, "_sse_verify", fake_verify)
+
+
+def _patch_launch(monkeypatch):
+    """Patch subprocess.Popen to capture commands without launching."""
+    launches = []
+    monkeypatch.setattr(
+        ensure_mod.subprocess, "Popen", lambda cmd, **kw: launches.append(cmd) or MagicMock()
+    )
+    return launches
+
+
+def _patch_lock(monkeypatch):
+    """Patch _StartupLock to a no-op async context manager."""
+
+    class FakeLock:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            pass
+
+    monkeypatch.setattr(ensure_mod, "_StartupLock", lambda *a, **kw: FakeLock())
+
+
+# ── 1. noop when both healthy ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_noop_when_rest_healthy_and_sse_up(monkeypatch):
+    _install_virtual_clock(monkeypatch)
+    _patch_health(monkeypatch, [{"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert launches == [], "should not launch anything when both are up"
+
+
+# ── 2. starts REST when missing ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_starts_rest_when_missing(monkeypatch):
+    _install_virtual_clock(monkeypatch)
+    # missing, then becomes healthy after launch
+    _patch_health(monkeypatch, [None, {"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert len(launches) == 1
+    assert any("start" in a for a in launches[0]) or "start" in launches[0]
+
+
+# ── 3. starts SSE when missing ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_starts_sse_when_missing(monkeypatch):
+    _install_virtual_clock(monkeypatch)
+    _patch_health(monkeypatch, [{"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [False, True])  # not up, then up after launch
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert len(launches) == 1
+    # launches[0] is the arg list; check for the mcp_server module + sse transport
+    assert any("mcp_server" in a for a in launches[0])
+    assert "sse" in launches[0]
+
+
+# ── 4. degraded waits then restarts ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_degraded_waits_then_restarts(monkeypatch):
+    t = _install_virtual_clock(monkeypatch)
+    # degraded for the whole 20s window, then healthy after restart
+    health_seq = [{"status": "degraded"}] * 20 + [{"status": "healthy"}]
+    _patch_health(monkeypatch, health_seq)
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    # Must have launched REST (the restart after degraded timeout)
+    assert len(launches) == 1
+    assert any("start" in a for a in launches[0])
+    # Must have waited (clock advanced past the degraded budget)
+    assert t[0] >= 20.0
+
+
+# ── 5. degraded recovers, no restart ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_degraded_recovers_no_restart(monkeypatch):
+    _install_virtual_clock(monkeypatch)
+    # degraded, then healthy within the window
+    _patch_health(
+        monkeypatch, [{"status": "degraded"}, {"status": "degraded"}, {"status": "healthy"}]
+    )
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert launches == [], "should NOT restart REST when it recovers from degraded"
+
+
+# ── 6. broken restarts REST immediately ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_broken_restarts_rest(monkeypatch):
+    _install_virtual_clock(monkeypatch)
+    _patch_health(monkeypatch, [{"status": "broken"}, {"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert len(launches) == 1
+    assert any("start" in a for a in launches[0])
+
+
+# ── 7. concurrent lock prevents double-launch (bounded wait) ───────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_lock_contention_exits_on_observed_state(monkeypatch):
+    _install_virtual_clock(monkeypatch)
+
+    class HeldLock:
+        async def __aenter__(self):
+            raise ensure_mod.LockAcquisitionError("held")
+
+        async def __aexit__(self, *a):
+            pass
+
+    monkeypatch.setattr(ensure_mod, "_StartupLock", lambda *a, **kw: HeldLock())
+    # During re-check, both are healthy → exit 0
+    _patch_health(monkeypatch, [{"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert launches == [], "should not launch while another ensure owns the lock"
+
+
+# ── 8. exit nonzero on failure ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_exit_nonzero_when_rest_never_healthy(monkeypatch):
+    _install_virtual_clock(monkeypatch)
+    _patch_health(monkeypatch, [None])  # never becomes healthy
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code != 0
+
+
+# ── 9. custom rest_port passed to subprocess ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_custom_rest_port_passed_to_subprocess(monkeypatch):
+    _install_virtual_clock(monkeypatch)
+    _patch_health(monkeypatch, [None, {"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8081, sse_port=8090)
+    assert code == 0
+    assert len(launches) == 1
+    # The custom port must appear in the REST launch command
+    assert "8081" in launches[0]
+
+
+# ── 10. cdp/config args propagated correctly ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cdp_and_config_args_propagated(monkeypatch):
+    """--cdp-port is ALWAYS passed. --config/--log-level ONLY when explicit."""
+    _install_virtual_clock(monkeypatch)
+    _patch_health(monkeypatch, [None, {"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [False, True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    # With explicit config + log_level
+    code = await run_ensure(
+        rest_port=8080,
+        sse_port=8090,
+        cdp_port=9333,
+        config_path="/tmp/cfg.json",
+        log_level="DEBUG",
+    )
+    assert code == 0
+    assert len(launches) == 2  # REST + SSE
+    rest_cmd, sse_cmd = launches
+    # --cdp-port always present
+    assert "--cdp-port" in rest_cmd and "9333" in rest_cmd
+    assert "--cdp-port" in sse_cmd and "9333" in sse_cmd
+    # --config present when explicit
+    assert "--config" in rest_cmd and "/tmp/cfg.json" in rest_cmd
+    assert "--config" in sse_cmd and "/tmp/cfg.json" in sse_cmd
+    # --log-level present when explicit
+    assert "--log-level" in rest_cmd and "DEBUG" in rest_cmd
+    assert "--log-level" in sse_cmd and "DEBUG" in sse_cmd
+
+
+@pytest.mark.asyncio
+async def test_no_config_no_log_level_when_not_explicit(monkeypatch):
+    """When config/log_level are None (not provided), they must NOT appear."""
+    _install_virtual_clock(monkeypatch)
+    _patch_health(monkeypatch, [None, {"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [False, True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)  # no config/log_level
+    assert code == 0
+    for cmd in launches:
+        assert "--config" not in cmd, f"--config should be absent: {cmd}"
+        assert "--log-level" not in cmd, f"--log-level should be absent: {cmd}"
+
+
+# ── unit tests for command builders (the 4 flag cases) ─────────────────
+
+
+def test_build_rest_cmd_minimal():
+    """No config/log_level → only --port and --cdp-port."""
+    cmd = _build_rest_cmd(8080, 9222, None, None)
+    assert "--port" in cmd and "8080" in cmd
+    assert "--cdp-port" in cmd and "9222" in cmd
+    assert "--config" not in cmd
+    assert "--log-level" not in cmd
+
+
+def test_build_rest_cmd_full():
+    """Explicit config/log_level → both present."""
+    cmd = _build_rest_cmd(8081, 9333, "/tmp/c.json", "DEBUG")
+    assert "--port" in cmd and "8081" in cmd
+    assert "--cdp-port" in cmd and "9333" in cmd
+    assert "--config" in cmd and "/tmp/c.json" in cmd
+    assert "--log-level" in cmd and "DEBUG" in cmd
+
+
+def test_build_sse_cmd_minimal():
+    cmd = _build_sse_cmd(8090, 9222, None, None)
+    assert "--transport" in cmd and "sse" in cmd
+    assert "--port" in cmd and "8090" in cmd
+    assert "--cdp-port" in cmd and "9222" in cmd
+    assert "--config" not in cmd
+    assert "--log-level" not in cmd
+
+
+def test_build_sse_cmd_full():
+    cmd = _build_sse_cmd(8091, 9333, "/tmp/c.json", "WARNING")
+    assert "--port" in cmd and "8091" in cmd
+    assert "--cdp-port" in cmd and "9333" in cmd
+    assert "--config" in cmd and "/tmp/c.json" in cmd
+    assert "--log-level" in cmd and "WARNING" in cmd

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -64,6 +64,27 @@ def _patch_sse_verify(monkeypatch, result):
     monkeypatch.setattr(ensure_mod, "_sse_verify", fake_verify)
 
 
+def _patch_listener_stop(monkeypatch):
+    """Patch _find_listener_pid + _terminate_pid so restart tests don't call
+    real netstat/taskkill. Returns a dict tracking calls."""
+    calls = {"find": 0, "terminate": 0, "stopped_ports": []}
+
+    def fake_find(port):
+        calls["find"] += 1
+        return 12345  # pretend a listener exists
+
+    def fake_terminate(pid):
+        calls["terminate"] += 1
+
+    async def fake_stop(port):
+        calls["stopped_ports"].append(port)
+
+    monkeypatch.setattr(ensure_mod, "_find_listener_pid", fake_find)
+    monkeypatch.setattr(ensure_mod, "_terminate_pid", fake_terminate)
+    monkeypatch.setattr(ensure_mod, "_stop_rest_listener", fake_stop)
+    return calls
+
+
 def _patch_launch(monkeypatch):
     """Patch subprocess.Popen to capture commands without launching."""
     launches = []
@@ -155,6 +176,7 @@ async def test_degraded_waits_then_restarts(monkeypatch):
     _patch_sse_verify(monkeypatch, True)
     launches = _patch_launch(monkeypatch)
     _patch_lock(monkeypatch)
+    stop_calls = _patch_listener_stop(monkeypatch)
 
     code = await run_ensure(rest_port=8080, sse_port=8090)
     assert code == 0
@@ -163,6 +185,8 @@ async def test_degraded_waits_then_restarts(monkeypatch):
     assert any("start" in a for a in launches[0])
     # Must have waited (clock advanced past the degraded budget)
     assert t[0] >= 20.0
+    # Restart MUST stop the existing listener before launching
+    assert stop_calls["stopped_ports"] == [8080]
 
 
 # ── 5. degraded recovers, no restart ────────────────────────────────────
@@ -196,11 +220,16 @@ async def test_broken_restarts_rest(monkeypatch):
     _patch_sse_verify(monkeypatch, True)
     launches = _patch_launch(monkeypatch)
     _patch_lock(monkeypatch)
+    stop_calls = _patch_listener_stop(monkeypatch)
 
     code = await run_ensure(rest_port=8080, sse_port=8090)
     assert code == 0
     assert len(launches) == 1
     assert any("start" in a for a in launches[0])
+    # Restart MUST stop the existing listener before launching — not a bare launch
+    assert stop_calls["stopped_ports"] == [8080], (
+        "restart must call _stop_rest_listener before relaunch"
+    )
 
 
 # ── 7. concurrent lock prevents double-launch (bounded wait) ───────────
@@ -352,3 +381,134 @@ def test_build_sse_cmd_full():
     assert "--cdp-port" in cmd and "9333" in cmd
     assert "--config" in cmd and "/tmp/c.json" in cmd
     assert "--log-level" in cmd and "WARNING" in cmd
+
+
+# ── 12. Lock handle retained until release (review fix #1) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_startup_lock_retains_handle_until_release(monkeypatch):
+    """The portalocker file handle must be HELD open until __aexit__. The old
+    code locked one handle then stored a different unlocked one — so concurrent
+    ensures could double-launch. Verify the held handle is the locked one and
+    survives until release."""
+    import tempfile
+    from pathlib import Path
+
+    # Use a temp dir so we don't clobber the real lock
+    tmpdir = tempfile.mkdtemp()
+    monkeypatch.setattr(Path, "home", lambda: Path(tmpdir))
+
+    lock = ensure_mod._StartupLock(sse_port=99999, timeout=5.0)
+    await lock.__aenter__()
+    # The handle must be set and open (not None, not closed)
+    assert lock._fh is not None, "lock handle must be retained after acquire"
+    assert not lock._fh.closed, "lock handle must still be open while held"
+    await lock.__aexit__(None, None, None)
+    # After release, the handle is closed
+    assert lock._fh.closed, "lock handle must be closed after release"
+
+
+# ── 13. starting + connected is ready for ensure (review fix #2) ───────
+
+
+def test_rest_ready_for_ensure_accepts_starting_connected():
+    """A cold-bootstrap REST may report 'starting' (no chat yet) but with
+    Chrome/CDP/driver all connected. That's ready enough for SSE to attach."""
+    assert (
+        ensure_mod._rest_ready_for_ensure(
+            {
+                "status": "starting",
+                "chrome_running": True,
+                "cdp_connected": True,
+                "driver_connected": True,
+            }
+        )
+        is True
+    )
+
+
+def test_rest_ready_for_ensure_rejects_starting_not_connected():
+    """starting WITHOUT full connectivity (Chrome up but driver not connected)
+    must NOT pass — SSE can't attach to a half-started REST."""
+    assert (
+        ensure_mod._rest_ready_for_ensure(
+            {
+                "status": "starting",
+                "chrome_running": True,
+                "cdp_connected": False,
+                "driver_connected": False,
+            }
+        )
+        is False
+    )
+
+
+def test_rest_ready_for_ensure_rejects_degraded_broken():
+    assert ensure_mod._rest_ready_for_ensure({"status": "degraded"}) is False
+    assert ensure_mod._rest_ready_for_ensure({"status": "broken"}) is False
+    assert ensure_mod._rest_ready_for_ensure(None) is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_accepts_starting_connected_as_ready(monkeypatch):
+    """End-to-end: REST reports starting+connected → ensure proceeds to SSE,
+    no restart, exits 0."""
+    _install_virtual_clock(monkeypatch)
+    _patch_health(
+        monkeypatch,
+        [
+            {
+                "status": "starting",
+                "chrome_running": True,
+                "cdp_connected": True,
+                "driver_connected": True,
+            }
+        ],
+    )
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert launches == [], "should not launch anything — starting+connected is ready"
+
+
+# ── 14. restart stops listener before relaunch (review fix #3) ─────────
+
+
+@pytest.mark.asyncio
+async def test_restart_calls_stop_listener_before_launch(monkeypatch):
+    """The broken/degraded-timeout restart path must call _stop_rest_listener
+    BEFORE _launch_detached — a bare launch on an occupied port fails to bind.
+    This is covered in test_broken_restarts_rest and test_degraded_waits_then_restarts
+    above; this is a focused unit test on _restart_rest itself."""
+    _install_virtual_clock(monkeypatch)
+    monkeypatch.setattr(ensure_mod, "_rest_health", lambda *a, **kw: {"status": "healthy"})
+
+    stop_order = []
+    monkeypatch.setattr(ensure_mod, "_stop_rest_listener", _make_async_recorder(stop_order, "stop"))
+    monkeypatch.setattr(ensure_mod, "_launch_detached", _make_recorder(stop_order, "launch"))
+    monkeypatch.setattr(ensure_mod, "_wait_rest_ready", _make_async_recorder(stop_order, "wait"))
+
+    await ensure_mod._restart_rest(8080, 9222, None, None)
+    # stop MUST come before launch
+    assert stop_order == ["stop", "launch", "wait"], f"order wrong: {stop_order}"
+
+
+def _make_recorder(lst, tag):
+    def _record(*a, **kw):
+        lst.append(tag)
+        return MagicMock()
+
+    return _record
+
+
+def _make_async_recorder(lst, tag):
+    async def _record(*a, **kw):
+        lst.append(tag)
+        return True
+
+    return _record


### PR DESCRIPTION
## Summary

ROADMAP Phase 3: the `chatgpt-web2api ensure` subcommand — point-in-time REST+SSE reconciliation for ZCode hooks. **New feature, no changes to existing server behavior.**

```bash
chatgpt-web2api ensure [--rest-port 8080] [--mcp-sse-port 8090] [--config X] [--cdp-port 9222] [--log-level INFO]
```

Checks REST (`/health`) and SSE, starts whichever is missing, verifies SSE via a real MCP handshake, exits `0` when both ready. Not a watchdog — re-run on next hook if a service dies.

## Pinned Phase 3 constraints (all honored)

| Constraint | Implementation |
|-----------|----------------|
| **Degraded-REST policy** | Poll 2s × 20s before restart (transient CDP reconnect); only `missing`/`broken` trigger immediate (re)start |
| **Bounded startup lock** | SSE-port-keyed (`~/.chatgpt_web2api/sse-startup-{port}.lock`), 10s timeout; contention → wait+recheck, never block indefinitely |
| **No watchdog** | Point-in-time reconcile, exit. No Python loop after exit |
| **REST owns Chrome** | `ensure` launches REST via `chatgpt-web2api start`; SSE via `chatgpt-web2api-mcp --transport sse`. Neither is in-process |

## Subprocess arg propagation (review guardrail)

- `--port` (REST) and `--port`+`--transport sse` (SSE): **always** passed
- `--cdp-port`: **always** passed (ensure resolved it)
- `--config`: **only** when caller provided an explicit path
- `--log-level`: **only** when caller provided it (`default=None` sentinel in the ensure parser, NOT the `_add_common_args` `"INFO"` default)

Covered by tests: `test_build_rest_cmd_minimal/full`, `test_build_sse_cmd_minimal/full`, `test_cdp_and_config_args_propagated`, `test_no_config_no_log_level_when_not_explicit`.

## SSE verification depth

TCP preflight (`socket.connect`) → then real `sse_client` + `ClientSession.initialize()` + `list_tools()`. TCP-up but handshake failure = NOT ready (the same pattern as the SSE e2e tests).

## Verification
- `ruff check .` + `ruff format --check .` — clean
- Unit suite: **336 passed** (321 + 15 new ensure tests)
- **Live tested both paths:**
  - Both REST+SSE up → no-op, exit 0 (~2s)
  - SSE killed → `ensure` detected missing, relaunched, verified via handshake, exit 0 (~10s)

## Tests (`tests/test_ensure.py`, 15 tests)
Policy tests (mocked health/TCP/subprocess/sse_client + virtual clock):
1. `noop_when_rest_healthy_and_sse_up`
2. `starts_rest_when_missing`
3. `starts_sse_when_missing`
4. `degraded_waits_then_restarts`
5. `degraded_recovers_no_restart`
6. `broken_restarts_rest`
7. `concurrent_lock_contention_exits_on_observed_state`
8. `exit_nonzero_when_rest_never_healthy`
9. `custom_rest_port_passed_to_subprocess`
10. `cdp_and_config_args_propagated`
11. `no_config_no_log_level_when_not_explicit`

Command-builder unit tests (the 4 flag cases):
12-15. `test_build_{rest,sse}_cmd_{minimal,full}`

## Out of scope
No watchdog (Phase 6), no SSE crash-recovery monitor, no changes to REST/`/health`/Chrome ownership.

## Docs
- README: "ZCode Hook: One-Line Bootstrap with `ensure`" subsection
- ROADMAP: Phase 3 marked DONE
