### PR TITLE
feat(breakers): non-rate-limit breaker registry + /health exposure (Phase 4 PR1)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -263,6 +263,35 @@ logs
 **Keep this before the big refactor (Phase 5).** Stabilize behavior first, then
 move code.
 
+### Sequencing — two PRs
+
+Phase 4 is split to keep review tight: ship the infrastructure with no behavior
+change first, then wire the real failure signals in a second PR.
+
+- **PR1 — breaker registry + `/health` exposure.** Ships
+  `src/chatgpt_web2api/breakers.py`: a `BreakerRegistry` keyed by `BreakerKind`
+  (auth_required, composer_send_readiness, cdp_reconnect, chrome_crash_loop)
+  with `record_failure` / `record_success` / `trip` / `is_open` / `snapshot`.
+  `/health` gains a `breakers` snapshot field. **Nothing records failures or
+  trips a breaker yet** — the registry only counts, and `trip()` is the explicit
+  caller-driven path (threshold auto-trip is deferred). Zero behavior change:
+  `/health` always reports all breakers closed. This proves the plumbing
+  risk-free.
+- **PR2 — wire failure signals + fail-fast.** Adds the typed exceptions the
+  composer/CDP paths need (they currently raise bare `RuntimeError`, so a
+  type-keyed breaker can't distinguish them), calls `record_failure`/`trip` at
+  the detection sites (`AuthExpiredError` at `cdp_driver.py:2046`/`:2207`,
+  composer at `_ensure_send_ready`/`type_message`/`click_send`, CDP reconnect at
+  `reconnect()`, Chrome at `chrome.py:restart()`), enforces the thresholds
+  above, adds REST fail-fast (`_error_response` 503 `circuit_open`) + MCP
+  `(circuit_open)` result, decides whether an open breaker forces `/health`
+  `status` to `degraded`, and wires config tunables (`W2A_BREAKER_*`).
+
+```
+PR1  →  registry + snapshot (no behavior change)
+PR2  →  signals + typed exceptions + fail-fast + status policy + config
+```
+
 ---
 
 ## Phase 5 — Split `cdp_driver.py`

--- a/src/chatgpt_web2api/api_server.py
+++ b/src/chatgpt_web2api/api_server.py
@@ -17,6 +17,7 @@ import uuid
 
 from aiohttp import web
 
+from .breakers import BreakerRegistry
 from .cdp_driver import (
     AuthExpiredError,
     CDPDriver,
@@ -65,6 +66,10 @@ class APIServer:
         self._started_at = time.time()
         self._last_error: str | None = None
         self._last_successful_send_at: float | None = None
+        # Non-rate-limit breaker registry (Phase 4, PR1). Snapshotted into
+        # /health below; no failure signals are recorded yet, so it always
+        # reports all breakers closed. PR2 wires the real trip signals.
+        self._breakers = BreakerRegistry()
         # Track last conversation for multi-turn continuity
         self._last_conv_id: str | None = None
         self._last_project_id: str | None = None
@@ -158,6 +163,7 @@ class APIServer:
             "started_at": self._started_at,
             "last_successful_send_at": self._last_successful_send_at,
             "last_error": self._last_error,
+            "breakers": self._breakers.snapshot(),
         })
 
     async def _handle_models(self, request: web.Request) -> web.Response:

