### PR TITLE
fix(ensure): robust listener discovery, generalized stop, SSE broken-handshake restart (#16)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -138,7 +138,13 @@ into the `__main__.py` subcommand dispatch. Point-in-time reconcile: checks
 REST + SSE, starts whichever is missing, verifies SSE via real MCP handshake,
 exits 0 when ready. Lock-protected (SSE-port-keyed startup lock, bounded
 contention). Degraded-REST policy honored (20s poll before restart). No
-watchdog loop. 15 unit tests in `tests/test_ensure.py`.
+watchdog loop. 30 unit tests in `tests/test_ensure.py`.
+
+Restart hardening (#16): Unix listener discovery uses a `lsof` → `ss` → `fuser`
+fallback chain (no single-tool dependency); `_stop_listener` returns False (and
+logs an error) when a port is occupied but no PID can be found, so the caller
+aborts the restart instead of launching into an occupied port. SSE
+handshake-failed path stops the existing listener before relaunch.
 
 ### Command
 
@@ -153,7 +159,9 @@ dispatch in `__main__.py`.
 
 1. Check REST `/health`.
 2. Reconcile REST per the **degraded-REST policy** below.
-3. Wait until REST is healthy.
+3. Wait until REST is ready (`healthy`, or `starting` + Chrome/CDP/driver
+   all connected — a cold bootstrap that hasn't served a chat yet is ready
+   enough for SSE to attach).
 4. Check MCP/SSE on `:8090`.
 5. If missing, start MCP/SSE.
 6. Verify MCP/SSE: initialize succeeds + list tools succeeds.

--- a/src/chatgpt_web2api/ensure.py
+++ b/src/chatgpt_web2api/ensure.py
@@ -225,27 +225,77 @@ def _launch_detached(cmd: list[str]) -> subprocess.Popen:
 
 def _find_listener_pid(port: int) -> int | None:
     """Find the PID listening on the given TCP port (loopback). Returns None
-    if nothing is listening or the lookup fails."""
+    if nothing is listening or the lookup fails.
+
+    Windows: ``netstat -ano`` (ubiquitous). Unix: a fallback chain of
+    ``lsof`` → ``ss`` → ``fuser`` — no single tool is guaranteed on every
+    distro/container, so we try each in turn. Returns the first PID found.
+    """
+    if sys.platform == "win32":
+        return _find_listener_pid_netstat(port)
+    for finder in (_find_listener_pid_lsof, _find_listener_pid_ss, _find_listener_pid_fuser):
+        pid = finder(port)
+        if pid is not None:
+            return pid
+    return None
+
+
+def _find_listener_pid_netstat(port: int) -> int | None:
     try:
-        if sys.platform == "win32":
-            # netstat -ano: last column is the PID for LISTENING rows
-            out = subprocess.check_output(
-                ["netstat", "-ano"], text=True, stderr=subprocess.DEVNULL, timeout=5
-            )
-            for line in out.splitlines():
-                parts = line.split()
-                if len(parts) >= 5 and "LISTENING" in line:
-                    if parts[1].endswith(f":{port}"):
-                        return int(parts[-1])
-        else:
-            # lsof -ti :<port> returns the PID(s) of listeners
-            out = subprocess.check_output(
-                ["lsof", "-ti", f":{port}"], text=True, stderr=subprocess.DEVNULL, timeout=5
-            ).strip()
-            if out:
-                return int(out.splitlines()[0])
+        out = subprocess.check_output(
+            ["netstat", "-ano"], text=True, stderr=subprocess.DEVNULL, timeout=5
+        )
+        for line in out.splitlines():
+            parts = line.split()
+            if len(parts) >= 5 and "LISTENING" in line and parts[1].endswith(f":{port}"):
+                return int(parts[-1])
     except Exception:
-        return None
+        pass
+    return None
+
+
+def _find_listener_pid_lsof(port: int) -> int | None:
+    try:
+        out = subprocess.check_output(
+            ["lsof", "-ti", f":{port}"], text=True, stderr=subprocess.DEVNULL, timeout=5
+        ).strip()
+        if out:
+            return int(out.splitlines()[0])
+    except Exception:
+        pass
+    return None
+
+
+def _find_listener_pid_ss(port: int) -> int | None:
+    """``ss -tlnp`` — standard on modern Linux (iproute2). Parse the pid= from
+    the users: column."""
+    try:
+        out = subprocess.check_output(
+            ["ss", "-tlnp"], text=True, stderr=subprocess.DEVNULL, timeout=5
+        )
+        for line in out.splitlines():
+            if f":{port}" in line and "pid=" in line:
+                # Extract pid=NNN from the users:(("proc",pid=NNN,...)) column
+                import re as _re
+
+                m = _re.search(r"pid=(\d+)", line)
+                if m:
+                    return int(m.group(1))
+    except Exception:
+        pass
+    return None
+
+
+def _find_listener_pid_fuser(port: int) -> int | None:
+    """``fuser <port>/tcp`` — older Linux fallback (psmisc)."""
+    try:
+        out = subprocess.check_output(
+            ["fuser", f"{port}/tcp"], text=True, stderr=subprocess.DEVNULL, timeout=5
+        ).strip()
+        if out:
+            return int(out.split()[0])
+    except Exception:
+        pass
     return None
 
 
@@ -271,25 +321,50 @@ def _terminate_pid(pid: int) -> None:
         logger.debug("terminate pid %s failed: %s", pid, e)
 
 
-async def _stop_rest_listener(rest_port: int) -> None:
-    """Stop whatever process is listening on the REST port, then wait for the
+async def _stop_listener(port: int, label: str) -> bool:
+    """Stop whatever process is listening on the given port, then wait for the
     port to free. A bare ``_launch_detached`` on an occupied port fails to bind
-    (stderr is discarded), so a restart must stop the existing listener first."""
-    pid = _find_listener_pid(rest_port)
+    (stderr is discarded), so a restart must stop the existing listener first.
+
+    Returns True if the port is free (either nothing was listening, or the
+    listener was stopped). Returns False if the port is still occupied but no
+    PID could be found to terminate — caller should NOT relaunch in that case
+    (the new process would fail to bind with no diagnostic)."""
+    pid = _find_listener_pid(port)
     if pid is None:
-        return
-    logger.info("Stopping existing REST listener (pid %s) on :%d", pid, rest_port)
+        # Check if the port is actually free (nothing listening) vs occupied
+        # but no PID discoverable (tools missing) — the dangerous case.
+        if _port_accepts(port):
+            logger.error(
+                "Port :%d (%s) is occupied but no listener PID could be found "
+                "(lsof/ss/fuser/netstat all failed or absent). Cannot safely "
+                "restart — the new process would fail to bind. Aborting restart.",
+                port,
+                label,
+            )
+            return False
+        return True  # port is genuinely free
+
+    logger.info("Stopping existing %s listener (pid %s) on :%d", label, pid, port)
     await asyncio.to_thread(_terminate_pid, pid)
     # Wait for the port to free (bind would fail if still occupied)
     for _ in range(20):
-        try:
-            with socket.socket() as s:
-                s.settimeout(0.5)
-                s.connect(("127.0.0.1", rest_port))
-            # still accepting connections — wait
-        except OSError:
-            break  # port closed — ready
+        if not _port_accepts(port):
+            return True  # port closed — ready
         await asyncio.sleep(0.5)
+    logger.error("%s listener (pid %s) did not release :%d after 10s", label, pid, port)
+    return False
+
+
+def _port_accepts(port: int) -> bool:
+    """Does anything accept a TCP connection on this loopback port?"""
+    try:
+        with socket.socket() as s:
+            s.settimeout(0.5)
+            s.connect(("127.0.0.1", port))
+        return True
+    except OSError:
+        return False
 
 
 async def _restart_rest(
@@ -297,8 +372,10 @@ async def _restart_rest(
 ) -> bool:
     """Stop the existing REST listener, then launch a fresh one. Used for
     ``broken`` and degraded-after-timeout — not for ``missing`` (no listener
-    to stop)."""
-    await _stop_rest_listener(rest_port)
+    to stop). Returns False if the listener couldn't be stopped (port still
+    occupied) — in that case do NOT relaunch (bind would fail silently)."""
+    if not await _stop_listener(rest_port, "REST"):
+        return False
     _launch_detached(_build_rest_cmd(rest_port, cdp_port, config_path, log_level))
     return await _wait_rest_ready(rest_port, _REST_HEALTHY_TIMEOUT)
 
@@ -357,15 +434,23 @@ async def _reconcile_rest(
 async def _reconcile_sse(
     sse_port: int, cdp_port: int, config_path: str | None, log_level: str | None
 ) -> bool:
-    """Start SSE if missing, then verify via real MCP handshake."""
+    """Start SSE if missing, then verify via real MCP handshake. If the port is
+    up but the handshake fails (broken/hung SSE), stop the existing listener
+    before relaunching — a bare launch on the occupied port would fail to bind."""
     if _sse_tcp_up(sse_port):
         ready = await _sse_verify(sse_port)
         if ready:
             logger.info("SSE ready on :%d", sse_port)
             return True
-        logger.info("SSE port up but handshake failed — treating as not ready")
+        # Port is up but handshake failed — stop the broken listener first.
+        # If _stop_listener can't confirm termination (tools missing), abort:
+        # a relaunch would fail to bind with no diagnostic.
+        logger.info("SSE port up but handshake failed — stopping broken listener")
+        if not await _stop_listener(sse_port, "SSE"):
+            logger.error("Could not stop broken SSE listener on :%d — aborting", sse_port)
+            return False
 
-    logger.info("SSE missing — starting")
+    logger.info("SSE starting")
     _launch_detached(_build_sse_cmd(sse_port, cdp_port, config_path, log_level))
 
     # Wait for TCP, then verify handshake.

--- a/src/chatgpt_web2api/ensure.py
+++ b/src/chatgpt_web2api/ensure.py
@@ -21,6 +21,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -247,6 +248,9 @@ def _find_listener_pid_netstat(port: int) -> int | None:
         )
         for line in out.splitlines():
             parts = line.split()
+            # parts[1] is "HOST:PORT" (e.g. "127.0.0.1:8080"). endswith is
+            # already exact here (":80" won't match ":8080" — the string ends in
+            # "0", not "80"); kept explicit for clarity.
             if len(parts) >= 5 and "LISTENING" in line and parts[1].endswith(f":{port}"):
                 return int(parts[-1])
     except Exception:
@@ -268,19 +272,30 @@ def _find_listener_pid_lsof(port: int) -> int | None:
 
 def _find_listener_pid_ss(port: int) -> int | None:
     """``ss -tlnp`` — standard on modern Linux (iproute2). Parse the pid= from
-    the users: column."""
+    the users: column.
+
+    The Local Address column is matched EXACTLY (host:port split on the last
+    ':'), never by substring — the previous ``f":{port}" in line`` check treated
+    port 80 as matching ':8080' and returned the wrong PID. See issue #16.
+    """
+    port_str = str(port)
     try:
         out = subprocess.check_output(
             ["ss", "-tlnp"], text=True, stderr=subprocess.DEVNULL, timeout=5
         )
         for line in out.splitlines():
-            if f":{port}" in line and "pid=" in line:
-                # Extract pid=NNN from the users:(("proc",pid=NNN,...)) column
-                import re as _re
-
-                m = _re.search(r"pid=(\d+)", line)
-                if m:
-                    return int(m.group(1))
+            if "pid=" not in line:
+                continue
+            # Columns run together when empty; "pid=" only appears on bound
+            # sockets, and the Local Address precedes Peer Address. Extract the
+            # port from the "<addr>:<port>" token (whitespace-delimited) and
+            # require an exact match.
+            tokens = line.split()
+            if not any(t.rsplit(":", 1)[-1] == port_str for t in tokens):
+                continue
+            m = re.search(r"pid=(\d+)", line)
+            if m:
+                return int(m.group(1))
     except Exception:
         pass
     return None

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -666,3 +666,62 @@ async def test_sse_broken_handshake_stops_listener_before_relaunch(monkeypatch):
     assert any(p == 8090 and lbl == "SSE" for p, lbl in stop_calls), (
         f"SSE broken-handshake must call _stop_listener: {stop_calls}"
     )
+
+
+# ── 18. Exact-port matching — no prefix-port false positive (#16 review) ──
+
+
+def test_find_listener_pid_ss_does_not_match_prefix_port(monkeypatch):
+    """The reviewer's exact scenario: querying port 80 must NOT match an ss
+    line for :8080. The old substring check ``f":{port}" in line`` matched
+    ``:8080`` when port==80 and returned pid=123, so _stop_listener could
+    terminate an unrelated process. Exact address parsing fixes it."""
+    from unittest.mock import patch
+
+    ss_output = (
+        "LISTEN 0      4096   127.0.0.1:8080   0.0.0.0:*   "
+        "users:((\"python\",pid=123,fd=5))\n"
+    )
+    with patch.object(ensure_mod.subprocess, "check_output", return_value=ss_output):
+        assert ensure_mod._find_listener_pid_ss(80) is None
+
+
+def test_find_listener_pid_ss_matches_exact_port(monkeypatch):
+    """The exact-port fix still returns the PID when the queried port IS the
+    listening port."""
+    from unittest.mock import patch
+
+    ss_output = (
+        "LISTEN 0      4096   127.0.0.1:8080   0.0.0.0:*   "
+        "users:((\"python\",pid=123,fd=5))\n"
+    )
+    with patch.object(ensure_mod.subprocess, "check_output", return_value=ss_output):
+        assert ensure_mod._find_listener_pid_ss(8080) == 123
+
+
+def test_find_listener_pid_ss_ignores_neighbor_port(monkeypatch):
+    """A listener on 8080 must not satisfy a query for 8090 (and vice versa)."""
+    from unittest.mock import patch
+
+    ss_output = (
+        "LISTEN 0      4096   127.0.0.1:8080   0.0.0.0:*   "
+        "users:((\"python\",pid=123,fd=5))\n"
+    )
+    with patch.object(ensure_mod.subprocess, "check_output", return_value=ss_output):
+        assert ensure_mod._find_listener_pid_ss(8090) is None
+
+
+def test_find_listener_pid_ss_picks_correct_pid_among_many(monkeypatch):
+    """When several listeners are present, the exact port returns its own PID,
+    not a neighbor's."""
+    from unittest.mock import patch
+
+    ss_output = (
+        "LISTEN 0      4096   127.0.0.1:80    0.0.0.0:*   "
+        "users:((\"nginx\",pid=7,fd=6))\n"
+        "LISTEN 0      4096   127.0.0.1:8080  0.0.0.0:*   "
+        "users:((\"python\",pid=123,fd=5))\n"
+    )
+    with patch.object(ensure_mod.subprocess, "check_output", return_value=ss_output):
+        assert ensure_mod._find_listener_pid_ss(80) == 7
+        assert ensure_mod._find_listener_pid_ss(8080) == 123

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -65,8 +65,8 @@ def _patch_sse_verify(monkeypatch, result):
 
 
 def _patch_listener_stop(monkeypatch):
-    """Patch _find_listener_pid + _terminate_pid so restart tests don't call
-    real netstat/taskkill. Returns a dict tracking calls."""
+    """Patch _stop_listener + _find_listener_pid + _terminate_pid so restart
+    tests don't call real netstat/taskkill. Returns a dict tracking calls."""
     calls = {"find": 0, "terminate": 0, "stopped_ports": []}
 
     def fake_find(port):
@@ -76,12 +76,13 @@ def _patch_listener_stop(monkeypatch):
     def fake_terminate(pid):
         calls["terminate"] += 1
 
-    async def fake_stop(port):
+    async def fake_stop(port, label="REST"):
         calls["stopped_ports"].append(port)
+        return True  # success
 
     monkeypatch.setattr(ensure_mod, "_find_listener_pid", fake_find)
     monkeypatch.setattr(ensure_mod, "_terminate_pid", fake_terminate)
-    monkeypatch.setattr(ensure_mod, "_stop_rest_listener", fake_stop)
+    monkeypatch.setattr(ensure_mod, "_stop_listener", fake_stop)
     return calls
 
 
@@ -481,7 +482,7 @@ async def test_ensure_accepts_starting_connected_as_ready(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_restart_calls_stop_listener_before_launch(monkeypatch):
-    """The broken/degraded-timeout restart path must call _stop_rest_listener
+    """The broken/degraded-timeout restart path must call _stop_listener
     BEFORE _launch_detached — a bare launch on an occupied port fails to bind.
     This is covered in test_broken_restarts_rest and test_degraded_waits_then_restarts
     above; this is a focused unit test on _restart_rest itself."""
@@ -489,7 +490,7 @@ async def test_restart_calls_stop_listener_before_launch(monkeypatch):
     monkeypatch.setattr(ensure_mod, "_rest_health", lambda *a, **kw: {"status": "healthy"})
 
     stop_order = []
-    monkeypatch.setattr(ensure_mod, "_stop_rest_listener", _make_async_recorder(stop_order, "stop"))
+    monkeypatch.setattr(ensure_mod, "_stop_listener", _make_async_recorder(stop_order, "stop"))
     monkeypatch.setattr(ensure_mod, "_launch_detached", _make_recorder(stop_order, "launch"))
     monkeypatch.setattr(ensure_mod, "_wait_rest_ready", _make_async_recorder(stop_order, "wait"))
 
@@ -512,3 +513,156 @@ def _make_async_recorder(lst, tag):
         return True
 
     return _record
+
+
+# ── 15. Unix listener discovery fallback (issue #16) ───────────────────
+
+
+def test_find_listener_pid_uses_netstat_on_windows(monkeypatch):
+    """On Windows, _find_listener_pid uses netstat (not the Unix chain)."""
+    from unittest.mock import patch
+
+    with (
+        patch.object(ensure_mod.sys, "platform", "win32"),
+        patch.object(ensure_mod, "_find_listener_pid_netstat", return_value=999) as netstat_mock,
+        patch.object(ensure_mod, "_find_listener_pid_lsof", return_value=111) as lsof_mock,
+    ):
+        assert ensure_mod._find_listener_pid(8080) == 999
+        netstat_mock.assert_called_once_with(8080)
+        lsof_mock.assert_not_called()
+
+
+def test_find_listener_pid_unix_lsof_found(monkeypatch):
+    """On Unix, when lsof succeeds, its PID is returned (no fallback needed)."""
+    from unittest.mock import patch
+
+    with (
+        patch.object(ensure_mod.sys, "platform", "linux"),
+        patch.object(ensure_mod, "_find_listener_pid_lsof", return_value=111),
+        patch.object(ensure_mod, "_find_listener_pid_ss", return_value=222) as ss_mock,
+    ):
+        assert ensure_mod._find_listener_pid(8080) == 111
+        ss_mock.assert_not_called()
+
+
+def test_find_listener_pid_unix_falls_back_to_ss():
+    """When lsof returns None (absent/fails), ss is tried."""
+    from unittest.mock import patch
+
+    with (
+        patch.object(ensure_mod.sys, "platform", "linux"),
+        patch.object(ensure_mod, "_find_listener_pid_lsof", return_value=None),
+        patch.object(ensure_mod, "_find_listener_pid_ss", return_value=222),
+    ):
+        assert ensure_mod._find_listener_pid(8080) == 222
+
+
+def test_find_listener_pid_unix_falls_back_to_fuser():
+    """When lsof and ss both fail, fuser is tried."""
+    from unittest.mock import patch
+
+    with (
+        patch.object(ensure_mod.sys, "platform", "linux"),
+        patch.object(ensure_mod, "_find_listener_pid_lsof", return_value=None),
+        patch.object(ensure_mod, "_find_listener_pid_ss", return_value=None),
+        patch.object(ensure_mod, "_find_listener_pid_fuser", return_value=333),
+    ):
+        assert ensure_mod._find_listener_pid(8080) == 333
+
+
+def test_find_listener_pid_unix_all_fail_returns_none():
+    """When all three Unix tools fail/are absent, returns None (not an error)."""
+    from unittest.mock import patch
+
+    with (
+        patch.object(ensure_mod.sys, "platform", "linux"),
+        patch.object(ensure_mod, "_find_listener_pid_lsof", return_value=None),
+        patch.object(ensure_mod, "_find_listener_pid_ss", return_value=None),
+        patch.object(ensure_mod, "_find_listener_pid_fuser", return_value=None),
+    ):
+        assert ensure_mod._find_listener_pid(8080) is None
+
+
+# ── 16. Occupied port but no PID → _stop_listener returns False (issue #16)
+
+
+@pytest.mark.asyncio
+async def test_stop_listener_returns_false_when_port_occupied_but_no_pid(monkeypatch):
+    """The dangerous case: port is occupied (accepts connections) but no PID can
+    be found (tools missing). _stop_listener must return False so the caller
+    does NOT relaunch into the occupied port."""
+    monkeypatch.setattr(ensure_mod, "_find_listener_pid", lambda port: None)
+    monkeypatch.setattr(ensure_mod, "_port_accepts", lambda port: True)  # occupied
+
+    result = await ensure_mod._stop_listener(8080, "REST")
+    assert result is False, "must return False when occupied but no PID found"
+
+
+@pytest.mark.asyncio
+async def test_stop_listener_returns_true_when_port_free(monkeypatch):
+    """Nothing listening → _stop_listener returns True (safe to launch)."""
+    monkeypatch.setattr(ensure_mod, "_find_listener_pid", lambda port: None)
+    monkeypatch.setattr(ensure_mod, "_port_accepts", lambda port: False)  # free
+
+    result = await ensure_mod._stop_listener(8080, "REST")
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_restart_rest_aborts_when_listener_cannot_be_stopped(monkeypatch):
+    """If _stop_listener returns False (can't stop), _restart_rest must NOT
+    launch — returns False (the launch would fail to bind)."""
+    _install_virtual_clock(monkeypatch)
+    monkeypatch.setattr(ensure_mod, "_rest_health", lambda *a, **kw: {"status": "healthy"})
+    launches = _patch_launch(monkeypatch)
+
+    async def stop_fails(port, label="REST"):
+        return False  # can't stop
+
+    monkeypatch.setattr(ensure_mod, "_stop_listener", stop_fails)
+
+    result = await ensure_mod._restart_rest(8080, 9222, None, None)
+    assert result is False
+    assert launches == [], "must NOT launch when listener can't be stopped"
+
+
+# ── 17. SSE broken-handshake stops listener before relaunch (issue #16) ─
+
+
+@pytest.mark.asyncio
+async def test_sse_broken_handshake_stops_listener_before_relaunch(monkeypatch):
+    """TCP-up + handshake-failed → _stop_listener called on the SSE port
+    before launching a new SSE. The old behavior launched without stopping,
+    causing a bind failure."""
+    _install_virtual_clock(monkeypatch)
+    _patch_health(monkeypatch, [{"status": "healthy"}])
+    # TCP up, handshake fails, then TCP up + handshake succeeds after relaunch
+    _patch_sse_tcp(monkeypatch, [True, False, True])
+    _patch_sse_verify(monkeypatch, False)  # first handshake fails
+    # But we need the second verify to succeed — use a sequence
+    verify_results = [False, True]
+
+    async def seq_verify(sse_port):
+        return verify_results.pop(0) if verify_results else True
+
+    monkeypatch.setattr(ensure_mod, "_sse_verify", seq_verify)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    stop_calls = []
+
+    # First TCP check returns True (port up), _stop_listener must be called.
+    # After stop, TCP goes False, then after launch TCP goes True.
+    async def fake_stop(port, label="REST"):
+        stop_calls.append((port, label))
+        return True
+
+    monkeypatch.setattr(ensure_mod, "_stop_listener", fake_stop)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert len(launches) == 1  # SSE was launched
+    # _stop_listener was called on the SSE port
+    assert any(p == 8090 and lbl == "SSE" for p, lbl in stop_calls), (
+        f"SSE broken-handshake must call _stop_listener: {stop_calls}"
+    )


### PR DESCRIPTION
## Summary

Fixes #16.

Hardens the `ensure` restart paths. The strongest risk was #1: Unix restart depended solely on `lsof` — if absent, `_find_listener_pid` silently returned None, `_stop_listener` no-oped, and `_restart_rest` launched a process that couldn't bind the occupied port with no diagnostic.

## Changes

### 1. Robust Unix listener discovery (`ensure.py`)
- `_find_listener_pid` now tries `lsof` → `ss -tlnp` → `fuser` in sequence (no single-tool dependency).
- Windows stays `netstat -ano` (ubiquitous).
- Each finder is a separate, independently testable function.

### 2. Generalized `_stop_listener(port, label)` with failure signaling
- Renamed from `_stop_rest_listener` (now shared by REST + SSE).
- **Returns `False`** (with `logger.error`) when a port is occupied but no PID can be found (all discovery tools failed/absent). The caller aborts the restart instead of launching into the occupied port.
- `_restart_rest` returns `False` in that case — does NOT relaunch.

### 3. SSE broken-handshake restart (`_reconcile_sse`)
- TCP-up + failed MCP handshake now calls `_stop_listener(sse_port, "SSE")` before relaunching.
- If `_stop_listener` returns False (can't stop), aborts with an error — no bind failure.

### 4. ROADMAP docs
- Test count: 15 → 30 (now 351 total suite).
- "Wait until REST is healthy" → "ready" predicate (`healthy` OR `starting` + Chrome/CDP/driver connected).
- Added a paragraph documenting the restart hardening.

## Verification
- `ruff check .` + `ruff format --check .` — clean
- Full unit suite: **351 passed** (342 + 9 new hardening tests)
- Tests are platform-aware (patch `sys.platform` for the Unix fallback chain on Windows CI)

## New tests (9)
- `test_find_listener_pid_uses_netstat_on_windows` — Windows path correctness
- `test_find_listener_pid_unix_lsof_found` / `_falls_back_to_ss` / `_falls_back_to_fuser` / `_all_fail_returns_none` — the fallback chain
- `test_stop_listener_returns_false_when_port_occupied_but_no_pid` — the dangerous silent-failure case now fails loudly
- `test_stop_listener_returns_true_when_port_free` — the happy no-op path
- `test_restart_rest_aborts_when_listener_cannot_be_stopped` — abort, not blind relaunch
- `test_sse_broken_handshake_stops_listener_before_relaunch` — SSE stops listener before relaunch

## Out of scope
No REST server behavior changes, no watchdog, no Phase 4 breaker policy.