--- a/src/chatgpt_web2api/breakers.py
+++ b/src/chatgpt_web2api/breakers.py
@@ -1,0 +1,173 @@
+"""Non-rate-limit circuit-breaker registry (ROADMAP Phase 4, PR1).
+
+A small, pure-logic registry that tracks four failure classes the project has
+no coherent story for today (rate-limit retry is already handled by
+``resilience.py`` — deliberately not duplicated here):
+
+  - ``auth_required``           — ChatGPT session expired (needs human login)
+  - ``composer_send_readiness`` — composer / send-readiness repeated failures
+  - ``cdp_reconnect``           — CDP websocket reconnect failures
+  - ``chrome_crash_loop``       — Chrome restart loop
+
+PR1 is infrastructure-only: the registry exists and is snapshotted into
+``/health``, but **nothing records failures or trips a breaker yet**, so every
+breaker always reports closed. This proves the plumbing with zero behavior
+change. PR2 wires the real failure signals (and the typed exceptions the
+composer/CDP paths need, since they currently raise bare ``RuntimeError``).
+
+Design notes:
+  - ``BreakerKind`` is a ``str`` enum so ``.value`` serializes straight into
+    the ``/health`` JSON without an extra mapping layer.
+  - Timestamps are ``time.monotonic()`` (not wall-clock) so cooldown math is
+    immune to system clock changes and unit tests can drive a virtual clock.
+  - Thresholds are encoded as defaults but ``record_failure`` does NOT auto-trip
+    on reaching a threshold in PR1 — that policy belongs in PR2 alongside the
+    signal wiring. PR1 only counts; ``trip()`` is the explicit, caller-driven
+    path. This keeps PR1 genuinely behavior-free.
+  - Single-process async server: no locks, matching ``APIServer``'s own
+    unsynchronized counters (``_request_count``, ``_last_error``).
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class BreakerKind(StrEnum):
+    """The four non-rate-limit failure classes. Values are the exposure names
+    used in the ``/health`` snapshot."""
+
+    AUTH_EXPIRED = "auth_required"
+    COMPOSER_SEND_READINESS = "composer_send_readiness"
+    CDP_RECONNECT = "cdp_reconnect"
+    CHROME_CRASH_LOOP = "chrome_crash_loop"
+
+
+@dataclass
+class BreakerState:
+    """Mutable per-kind state. Not part of the public snapshot shape; the
+    registry serializes a flat dict via ``snapshot()``."""
+
+    tripped: bool = False
+    reason: str | None = None
+    tripped_at: float | None = None
+    cooldown_until: float | None = None
+    recent_failures: deque[float] = field(default_factory=deque)
+
+
+# ROADMAP Phase 4 thresholds (failures within ``_fail_window_s`` to qualify).
+# PR1 records these but does not auto-trip on them — PR2 enforces them.
+_DEFAULT_THRESHOLDS: dict[BreakerKind, int] = {
+    BreakerKind.AUTH_EXPIRED: 1,  # trip immediately (human login required)
+    BreakerKind.COMPOSER_SEND_READINESS: 3,  # 3 in 2 min
+    BreakerKind.CDP_RECONNECT: 5,  # 5 in 2 min
+    BreakerKind.CHROME_CRASH_LOOP: 3,  # 3 in 5 min (separate window)
+}
+
+
+@dataclass
+class BreakerRegistry:
+    """Tracks failure history and explicit trip state for each ``BreakerKind``.
+
+    PR1 contract: ``record_failure`` counts (no auto-trip); ``trip`` opens a
+    breaker explicitly; ``is_open`` / ``snapshot`` read state. Callers in PR2
+    will decide when to trip based on the thresholds below.
+    """
+
+    _fail_window_s: float = 120.0  # 2 min rolling window
+    _max_recent: int = 50  # cap deque depth (bound memory under a storm)
+    _thresholds: dict[BreakerKind, int] = field(
+        default_factory=lambda: dict(_DEFAULT_THRESHOLDS)
+    )
+    _states: dict[BreakerKind, BreakerState] = field(
+        default_factory=lambda: {k: BreakerState() for k in BreakerKind}
+    )
+
+    # ── recording ────────────────────────────────────────────────────────
+
+    def record_failure(self, kind: BreakerKind) -> None:
+        """Append a failure timestamp and prune the rolling window. Does NOT
+        auto-trip in PR1 — threshold enforcement is a PR2 policy decision."""
+        state = self._states[kind]
+        state.recent_failures.append(time.monotonic())
+        self._prune(state)
+
+    def record_success(self, kind: BreakerKind) -> None:
+        """Record a success. In PR1 this is a no-op beyond clearing the failure
+        history for the kind — a successful operation means the failure run is
+        over. Does NOT auto-close an explicitly-tripped breaker (PR2 policy)."""
+        state = self._states[kind]
+        state.recent_failures.clear()
+
+    def trip(
+        self, kind: BreakerKind, reason: str, *, cooldown_s: float = 0.0
+    ) -> None:
+        """Explicitly open a breaker.
+
+        ``cooldown_s=0`` (the auth case) means the breaker stays open
+        indefinitely until an external recovery calls ``reset`` — matching the
+        ROADMAP's "require human browser login" intent. A positive cooldown
+        sets ``cooldown_until``; ``is_open`` returns False once monotonic time
+        passes it (half-open, eligible for re-trip).
+        """
+        now = time.monotonic()
+        state = self._states[kind]
+        state.tripped = True
+        state.reason = reason
+        state.tripped_at = now
+        # cooldown_s=0 → no expiry (stays open until reset). Positive → timed.
+        state.cooldown_until = now + cooldown_s if cooldown_s > 0 else None
+
+    def reset(self, kind: BreakerKind) -> None:
+        """Clear a breaker back to its untripped state. Used by PR2's recovery
+        paths (e.g. after a successful human re-login for auth)."""
+        self._states[kind] = BreakerState()
+
+    # ── reading ──────────────────────────────────────────────────────────
+
+    def is_open(self, kind: BreakerKind) -> bool:
+        """True if the breaker is tripped and within its cooldown.
+
+        A tripped breaker past its cooldown is half-open (returns False) — a
+        subsequent operation may re-trip it. A ``cooldown_s=0`` trip (auth) has
+        ``cooldown_until=None`` (no expiry), so it stays open until ``reset``."""
+        state = self._states[kind]
+        if not state.tripped:
+            return False
+        if state.cooldown_until is None:
+            return True
+        return time.monotonic() < state.cooldown_until
+
+    def snapshot(self) -> dict[str, dict]:
+        """JSON-serializable view of all breakers. Every kind is always present
+        (even when untouched) so the ``/health`` shape is stable for consumers
+        like ``ensure.py`` that branch on it."""
+        out: dict[str, dict] = {}
+        for kind in BreakerKind:
+            state = self._states[kind]
+            self._prune(state)
+            out[kind.value] = {
+                "open": self.is_open(kind),
+                "reason": state.reason,
+                "tripped_at": state.tripped_at,
+                "cooldown_until": state.cooldown_until,
+                "failures_in_window": len(state.recent_failures),
+            }
+        return out
+
+    # ── internal ─────────────────────────────────────────────────────────
+
+    def _prune(self, state: BreakerState) -> None:
+        """Drop failure timestamps older than the rolling window and cap the
+        deque depth as a memory guard under a sustained storm."""
+        cutoff = time.monotonic() - self._fail_window_s
+        failures = state.recent_failures
+        while failures and failures[0] < cutoff:
+            failures.popleft()
+        # Hard cap: if somehow more than _max_recent survived (clock skew or a
+        # huge burst within the window), drop the oldest.
+        while len(failures) > self._max_recent:
+            failures.popleft()

--- a/src/chatgpt_web2api/breakers.py
+++ b/src/chatgpt_web2api/breakers.py
@@ -58,13 +58,30 @@ class BreakerState:
     recent_failures: deque[float] = field(default_factory=deque)
 
 
-# ROADMAP Phase 4 thresholds (failures within ``_fail_window_s`` to qualify).
+# ROADMAP Phase 4 policies per kind. The window differs by class — notably
+# ``CHROME_CRASH_LOOP`` is 3 restarts in **5 min** (300s), not the 2 min window
+# the other three classes use — so the window must be per-kind, not global.
 # PR1 records these but does not auto-trip on them — PR2 enforces them.
-_DEFAULT_THRESHOLDS: dict[BreakerKind, int] = {
-    BreakerKind.AUTH_EXPIRED: 1,  # trip immediately (human login required)
-    BreakerKind.COMPOSER_SEND_READINESS: 3,  # 3 in 2 min
-    BreakerKind.CDP_RECONNECT: 5,  # 5 in 2 min
-    BreakerKind.CHROME_CRASH_LOOP: 3,  # 3 in 5 min (separate window)
+@dataclass(frozen=True)
+class BreakerPolicy:
+    """Per-kind failure policy: how many failures, in what window, trip a
+    breaker, and how long that breaker then cools down.
+
+    ``cooldown_s`` of ``None`` means "indefinite until external reset" and is
+    used only for the auth case; the snapshot represents it as
+    ``cooldown_until=None`` after a trip.
+    """
+
+    threshold: int
+    window_s: float
+    cooldown_s: float | None
+
+
+_DEFAULT_POLICIES: dict[BreakerKind, BreakerPolicy] = {
+    BreakerKind.AUTH_EXPIRED: BreakerPolicy(1, 120.0, None),
+    BreakerKind.COMPOSER_SEND_READINESS: BreakerPolicy(3, 120.0, 300.0),
+    BreakerKind.CDP_RECONNECT: BreakerPolicy(5, 120.0, 120.0),
+    BreakerKind.CHROME_CRASH_LOOP: BreakerPolicy(3, 300.0, 300.0),
 }
 
 
@@ -77,11 +94,10 @@ class BreakerRegistry:
     will decide when to trip based on the thresholds below.
     """
 
-    _fail_window_s: float = 120.0  # 2 min rolling window
-    _max_recent: int = 50  # cap deque depth (bound memory under a storm)
-    _thresholds: dict[BreakerKind, int] = field(
-        default_factory=lambda: dict(_DEFAULT_THRESHOLDS)
+    _policies: dict[BreakerKind, BreakerPolicy] = field(
+        default_factory=lambda: dict(_DEFAULT_POLICIES)
     )
+    _max_recent: int = 50  # cap deque depth (bound memory under a storm)
     _states: dict[BreakerKind, BreakerState] = field(
         default_factory=lambda: {k: BreakerState() for k in BreakerKind}
     )
@@ -93,7 +109,7 @@ class BreakerRegistry:
         auto-trip in PR1 — threshold enforcement is a PR2 policy decision."""
         state = self._states[kind]
         state.recent_failures.append(time.monotonic())
-        self._prune(state)
+        self._prune(kind, state)
 
     def record_success(self, kind: BreakerKind) -> None:
         """Record a success. In PR1 this is a no-op beyond clearing the failure
@@ -102,9 +118,7 @@ class BreakerRegistry:
         state = self._states[kind]
         state.recent_failures.clear()
 
-    def trip(
-        self, kind: BreakerKind, reason: str, *, cooldown_s: float = 0.0
-    ) -> None:
+    def trip(self, kind: BreakerKind, reason: str, *, cooldown_s: float = 0.0) -> None:
         """Explicitly open a breaker.
 
         ``cooldown_s=0`` (the auth case) means the breaker stays open
@@ -148,7 +162,7 @@ class BreakerRegistry:
         out: dict[str, dict] = {}
         for kind in BreakerKind:
             state = self._states[kind]
-            self._prune(state)
+            self._prune(kind, state)
             out[kind.value] = {
                 "open": self.is_open(kind),
                 "reason": state.reason,
@@ -160,10 +174,11 @@ class BreakerRegistry:
 
     # ── internal ─────────────────────────────────────────────────────────
 
-    def _prune(self, state: BreakerState) -> None:
-        """Drop failure timestamps older than the rolling window and cap the
-        deque depth as a memory guard under a sustained storm."""
-        cutoff = time.monotonic() - self._fail_window_s
+    def _prune(self, kind: BreakerKind, state: BreakerState) -> None:
+        """Drop failure timestamps older than the kind's rolling window and cap
+        the deque depth as a memory guard under a sustained storm. The window is
+        per-kind: ``CHROME_CRASH_LOOP`` uses 300s, the others 120s."""
+        cutoff = time.monotonic() - self._policies[kind].window_s
         failures = state.recent_failures
         while failures and failures[0] < cutoff:
             failures.popleft()

--- a/tests/test_breakers.py
+++ b/tests/test_breakers.py
@@ -1,0 +1,185 @@
+"""Tests for the non-rate-limit breaker registry (Phase 4, PR1).
+
+Pure unit tests — the registry is pure logic (stdlib only), so no mocking of
+subprocesses or drivers is needed. A virtual clock drives cooldown/window math
+the same way ``tests/test_ensure.py`` does.
+
+PR1 is behavior-free: these tests pin the registry's contract so PR2's signal
+wiring has a stable foundation to call into.
+"""
+
+import chatgpt_web2api.breakers as breakers_mod
+from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+
+
+def _install_clock(monkeypatch, start: float = 1000.0):
+    """Drive time.monotonic deterministically. Returns an advance(t) helper."""
+    now = [start]
+    monkeypatch.setattr(breakers_mod.time, "monotonic", lambda: now[0])
+
+    def advance(dt: float) -> None:
+        now[0] += dt
+
+    return advance
+
+
+# ── snapshot shape ──────────────────────────────────────────────────────
+
+
+def test_snapshot_all_kinds_present():
+    """Every BreakerKind is always in the snapshot, even on a fresh registry,
+    so /health consumers can rely on a stable shape."""
+    reg = BreakerRegistry()
+    snap = reg.snapshot()
+    assert set(snap.keys()) == {k.value for k in BreakerKind}
+    # exactly the four expected exposure names
+    assert set(snap.keys()) == {
+        "auth_required",
+        "composer_send_readiness",
+        "cdp_reconnect",
+        "chrome_crash_loop",
+    }
+
+
+def test_snapshot_closed_initially():
+    """Fresh registry: nothing tripped, nulls, zero failures."""
+    reg = BreakerRegistry()
+    snap = reg.snapshot()
+    for kind in BreakerKind:
+        entry = snap[kind.value]
+        assert entry["open"] is False
+        assert entry["reason"] is None
+        assert entry["tripped_at"] is None
+        assert entry["cooldown_until"] is None
+        assert entry["failures_in_window"] == 0
+
+
+# ── failure counting & pruning ─────────────────────────────────────────
+
+
+def test_record_failure_counts_in_window():
+    """N failures within the window are all counted."""
+    reg = BreakerRegistry()
+    for _ in range(3):
+        reg.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+    snap = reg.snapshot()["composer_send_readiness"]
+    assert snap["failures_in_window"] == 3
+
+
+def test_record_failure_prunes_old_entries(monkeypatch):
+    """Failures older than the rolling window are dropped on the next record."""
+    advance = _install_clock(monkeypatch)
+    reg = BreakerRegistry(_fail_window_s=120.0)
+
+    reg.record_failure(BreakerKind.CDP_RECONNECT)  # at t=1000
+    advance(200.0)  # t=1200 — first failure is now outside the 120s window
+    reg.record_failure(BreakerKind.CDP_RECONNECT)  # prunes the old one
+
+    snap = reg.snapshot()["cdp_reconnect"]
+    assert snap["failures_in_window"] == 1  # only the recent one survives
+
+
+def test_record_failure_does_not_auto_trip():
+    """PR1 contract: record_failure only counts — reaching a threshold does NOT
+    open the breaker. Auto-trip is a PR2 policy decision."""
+    reg = BreakerRegistry()
+    # CDP threshold is 5; record 10 — still must not trip in PR1.
+    for _ in range(10):
+        reg.record_failure(BreakerKind.CDP_RECONNECT)
+    assert reg.is_open(BreakerKind.CDP_RECONNECT) is False
+
+
+def test_record_success_clears_failure_history():
+    """A success clears the failure run for that kind (but does not close an
+    explicitly-tripped breaker — that's reset's job)."""
+    reg = BreakerRegistry()
+    for _ in range(4):
+        reg.record_failure(BreakerKind.CHROME_CRASH_LOOP)
+    assert reg.snapshot()["chrome_crash_loop"]["failures_in_window"] == 4
+
+    reg.record_success(BreakerKind.CHROME_CRASH_LOOP)
+    assert reg.snapshot()["chrome_crash_loop"]["failures_in_window"] == 0
+
+
+# ── trip / cooldown / reset ────────────────────────────────────────────
+
+
+def test_trip_with_cooldown_open_then_half_open(monkeypatch):
+    """A timed trip is open immediately and becomes half-open (closed) once the
+    cooldown elapses."""
+    advance = _install_clock(monkeypatch)
+    reg = BreakerRegistry()
+
+    reg.trip(BreakerKind.CDP_RECONNECT, "ws closed", cooldown_s=60.0)
+    assert reg.is_open(BreakerKind.CDP_RECONNECT) is True
+
+    advance(59.0)  # still within cooldown
+    assert reg.is_open(BreakerKind.CDP_RECONNECT) is True
+
+    advance(2.0)  # now at t=1061, past the 60s cooldown
+    assert reg.is_open(BreakerKind.CDP_RECONNECT) is False
+
+
+def test_trip_immediate_auth_stays_open(monkeypatch):
+    """Auth trips with cooldown_s=0 — it must stay open indefinitely until an
+    external recovery (reset) clears it. This is the ROADMAP's 'require human
+    browser login' intent: no automatic half-open."""
+    advance = _install_clock(monkeypatch)
+    reg = BreakerRegistry()
+
+    reg.trip(BreakerKind.AUTH_EXPIRED, "401", cooldown_s=0)
+    assert reg.is_open(BreakerKind.AUTH_EXPIRED) is True
+    assert reg.snapshot()["auth_required"]["cooldown_until"] is None
+
+    advance(99999.0)  # arbitrarily far into the future
+    assert reg.is_open(BreakerKind.AUTH_EXPIRED) is True  # still open
+
+
+def test_trip_records_reason_and_tripped_at(monkeypatch):
+    """The trip reason and timestamp are surfaced in the snapshot."""
+    _install_clock(monkeypatch, start=500.0)
+    reg = BreakerRegistry()
+
+    reg.trip(BreakerKind.COMPOSER_SEND_READINESS, "no composer", cooldown_s=30.0)
+    snap = reg.snapshot()["composer_send_readiness"]
+    assert snap["reason"] == "no composer"
+    assert snap["tripped_at"] == 500.0
+    assert snap["cooldown_until"] == 530.0
+    assert snap["open"] is True
+
+
+def test_reset_clears_a_tripped_breaker():
+    """reset() returns a breaker to its untouched state."""
+    reg = BreakerRegistry()
+    reg.trip(BreakerKind.AUTH_EXPIRED, "expired", cooldown_s=0)
+    assert reg.is_open(BreakerKind.AUTH_EXPIRED) is True
+
+    reg.reset(BreakerKind.AUTH_EXPIRED)
+    snap = reg.snapshot()["auth_required"]
+    assert snap["open"] is False
+    assert snap["reason"] is None
+    assert snap["tripped_at"] is None
+
+
+def test_is_open_false_for_never_tripped():
+    """An untouched breaker is never open."""
+    reg = BreakerRegistry()
+    for kind in BreakerKind:
+        assert reg.is_open(kind) is False
+
+
+# ── isolation between kinds ────────────────────────────────────────────
+
+
+def test_kinds_are_independent():
+    """Tripping one breaker does not affect the others."""
+    reg = BreakerRegistry()
+    reg.trip(BreakerKind.AUTH_EXPIRED, "401", cooldown_s=0)
+
+    assert reg.is_open(BreakerKind.AUTH_EXPIRED) is True
+    for kind in (
+        BreakerKind.COMPOSER_SEND_READINESS,
+        BreakerKind.CDP_RECONNECT,
+        BreakerKind.CHROME_CRASH_LOOP,
+    ):
+        assert reg.is_open(kind) is False

--- a/tests/test_breakers.py
+++ b/tests/test_breakers.py
@@ -69,7 +69,7 @@ def test_record_failure_counts_in_window():
 def test_record_failure_prunes_old_entries(monkeypatch):
     """Failures older than the rolling window are dropped on the next record."""
     advance = _install_clock(monkeypatch)
-    reg = BreakerRegistry(_fail_window_s=120.0)
+    reg = BreakerRegistry()
 
     reg.record_failure(BreakerKind.CDP_RECONNECT)  # at t=1000
     advance(200.0)  # t=1200 — first failure is now outside the 120s window
@@ -77,6 +77,37 @@ def test_record_failure_prunes_old_entries(monkeypatch):
 
     snap = reg.snapshot()["cdp_reconnect"]
     assert snap["failures_in_window"] == 1  # only the recent one survives
+
+
+def test_chrome_crash_loop_uses_300s_window(monkeypatch):
+    """CHROME_CRASH_LOOP is 3 restarts in **5 min** (ROADMAP Phase 4), not the
+    2 min window the other three classes use. The window is per-kind, so:
+
+      - failures at t=0, t=150, t=250 all count (3) for chrome_crash_loop
+        (300s window), because t=250 − t=0 = 250s ≤ 300s;
+      - the same spacing must NOT count as 3 for a 120s-window breaker
+        (CDP_RECONNECT here), because t=250 − t=0 = 250s > 120s.
+
+    This pins the policy mismatch the single global window used to hide."""
+    advance = _install_clock(monkeypatch)
+    reg = BreakerRegistry()
+
+    # t=1000
+    reg.record_failure(BreakerKind.CHROME_CRASH_LOOP)
+    reg.record_failure(BreakerKind.CDP_RECONNECT)
+    advance(150.0)  # t=1150 — +150s from the first failure
+    reg.record_failure(BreakerKind.CHROME_CRASH_LOOP)
+    reg.record_failure(BreakerKind.CDP_RECONNECT)
+    advance(100.0)  # t=1250 — +250s total from the first failure
+    reg.record_failure(BreakerKind.CHROME_CRASH_LOOP)
+    reg.record_failure(BreakerKind.CDP_RECONNECT)
+
+    snap = reg.snapshot()
+    # 300s window: all three (0s, 150s, 250s) survive → 3
+    assert snap["chrome_crash_loop"]["failures_in_window"] == 3
+    # 120s window: only the two at +150s and +250s survive (the t=1000 one is
+    # 250s old by snapshot time) → 2
+    assert snap["cdp_reconnect"]["failures_in_window"] == 2
 
 
 def test_record_failure_does_not_auto_trip():

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -115,3 +115,23 @@ async def test_health_exposes_last_error():
     server._last_error = "RateLimitError: too many requests"
     body = await _health_body(server, chrome_running=True)
     assert body["last_error"] == "RateLimitError: too many requests"
+
+
+@pytest.mark.asyncio
+async def test_health_includes_breakers_snapshot():
+    """Phase 4 PR1: /health carries a 'breakers' snapshot. On a fresh server
+    every breaker is closed — PR1 records no failure signals, so this is the
+    only state a real deployment will see until PR2 wires trips."""
+    from chatgpt_web2api.breakers import BreakerKind
+
+    server = _make_server(driver_connected=True)
+    body = await _health_body(server, chrome_running=True)
+
+    assert "breakers" in body
+    breakers = body["breakers"]
+    # All four kinds present (stable shape for consumers like ensure.py)
+    assert set(breakers.keys()) == {k.value for k in BreakerKind}
+    # PR1: nothing is wired, so all are closed
+    for entry in breakers.values():
+        assert entry["open"] is False
+        assert entry["failures_in_window"] == 0


### PR DESCRIPTION
## Summary

Phase 4, PR1 of 2. Ships a pure-logic circuit-breaker registry for the four non-rate-limit failure classes and exposes it through `/health`. **No behavior change:** nothing records failures or trips a breaker yet, so `/health` always reports all breakers closed. This proves the plumbing risk-free; PR2 wires the real signals.

Rate-limit retry/backoff is already handled by `resilience.py` and is deliberately **not** duplicated here.

## Why split into two PRs

Wiring the failure signals requires new typed exceptions (`SendReadinessError`, `CDPReconnectError`) — the composer and CDP-reconnect paths currently raise bare `RuntimeError`, which a type-keyed breaker can't distinguish. Mixing that with infrastructure + REST/MCP fail-fast + status-policy + config would make review unwieldy. PR1 establishes the stable registry contract; PR2 calls into it.

## Changes

### `src/chatgpt_web2api/breakers.py` (new)
- `BreakerKind` (StrEnum): `auth_required`, `composer_send_readiness`, `cdp_reconnect`, `chrome_crash_loop` — values serialize straight into JSON.
- `BreakerRegistry`: `record_failure` / `record_success` / `trip` / `is_open` / `snapshot` / `reset`.
- `record_failure` only counts + prunes a rolling window — **does not auto-trip** (threshold enforcement is a PR2 policy decision).
- `trip(kind, reason, cooldown_s=0)` is the explicit caller-driven path. `cooldown_s=0` (the auth case) → `cooldown_until=None` → stays open until `reset` (matches ROADMAP "require human browser login").
- Timestamps are `time.monotonic()` (immune to clock skew; virtual-clock testable).

### `src/chatgpt_web2api/api_server.py`
- `__init__`: `self._breakers = BreakerRegistry()`.
- `/health` response gains `"breakers": self._breakers.snapshot()`.
- **No change to status logic** — an open breaker does not alter `status` yet (PR2 policy decision).

### `docs/ROADMAP.md`
- Phase 4 sequenced into PR1 (this) + PR2 (signals + fail-fast + status policy + config). No change to the four classes or thresholds.

## Out of scope (PR2)
- Wiring `record_failure`/`trip` at detection sites (`AuthExpiredError`, composer, CDP reconnect, Chrome restart)
- Typed exceptions for composer/CDP (needed because they raise bare `RuntimeError` today)
- REST fail-fast (`503 circuit_open`) + MCP `(circuit_open)` result
- Forcing `/health` `status` to `degraded` when a breaker is open
- Config tunables (`W2A_BREAKER_*`)

## Verification
```
ruff check src tests              ✅ All checks passed
pytest tests/ -q                  ✅ 368 passed (was 355; +13)
```