### PR TITLE
feat(breakers): wire failure signals + fail-fast (Phase 4 PR2)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -278,18 +278,31 @@ change first, then wire the real failure signals in a second PR.
   `/health` always reports all breakers closed. This proves the plumbing
   risk-free.
 - **PR2 — wire failure signals + fail-fast.** Adds the typed exceptions the
-  composer/CDP paths need (they currently raise bare `RuntimeError`, so a
-  type-keyed breaker can't distinguish them), calls `record_failure`/`trip` at
-  the detection sites (`AuthExpiredError` at `cdp_driver.py:2046`/`:2207`,
-  composer at `_ensure_send_ready`/`type_message`/`click_send`, CDP reconnect at
-  `reconnect()`, Chrome at `chrome.py:restart()`), enforces the thresholds
+  composer/CDP paths need (`SendReadinessError`, `CDPReconnectError` — they
+  previously raised bare `RuntimeError`, so a type-keyed breaker couldn't
+  distinguish them), calls `record_failure`/`trip` at the detection sites
+  (`AuthExpiredError` at `cdp_driver.py:2046`/`:2207` uses explicit `trip()`;
+  composer at `_ensure_send_ready`/`type_message`/`click_send` and CDP reconnect
+  at `reconnect()` use `record_failure` with auto-trip; Chrome at
+  `chrome.py:restart()` records `CHROME_CRASH_LOOP`), enforces the thresholds
   above, adds REST fail-fast (`_error_response` 503 `circuit_open`) + MCP
-  `(circuit_open)` result, decides whether an open breaker forces `/health`
-  `status` to `degraded`, and wires config tunables (`W2A_BREAKER_*`).
+  `(circuit_open, kind=...)` result, and wires half-open recovery
+  (`record_success` after a confirmed send / successful reconnect; auth stays
+  indefinite until explicit `reset()`). The registry is per-process
+  (driver-owned via DI): REST shares one across Chrome + driver + server; MCP
+  has its own for its driver. `CircuitOpenError` lives in `breakers.py` (not the
+  driver) since it is a control-plane preflight signal, not a driver failure.
+- **PR3 — `/health` status policy + config tunables (deferred).** PR2 ships the
+  `breakers` snapshot but does NOT change the `/health` status string (an open
+  breaker does not yet flip `healthy` → `degraded`) and does NOT add config
+  tunables (`W2A_BREAKER_*`). Both are deferred until the PR2 behavior is proven
+  in operation; the policy constants stay in `breakers.py` until real-world
+  tuning data shows the defaults need adjustment.
 
 ```
 PR1  →  registry + snapshot (no behavior change)
-PR2  →  signals + typed exceptions + fail-fast + status policy + config
+PR2  →  signals + typed exceptions + fail-fast + half-open recovery
+PR3  →  status policy (degraded on open breaker) + config tunables
 ```
 
 ---

--- a/src/chatgpt_web2api/api_server.py
+++ b/src/chatgpt_web2api/api_server.py
@@ -17,7 +17,7 @@ import uuid
 
 from aiohttp import web
 
-from .breakers import BreakerRegistry, CircuitOpenError
+from .breakers import BreakerKind, BreakerRegistry, CircuitOpenError
 from .cdp_driver import (
     AuthExpiredError,
     CDPDriver,
@@ -309,11 +309,17 @@ class APIServer:
             # the except below → _error_response + _last_error, consistent with
             # every other failure path. Checked before acquiring the lock so a
             # process that already knows it will refuse doesn't block on the
-            # browser lock.
-            if open_kind := self._breakers.first_open():
-                raise CircuitOpenError(open_kind)
+            # browser lock. If AUTH_EXPIRED is open, probes auth recovery first
+            # (the user may have logged back in).
+            await self._check_circuit_or_recover()
 
             async with CrossProcessLock(cdp_port=self._cdp_port):
+                # Second circuit-open check, now that we hold the lock. A
+                # concurrent request may have tripped a breaker while we were
+                # waiting. Without this, we'd drive Chrome despite the process
+                # already knowing the circuit is open.
+                await self._check_circuit_or_recover()
+
                 # Select model if specified (non-fatal on failure)
                 if model_slug and model_slug != "auto":
                     selected = await self._driver.select_model(model_slug)
@@ -354,6 +360,28 @@ class APIServer:
             logger.error("Chat error: %s", e, exc_info=True)
             self._last_error = f"{type(e).__name__}: {e}"
             return self._error_response(e)
+
+    async def _check_circuit_or_recover(self) -> None:
+        """Fail-fast if a breaker is open, with one exception: if AUTH_EXPIRED
+        is the open breaker, probe auth recovery first (the user may have logged
+        back in via the browser since the trip). If recovery succeeds the breaker
+        is reset and the request proceeds; if it fails, or if a non-auth breaker
+        is open, raise CircuitOpenError.
+
+        Called at each fail-fast checkpoint (pre-lock, post-lock, streaming
+        pre-prepare). Does NOT drive a chat send — recovery is a lightweight
+        ``/api/auth/session`` token fetch via ``driver.recover_auth()``.
+        """
+        open_kind = self._breakers.first_open()
+        if open_kind is None:
+            return
+        if open_kind is BreakerKind.AUTH_EXPIRED:
+            if await self._driver.recover_auth():
+                # Auth restored — re-check in case another breaker is also open.
+                open_kind = self._breakers.first_open()
+                if open_kind is None:
+                    return
+        raise CircuitOpenError(open_kind)
 
     # ── Error mapping ─────────────────────────────────────────
 
@@ -528,13 +556,11 @@ class APIServer:
             # Persistent at pre-flight: still pre-prepare, so send a clean 429.
             raise
 
-        # Circuit-open fail-fast (Phase 4 PR2): second check, after navigation
-        # and rate-limit preflight but still before prepare() commits HTTP 200.
-        # A breaker may have opened during model selection/navigation since the
-        # pre-lock check in _handle_chat. After prepare() no status change is
-        # possible, so this must stay pre-prepare.
-        if open_kind := self._breakers.first_open():
-            raise CircuitOpenError(open_kind)
+        # Circuit-open fail-fast (Phase 4 PR2): final check, after rate-limit
+        # preflight but still before prepare() commits HTTP 200. A breaker may
+        # have opened during model selection/navigation. After prepare() no
+        # status change is possible, so this must stay pre-prepare.
+        await self._check_circuit_or_recover()
 
         resp = web.StreamResponse()
         resp.content_type = "text/event-stream"

--- a/src/chatgpt_web2api/api_server.py
+++ b/src/chatgpt_web2api/api_server.py
@@ -52,7 +52,9 @@ MODEL_MAP = {
 class APIServer:
     """OpenAI-compatible API backed by CDP automation."""
 
-    def __init__(self, config: Config, driver: CDPDriver) -> None:
+    def __init__(
+        self, config: Config, driver: CDPDriver, breakers: BreakerRegistry | None = None
+    ) -> None:
         self._config = config
         self._driver = driver
         self._cdp_port = config.chrome.cdp_port
@@ -66,10 +68,10 @@ class APIServer:
         self._started_at = time.time()
         self._last_error: str | None = None
         self._last_successful_send_at: float | None = None
-        # Non-rate-limit breaker registry (Phase 4, PR1). Snapshotted into
-        # /health below; no failure signals are recorded yet, so it always
-        # reports all breakers closed. PR2 wires the real trip signals.
-        self._breakers = BreakerRegistry()
+        # Non-rate-limit breaker registry (Phase 4). Injected by Service so the
+        # REST process shares one registry across Chrome + driver + server.
+        # Default-constructed for back-compat with tests that don't pass one.
+        self._breakers = breakers or BreakerRegistry()
         # Track last conversation for multi-turn continuity
         self._last_conv_id: str | None = None
         self._last_project_id: str | None = None
@@ -131,6 +133,7 @@ class APIServer:
         chrome_running = False
         try:
             loop = asyncio.get_event_loop()
+
             def _probe():
                 try:
                     with urllib.request.urlopen(
@@ -139,6 +142,7 @@ class APIServer:
                         return r.status == 200
                 except Exception:
                     return False
+
             chrome_running = await loop.run_in_executor(None, _probe)
         except Exception:
             chrome_running = False
@@ -154,17 +158,19 @@ class APIServer:
         else:
             status = "healthy"
 
-        return web.json_response({
-            "status": status,
-            "chrome_running": chrome_running,
-            "cdp_connected": driver_connected,
-            "driver_connected": driver_connected,
-            "requests_served": self._request_count,
-            "started_at": self._started_at,
-            "last_successful_send_at": self._last_successful_send_at,
-            "last_error": self._last_error,
-            "breakers": self._breakers.snapshot(),
-        })
+        return web.json_response(
+            {
+                "status": status,
+                "chrome_running": chrome_running,
+                "cdp_connected": driver_connected,
+                "driver_connected": driver_connected,
+                "requests_served": self._request_count,
+                "started_at": self._started_at,
+                "last_successful_send_at": self._last_successful_send_at,
+                "last_error": self._last_error,
+                "breakers": self._breakers.snapshot(),
+            }
+        )
 
     async def _handle_models(self, request: web.Request) -> web.Response:
         if err := self._check_auth(request):
@@ -177,16 +183,25 @@ class APIServer:
         models = []
         for m in raw:
             slug = m.get("slug", "")
-            models.append({
-                "id": slug,
-                "object": "model",
-                "created": 1700000000,
-                "owned_by": "chatgpt-web",
-            })
+            models.append(
+                {
+                    "id": slug,
+                    "object": "model",
+                    "created": 1700000000,
+                    "owned_by": "chatgpt-web",
+                }
+            )
 
         if not models:
             for slug in ["auto", "gpt-5-5", "gpt-5-mini"]:
-                models.append({"id": slug, "object": "model", "created": 1700000000, "owned_by": "chatgpt-web"})
+                models.append(
+                    {
+                        "id": slug,
+                        "object": "model",
+                        "created": 1700000000,
+                        "owned_by": "chatgpt-web",
+                    }
+                )
 
         return web.json_response({"object": "list", "data": models})
 
@@ -243,8 +258,7 @@ class APIServer:
             content = msg.get("content", "")
             if isinstance(content, list):
                 content = "\n".join(
-                    p.get("text", "") if isinstance(p, dict) else str(p)
-                    for p in content
+                    p.get("text", "") if isinstance(p, dict) else str(p) for p in content
                 )
             else:
                 content = str(content)
@@ -259,7 +273,7 @@ class APIServer:
 
         # Trim to last N turns if too many messages
         if len(conversation_lines) > MAX_HISTORY_TURNS * 2:
-            conversation_lines = conversation_lines[-(MAX_HISTORY_TURNS * 2):]
+            conversation_lines = conversation_lines[-(MAX_HISTORY_TURNS * 2) :]
 
         # Verify at least one user message exists
         if user_msg_count == 0:
@@ -279,7 +293,13 @@ class APIServer:
 
         logger.info(
             "Request #%d: model=%s->%s conv=%s project=%s stream=%s msg=%.60s",
-            self._request_count, model, model_slug, conversation_id, project_id, stream, full_text,
+            self._request_count,
+            model,
+            model_slug,
+            conversation_id,
+            project_id,
+            stream,
+            full_text,
         )
 
         # Serialize — cross-process lock so MCP + REST don't corrupt each other
@@ -298,10 +318,12 @@ class APIServer:
                 if conversation_id:
                     # Explicit conversation_id from client — navigate to it
                     await self._driver.navigate_conversation(conversation_id)
-                elif (self._last_conv_id
-                      and self._driver._current_conv_id == self._last_conv_id
-                      and project_id == self._last_project_id
-                      and not system_parts):
+                elif (
+                    self._last_conv_id
+                    and self._driver._current_conv_id == self._last_conv_id
+                    and project_id == self._last_project_id
+                    and not system_parts
+                ):
                     # Same session, same project, no system prompt override — continue.
                     # Reconcile against the live tab before sending: another process
                     # sharing the Chrome tab may have navigated it since our last turn,
@@ -422,19 +444,23 @@ class APIServer:
         self._last_conv_id = conv_id
         self._last_successful_send_at = time.time()
 
-        return web.json_response({
-            "id": f"chatcmpl-{uuid.uuid4().hex[:29]}",
-            "object": "chat.completion",
-            "created": int(time.time()),
-            "model": model,
-            "conversation_id": conv_id,
-            "choices": [{
-                "index": 0,
-                "message": {"role": "assistant", "content": full_text},
-                "finish_reason": "stop",
-            }],
-            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
-        })
+        return web.json_response(
+            {
+                "id": f"chatcmpl-{uuid.uuid4().hex[:29]}",
+                "object": "chat.completion",
+                "created": int(time.time()),
+                "model": model,
+                "conversation_id": conv_id,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": full_text},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            }
+        )
 
     async def _stream_response(
         self, request: web.Request, model: str, text: str, timeout: float
@@ -489,59 +515,143 @@ class APIServer:
         created = int(time.time())
 
         # Role chunk
-        await self._send_sse(resp, {
-            "id": cid, "object": "chat.completion.chunk", "created": created, "model": model,
-            "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
-        })
+        await self._send_sse(
+            resp,
+            {
+                "id": cid,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": ""},
+                        "finish_reason": None,
+                    }
+                ],
+            },
+        )
 
         try:
             async for chunk in self._driver.send_and_stream(text, timeout=timeout):
                 if chunk.delta:
-                    await self._send_sse(resp, {
-                        "id": cid, "object": "chat.completion.chunk", "created": created, "model": model,
-                        "choices": [{"index": 0, "delta": {"content": chunk.delta}, "finish_reason": None}],
-                    })
+                    await self._send_sse(
+                        resp,
+                        {
+                            "id": cid,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {"content": chunk.delta},
+                                    "finish_reason": None,
+                                }
+                            ],
+                        },
+                    )
                 if chunk.finish_reason:
                     conv_id = self._driver._current_conv_id or ""
                     self._last_conv_id = conv_id
                     if chunk.finish_reason == "stop":
                         self._last_successful_send_at = time.time()
-                    await self._send_sse(resp, {
-                        "id": cid, "object": "chat.completion.chunk", "created": created, "model": model,
-                        "conversation_id": conv_id,
-                        "choices": [{"index": 0, "delta": {}, "finish_reason": chunk.finish_reason}],
-                    })
+                    await self._send_sse(
+                        resp,
+                        {
+                            "id": cid,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "conversation_id": conv_id,
+                            "choices": [
+                                {"index": 0, "delta": {}, "finish_reason": chunk.finish_reason}
+                            ],
+                        },
+                    )
         except RateLimitError as e:
             # Mid-stream throttle (rare after pre-flight). Status is locked at
             # 200, so we can't upgrade to 429; surface as an inline error chunk
             # with a recognizable marker so clients can detect it.
             logger.warning("Mid-stream rate limit: %s", e)
-            await self._send_sse(resp, {
-                "id": cid, "object": "chat.completion.chunk", "created": created, "model": model,
-                "choices": [{"index": 0, "delta": {"content": f"\n\n[Error: rate_limit_exceeded — retry in {e.retry_after}s]"}, "finish_reason": "error"}],
-            })
+            await self._send_sse(
+                resp,
+                {
+                    "id": cid,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "content": f"\n\n[Error: rate_limit_exceeded — retry in {e.retry_after}s]"
+                            },
+                            "finish_reason": "error",
+                        }
+                    ],
+                },
+            )
         except AuthExpiredError:
             # Session expired mid-stream (status locked at 200). Surface with a
             # recognizable marker so clients can prompt re-login.
             logger.warning("Mid-stream auth expiry")
-            await self._send_sse(resp, {
-                "id": cid, "object": "chat.completion.chunk", "created": created, "model": model,
-                "choices": [{"index": 0, "delta": {"content": "\n\n[Error: auth_expired — re-login required]"}, "finish_reason": "error"}],
-            })
+            await self._send_sse(
+                resp,
+                {
+                    "id": cid,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": "\n\n[Error: auth_expired — re-login required]"},
+                            "finish_reason": "error",
+                        }
+                    ],
+                },
+            )
         except GenerationStuckError as e:
             # Generation stalled mid-stream (status locked at 200). Surface the
             # phase + duration so the client can decide whether to retry.
             logger.warning("Mid-stream generation stuck: %s", e)
-            await self._send_sse(resp, {
-                "id": cid, "object": "chat.completion.chunk", "created": created, "model": model,
-                "choices": [{"index": 0, "delta": {"content": f"\n\n[Error: generation_stuck — stalled in {e.phase} for {e.stalled_for_s:.0f}s]"}, "finish_reason": "error"}],
-            })
+            await self._send_sse(
+                resp,
+                {
+                    "id": cid,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "content": f"\n\n[Error: generation_stuck — stalled in {e.phase} for {e.stalled_for_s:.0f}s]"
+                            },
+                            "finish_reason": "error",
+                        }
+                    ],
+                },
+            )
         except Exception as e:
             logger.error("Stream error: %s", e)
-            await self._send_sse(resp, {
-                "id": cid, "object": "chat.completion.chunk", "created": created, "model": model,
-                "choices": [{"index": 0, "delta": {"content": f"\n\n[Error: {e}]"}, "finish_reason": "error"}],
-            })
+            await self._send_sse(
+                resp,
+                {
+                    "id": cid,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": f"\n\n[Error: {e}]"},
+                            "finish_reason": "error",
+                        }
+                    ],
+                },
+            )
 
         await resp.write(b"data: [DONE]\n\n")
         await resp.write_eof()

--- a/src/chatgpt_web2api/api_server.py
+++ b/src/chatgpt_web2api/api_server.py
@@ -17,7 +17,7 @@ import uuid
 
 from aiohttp import web
 
-from .breakers import BreakerRegistry
+from .breakers import BreakerRegistry, CircuitOpenError
 from .cdp_driver import (
     AuthExpiredError,
     CDPDriver,
@@ -303,8 +303,17 @@ class APIServer:
         )
 
         # Serialize — cross-process lock so MCP + REST don't corrupt each other
-        async with CrossProcessLock(cdp_port=self._cdp_port):
-            try:
+        try:
+            # Circuit-open fail-fast (Phase 4 PR2): refuse before touching Chrome
+            # if a breaker is open. Placed inside the try so it flows through
+            # the except below → _error_response + _last_error, consistent with
+            # every other failure path. Checked before acquiring the lock so a
+            # process that already knows it will refuse doesn't block on the
+            # browser lock.
+            if open_kind := self._breakers.first_open():
+                raise CircuitOpenError(open_kind)
+
+            async with CrossProcessLock(cdp_port=self._cdp_port):
                 # Select model if specified (non-fatal on failure)
                 if model_slug and model_slug != "auto":
                     selected = await self._driver.select_model(model_slug)
@@ -341,10 +350,10 @@ class APIServer:
                 else:
                     return await self._full_response(request, model_slug, full_text, timeout)
 
-            except Exception as e:
-                logger.error("Chat error: %s", e, exc_info=True)
-                self._last_error = f"{type(e).__name__}: {e}"
-                return self._error_response(e)
+        except Exception as e:
+            logger.error("Chat error: %s", e, exc_info=True)
+            self._last_error = f"{type(e).__name__}: {e}"
+            return self._error_response(e)
 
     # ── Error mapping ─────────────────────────────────────────
 
@@ -410,6 +419,20 @@ class APIServer:
                         "type": "server_error",
                         "param": None,
                         "code": "lock_timeout",
+                    }
+                },
+                status=503,
+            )
+        if isinstance(exc, CircuitOpenError):
+            return web.json_response(
+                {
+                    "error": {
+                        "message": (
+                            f"Circuit open for {exc.kind.value} — cooling down. Retry later."
+                        ),
+                        "type": "server_error",
+                        "param": None,
+                        "code": "circuit_open",
                     }
                 },
                 status=503,
@@ -504,6 +527,14 @@ class APIServer:
         except RateLimitError:
             # Persistent at pre-flight: still pre-prepare, so send a clean 429.
             raise
+
+        # Circuit-open fail-fast (Phase 4 PR2): second check, after navigation
+        # and rate-limit preflight but still before prepare() commits HTTP 200.
+        # A breaker may have opened during model selection/navigation since the
+        # pre-lock check in _handle_chat. After prepare() no status change is
+        # possible, so this must stay pre-prepare.
+        if open_kind := self._breakers.first_open():
+            raise CircuitOpenError(open_kind)
 
         resp = web.StreamResponse()
         resp.content_type = "text/event-stream"

--- a/src/chatgpt_web2api/breakers.py
+++ b/src/chatgpt_web2api/breakers.py
@@ -9,23 +9,30 @@ no coherent story for today (rate-limit retry is already handled by
   - ``cdp_reconnect``           — CDP websocket reconnect failures
   - ``chrome_crash_loop``       — Chrome restart loop
 
-PR1 is infrastructure-only: the registry exists and is snapshotted into
-``/health``, but **nothing records failures or trips a breaker yet**, so every
-breaker always reports closed. This proves the plumbing with zero behavior
-change. PR2 wires the real failure signals (and the typed exceptions the
-composer/CDP paths need, since they currently raise bare ``RuntimeError``).
+PR1 landed the registry and its ``/health`` snapshot. PR2 (this module's
+current contract) makes it live: ``record_failure`` auto-trips a breaker once
+its per-kind threshold is met, ``record_success`` implements half-open
+recovery (a successful trial after cooldown closes the breaker), and
+``first_open`` drives the REST/MCP fail-fast surface via ``CircuitOpenError``.
+
+The signal wiring lives at the call sites: the driver records composer/CDP
+failures with typed exceptions (``SendReadinessError`` / ``CDPReconnectError``)
+and trips auth explicitly (``AuthExpiredError`` → ``trip(AUTH_EXPIRED)``);
+``ChromeProcess`` records crash-loop restarts. The registry itself stays
+pure logic — no I/O, no locks.
 
 Design notes:
   - ``BreakerKind`` is a ``str`` enum so ``.value`` serializes straight into
     the ``/health`` JSON without an extra mapping layer.
   - Timestamps are ``time.monotonic()`` (not wall-clock) so cooldown math is
     immune to system clock changes and unit tests can drive a virtual clock.
-  - Thresholds are encoded as defaults but ``record_failure`` does NOT auto-trip
-    on reaching a threshold in PR1 — that policy belongs in PR2 alongside the
-    signal wiring. PR1 only counts; ``trip()`` is the explicit, caller-driven
-    path. This keeps PR1 genuinely behavior-free.
+  - Auto-trip fires from explicit ``BreakerKind`` calls only — never from a
+    catch-all ``RuntimeError``. The auth path uses explicit ``trip()`` rather
+    than ``record_failure()``, because auth is a single-shot "needs human
+    login" condition, not a rolling-window failure count.
   - Single-process async server: no locks, matching ``APIServer``'s own
-    unsynchronized counters (``_request_count``, ``_last_error``).
+    unsynchronized counters (``_request_count``, ``_last_error``). Each process
+    (REST, MCP) owns its own registry; there is no cross-process propagation.
 """
 
 from __future__ import annotations
@@ -46,6 +53,21 @@ class BreakerKind(StrEnum):
     CHROME_CRASH_LOOP = "chrome_crash_loop"
 
 
+class CircuitOpenError(RuntimeError):
+    """Raised by the REST/MCP fail-fast preflight when a breaker is open.
+
+    Carries the offending ``BreakerKind`` so the error-response layer can name
+    it (using ``kind.value``) without re-interrogating the registry. Lives in
+    this module — not ``cdp_driver.py`` — because it is a control-plane
+    fail-fast signal raised *before* the driver is touched, not a driver
+    failure.
+    """
+
+    def __init__(self, kind: BreakerKind) -> None:
+        self.kind = kind
+        super().__init__(f"Circuit open for {kind.value}")
+
+
 @dataclass
 class BreakerState:
     """Mutable per-kind state. Not part of the public snapshot shape; the
@@ -61,7 +83,9 @@ class BreakerState:
 # ROADMAP Phase 4 policies per kind. The window differs by class — notably
 # ``CHROME_CRASH_LOOP`` is 3 restarts in **5 min** (300s), not the 2 min window
 # the other three classes use — so the window must be per-kind, not global.
-# PR1 records these but does not auto-trip on them — PR2 enforces them.
+# ``record_failure`` auto-trips once ``threshold`` failures land within
+# ``window_s``; ``cooldown_s`` then governs the half-open recovery window
+# (``None`` = indefinite, used only for auth, which trip()s explicitly).
 @dataclass(frozen=True)
 class BreakerPolicy:
     """Per-kind failure policy: how many failures, in what window, trip a
@@ -87,11 +111,13 @@ _DEFAULT_POLICIES: dict[BreakerKind, BreakerPolicy] = {
 
 @dataclass
 class BreakerRegistry:
-    """Tracks failure history and explicit trip state for each ``BreakerKind``.
+    """Tracks failure history and trip state for each ``BreakerKind``.
 
-    PR1 contract: ``record_failure`` counts (no auto-trip); ``trip`` opens a
-    breaker explicitly; ``is_open`` / ``snapshot`` read state. Callers in PR2
-    will decide when to trip based on the thresholds below.
+    ``record_failure`` counts within the per-kind rolling window and auto-trips
+    once the threshold is met. ``record_success`` clears failures and, if the
+    breaker is past its cooldown (half-open), closes it — so a successful
+    trial recovers the breaker. ``trip`` opens a breaker explicitly (used by
+    the auth path). ``first_open`` drives the REST/MCP fail-fast preflight.
     """
 
     _policies: dict[BreakerKind, BreakerPolicy] = field(
@@ -105,18 +131,27 @@ class BreakerRegistry:
     # ── recording ────────────────────────────────────────────────────────
 
     def record_failure(self, kind: BreakerKind) -> None:
-        """Append a failure timestamp and prune the rolling window. Does NOT
-        auto-trip in PR1 — threshold enforcement is a PR2 policy decision."""
+        """Append a failure timestamp, prune the rolling window, and auto-trip
+        if the per-kind threshold is met. The auth path does NOT use this — it
+        calls ``trip()`` directly, because auth is a single-shot condition, not
+        a rolling count."""
         state = self._states[kind]
         state.recent_failures.append(time.monotonic())
         self._prune(kind, state)
+        self._maybe_auto_trip(kind, state)
 
     def record_success(self, kind: BreakerKind) -> None:
-        """Record a success. In PR1 this is a no-op beyond clearing the failure
-        history for the kind — a successful operation means the failure run is
-        over. Does NOT auto-close an explicitly-tripped breaker (PR2 policy)."""
+        """Record a success. Clears the kind's failure history, and — if the
+        breaker is tripped but past its cooldown (half-open) — closes it. This
+        is the recovery path: one successful trial after cooldown recovers the
+        breaker. A breaker still within cooldown, or an indefinite (auth) trip,
+        is NOT reset by a success (its ``tripped`` flag stays set; only the
+        failure history clears)."""
         state = self._states[kind]
         state.recent_failures.clear()
+        if state.tripped and state.cooldown_until is not None:
+            if time.monotonic() >= state.cooldown_until:
+                self._states[kind] = BreakerState()
 
     def trip(self, kind: BreakerKind, reason: str, *, cooldown_s: float = 0.0) -> None:
         """Explicitly open a breaker.
@@ -155,6 +190,15 @@ class BreakerRegistry:
             return True
         return time.monotonic() < state.cooldown_until
 
+    def first_open(self) -> BreakerKind | None:
+        """Return the first currently-open breaker kind, or ``None`` if all are
+        closed/half-open. Callers (REST/MCP preflight) raise ``CircuitOpenError``
+        themselves — the registry stays read-only here."""
+        for kind in BreakerKind:
+            if self.is_open(kind):
+                return kind
+        return None
+
     def snapshot(self) -> dict[str, dict]:
         """JSON-serializable view of all breakers. Every kind is always present
         (even when untouched) so the ``/health`` shape is stable for consumers
@@ -173,6 +217,20 @@ class BreakerRegistry:
         return out
 
     # ── internal ─────────────────────────────────────────────────────────
+
+    def _maybe_auto_trip(self, kind: BreakerKind, state: BreakerState) -> None:
+        """Trip the breaker if the in-window failure count meets the per-kind
+        threshold. Uses the policy's cooldown (timed for composer/CDP/crash;
+        ``None``/indefinite only for auth, which trip()s explicitly anyway)."""
+        policy = self._policies[kind]
+        if len(state.recent_failures) < policy.threshold:
+            return
+        # Already-open within cooldown: refresh the trip so the cooldown
+        # restarts from the latest failure burst (sustained failures extend
+        # the open window rather than letting it lapse mid-storm).
+        reason = f"{policy.threshold} failures in {policy.window_s:.0f}s window"
+        cooldown = policy.cooldown_s if policy.cooldown_s is not None else 0.0
+        self.trip(kind, reason, cooldown_s=cooldown)
 
     def _prune(self, kind: BreakerKind, state: BreakerState) -> None:
         """Drop failure timestamps older than the kind's rolling window and cap

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -21,6 +21,7 @@ import urllib.request
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 
+from .breakers import BreakerKind, BreakerRegistry
 from .diagnostics import diagnose
 
 try:
@@ -181,6 +182,26 @@ class CDPJSError(RuntimeError):
         super().__init__(message)
 
 
+class SendReadinessError(RuntimeError):
+    """Raised when the composer / send-readiness path fails — no composer found,
+    the composer wouldn't focus, or the send button didn't fire.
+
+    Typed (not bare ``RuntimeError``) so the breaker wiring can classify it
+    explicitly at the catch site as ``BreakerKind.COMPOSER_SEND_READINESS``
+    rather than guessing from a string. Raised by ``_ensure_send_ready``,
+    ``type_message``, and ``click_send``.
+    """
+
+
+class CDPReconnectError(RuntimeError):
+    """Raised when CDP reconnect exhausts its 3-attempt backoff without
+    re-establishing the websocket.
+
+    Typed (not bare ``RuntimeError``) so the breaker wiring can classify it
+    explicitly as ``BreakerKind.CDP_RECONNECT``.
+    """
+
+
 # Phrases ChatGPT uses in its rate-limit pop-up. Matched case-insensitively
 # against scanned DOM text. Kept narrow to avoid false positives on normal
 # chat content (e.g. a user asking about "rate limits" in a message).
@@ -263,6 +284,7 @@ class CDPDriver:
         cdp_port: int = 9222,
         tab_mode: str = "owned",
         instance_id: str | None = None,
+        breakers: BreakerRegistry | None = None,
     ) -> None:
         self.port = cdp_port
         # Tab isolation strategy: "owned" creates a dedicated chatgpt.com tab
@@ -305,6 +327,11 @@ class CDPDriver:
         # open tabs on clean shutdown.
         self._target_id: str | None = None
         self._owns_target: bool = False
+        # Phase 4 PR2: optional circuit-breaker registry. When set, failure
+        # sites record/trip their kind and success sites clear failures /
+        # recover half-open breakers. None = back-compat (tests, legacy
+        # construction) — every recorder checks `if self._breakers:`.
+        self._breakers = breakers
 
     # ── Connection ────────────────────────────────────────────
 
@@ -566,12 +593,19 @@ class CDPDriver:
                 await self._wait_for_chatgpt_ready()
                 await self._refresh_token()
                 logger.info("CDP reconnected on attempt %d", attempt)
+                # Success: clear CDP failure history and recover a half-open
+                # breaker. Only after refresh_token succeeds — a reconnect that
+                # reopens the socket but can't auth isn't a clean recovery.
+                if self._breakers:
+                    self._breakers.record_success(BreakerKind.CDP_RECONNECT)
                 return
             except Exception as e:
                 logger.warning("Reconnect attempt %d failed: %s", attempt, e)
                 if attempt < 3:
                     await asyncio.sleep(delay)
-        raise RuntimeError("CDP reconnect failed after 3 attempts")
+        if self._breakers:
+            self._breakers.record_failure(BreakerKind.CDP_RECONNECT)
+        raise CDPReconnectError("CDP reconnect failed after 3 attempts")
 
     async def _find_page_ws(self) -> str:
         """Find a suitable page's websocket URL."""
@@ -1233,7 +1267,9 @@ class CDPDriver:
         await self.navigate_new_chat()  # navigates to ?model=auto + polls composer
         if not await self._wait_for_composer(timeout=5):
             await self._capture_selector_diagnostic("composer (connect send-ready)")
-            raise RuntimeError("No composer found after navigating to a new chat")
+            if self._breakers:
+                self._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+            raise SendReadinessError("No composer found after navigating to a new chat")
 
     async def _wait_for_composer(self, timeout: float = 8) -> bool:
         """Poll until a composer appears, or *timeout* seconds elapse.
@@ -1381,7 +1417,9 @@ class CDPDriver:
         )
         if focus_result == "no composer":
             await self._capture_selector_diagnostic("composer (type_message)")
-            raise RuntimeError("No composer found")
+            if self._breakers:
+                self._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+            raise SendReadinessError("No composer found")
         focused_target = focus_result  # 'composer' or 'fallback'
 
         # Clear existing text and insert. Prefer a platform-aware select-all
@@ -1448,7 +1486,9 @@ class CDPDriver:
             await self._cdp("Input.insertText", {"text": text})
             await asyncio.sleep(0.5)
             if not await self._verify_composer_text(verify_selector, text):
-                raise RuntimeError(
+                if self._breakers:
+                    self._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+                raise SendReadinessError(
                     f"Composer text verification failed after retry; expected {text[:60]!r}"
                 )
         logger.info("Typed: %s", text[:80])
@@ -1576,8 +1616,15 @@ class CDPDriver:
         )
         if result != "sent":
             await self._capture_selector_diagnostic("send-button (click_send)")
-            raise RuntimeError(f"Send failed: {result}")
+            if self._breakers:
+                self._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+            raise SendReadinessError(f"Send failed: {result}")
         logger.info("Message sent")
+        # Success: clear composer failure history and recover a half-open
+        # breaker. Only after the message is confirmed sent — not after
+        # type_message alone, since a successful type can still fail to send.
+        if self._breakers:
+            self._breakers.record_success(BreakerKind.COMPOSER_SEND_READINESS)
 
     # ── Response Retrieval ────────────────────────────────────
 
@@ -2043,6 +2090,8 @@ class CDPDriver:
             except (json.JSONDecodeError, TypeError):
                 status = None
             if status == 401:
+                if self._breakers:
+                    self._breakers.trip(BreakerKind.AUTH_EXPIRED, "HTTP 401 from backend-api")
                 raise AuthExpiredError()
             if status is not None:
                 raise RuntimeError(f"_fetch_text HTTP {status} for {conversation_id}")
@@ -2204,6 +2253,8 @@ class CDPDriver:
         # Login pages contain these markers
         lower = raw[:500].lower()
         if "sign in" in lower and "chatgpt" in lower and "<html" in lower:
+            if self._breakers:
+                self._breakers.trip(BreakerKind.AUTH_EXPIRED, "login page returned instead of data")
             raise AuthExpiredError("Session expired — read returned login page instead of data")
 
     async def _capture_selector_diagnostic(self, selector_name: str) -> None:

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -2953,6 +2953,33 @@ class CDPDriver:
         self._owns_target = False
         logger.info("CDP driver closed")
 
+    async def recover_auth(self) -> bool:
+        """Probe whether the ChatGPT session is valid again, and if so reset
+        the AUTH_EXPIRED breaker.
+
+        Called by the REST/MCP fail-fast preflight when AUTH_EXPIRED is the open
+        breaker — a user may have logged back in via the browser since the trip.
+        This refreshes the access token (a lightweight ``/api/auth/session``
+        fetch, NOT a chat send): a non-empty token means auth is restored, so we
+        reset the breaker and return True. A failure or empty token leaves the
+        breaker open and returns False (caller proceeds to fail-fast).
+
+        Does NOT touch ``record_success`` — auth recovery is an explicit
+        ``reset()``, matching the indefinite-auth semantics (auth is not a
+        rolling-window breaker).
+        """
+        if self._breakers is None or not self._breakers.is_open(BreakerKind.AUTH_EXPIRED):
+            return True  # nothing to recover
+        try:
+            await self._refresh_token()
+        except Exception as e:
+            logger.info("Auth recovery probe failed: %s", e)
+            return False
+        # _refresh_token only returns on a non-empty token (it raises on failure).
+        logger.info("Auth recovered — resetting AUTH_EXPIRED breaker")
+        self._breakers.reset(BreakerKind.AUTH_EXPIRED)
+        return True
+
     @property
     def is_connected(self) -> bool:
         return self._ws is not None and self._ws.state.name == "OPEN"

--- a/src/chatgpt_web2api/chrome.py
+++ b/src/chatgpt_web2api/chrome.py
@@ -19,6 +19,7 @@ import time
 import urllib.request
 from pathlib import Path
 
+from .breakers import BreakerKind, BreakerRegistry
 from .config import Config
 
 logger = logging.getLogger(__name__)
@@ -27,13 +28,19 @@ logger = logging.getLogger(__name__)
 class ChromeProcess:
     """Manages a Chrome subprocess with CDP access."""
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: Config, breakers: BreakerRegistry | None = None) -> None:
         self._cfg = config.chrome
         self._process: subprocess.Popen | None = None
         self._monitor_task: asyncio.Task | None = None
         self._healthy = False
         self._started_at: float = 0
         self._restart_count = 0
+        # Phase 4 PR2: optional breaker registry. When set, each restart records
+        # a CHROME_CRASH_LOOP failure (3-in-300s trips it). None = back-compat.
+        # No record_success here — clearing the rolling crash history on every
+        # restart would defeat the 3-in-300s policy; recovery is cooldown/half-
+        # open only.
+        self._breakers = breakers
 
     # ── Public API ────────────────────────────────────────────
 
@@ -57,6 +64,8 @@ class ChromeProcess:
         logger.warning("Restarting Chrome (restart #%d)", self._restart_count + 1)
         await self._kill()
         self._restart_count += 1
+        if self._breakers:
+            self._breakers.record_failure(BreakerKind.CHROME_CRASH_LOOP)
         await self._launch()
         await self._wait_for_cdp(timeout=30)
 
@@ -81,9 +90,7 @@ class ChromeProcess:
     def get_page_targets(self) -> list[dict]:
         """Get all page targets from CDP."""
         try:
-            req = urllib.request.Request(
-                f"http://127.0.0.1:{self._cfg.cdp_port}/json/list"
-            )
+            req = urllib.request.Request(f"http://127.0.0.1:{self._cfg.cdp_port}/json/list")
             with urllib.request.urlopen(req, timeout=5) as resp:
                 return json.loads(resp.read())
         except Exception:
@@ -167,9 +174,7 @@ class ChromeProcess:
     async def _cdp_alive(self) -> bool:
         """Check if CDP is responding."""
         try:
-            req = urllib.request.Request(
-                f"http://127.0.0.1:{self._cfg.cdp_port}/json/version"
-            )
+            req = urllib.request.Request(f"http://127.0.0.1:{self._cfg.cdp_port}/json/version")
             with urllib.request.urlopen(req, timeout=3) as resp:
                 return resp.status == 200
         except Exception:
@@ -200,7 +205,9 @@ class ChromeProcess:
                     self._healthy = alive
                     if not alive:
                         if self._cfg.restart_on_crash:
-                            logger.warning("Chrome died — restarting (attempt #%d)...", self._restart_count + 1)
+                            logger.warning(
+                                "Chrome died — restarting (attempt #%d)...", self._restart_count + 1
+                            )
                             try:
                                 await self.restart()
                                 logger.info("Chrome restarted successfully")

--- a/src/chatgpt_web2api/mcp_server.py
+++ b/src/chatgpt_web2api/mcp_server.py
@@ -42,7 +42,7 @@ from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from pydantic import BaseModel, Field
 
-from .breakers import BreakerRegistry
+from .breakers import BreakerRegistry, CircuitOpenError
 from .cdp_driver import (
     AuthExpiredError,
     CDPDriver,
@@ -1513,6 +1513,11 @@ def create_server() -> Server:
 
         async def _run() -> dict:
             """Execute the handler, with transparent rate-limit retry for chat tools."""
+            # Circuit-open fail-fast (Phase 4 PR2): refuse before driving Chrome
+            # if a breaker is open on this process's driver. Checked here so it
+            # covers both chat and non-chat tools.
+            if _breakers is not None and (open_kind := _breakers.first_open()):
+                raise CircuitOpenError(open_kind)
             if name in _CHAT_TOOLS:
                 # on_progress is the same callback the lambda captures and
                 # passes into the business function; here it's also used by
@@ -1542,6 +1547,22 @@ def create_server() -> Server:
                         text=(
                             f"ChatGPT rate limit reached. Retry in {e.retry_after}s. "
                             f"(rate_limit_exceeded, retry_after={e.retry_after})"
+                        ),
+                    )
+                ],
+                isError=True,
+            )
+        except CircuitOpenError as e:
+            # A breaker is open on this process's driver — refuse fast with a
+            # structured error so the agent knows to back off. Mirrors the
+            # RateLimitError shape: isError=True, text only, machine token.
+            return mcp_types.CallToolResult(
+                content=[
+                    mcp_types.TextContent(
+                        type="text",
+                        text=(
+                            f"Circuit open for {e.kind.value} — cooling down. "
+                            f"Retry later. (circuit_open, kind={e.kind.value})"
                         ),
                     )
                 ],

--- a/src/chatgpt_web2api/mcp_server.py
+++ b/src/chatgpt_web2api/mcp_server.py
@@ -42,7 +42,7 @@ from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from pydantic import BaseModel, Field
 
-from .breakers import BreakerRegistry, CircuitOpenError
+from .breakers import BreakerKind, BreakerRegistry, CircuitOpenError
 from .cdp_driver import (
     AuthExpiredError,
     CDPDriver,
@@ -1514,10 +1514,16 @@ def create_server() -> Server:
         async def _run() -> dict:
             """Execute the handler, with transparent rate-limit retry for chat tools."""
             # Circuit-open fail-fast (Phase 4 PR2): refuse before driving Chrome
-            # if a breaker is open on this process's driver. Checked here so it
-            # covers both chat and non-chat tools.
-            if _breakers is not None and (open_kind := _breakers.first_open()):
-                raise CircuitOpenError(open_kind)
+            # if a breaker is open on this process's driver. If AUTH_EXPIRED is
+            # open, probe auth recovery first (the user may have logged back in).
+            if _breakers is not None:
+                open_kind = _breakers.first_open()
+                if open_kind is not None:
+                    if open_kind is BreakerKind.AUTH_EXPIRED:
+                        if await _driver.recover_auth():
+                            open_kind = _breakers.first_open()
+                    if open_kind is not None:
+                        raise CircuitOpenError(open_kind)
             if name in _CHAT_TOOLS:
                 # on_progress is the same callback the lambda captures and
                 # passes into the business function; here it's also used by

--- a/src/chatgpt_web2api/mcp_server.py
+++ b/src/chatgpt_web2api/mcp_server.py
@@ -42,6 +42,7 @@ from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from pydantic import BaseModel, Field
 
+from .breakers import BreakerRegistry
 from .cdp_driver import (
     AuthExpiredError,
     CDPDriver,
@@ -71,8 +72,10 @@ ProgressCallback = Callable[[str], Awaitable[None]]
 # Input Schemas — Pydantic BaseModel (official pattern from mcp-server-git)
 # ═══════════════════════════════════════════════════════════════
 
+
 class ChatCompletionInput(BaseModel):
     """Input schema for chat_completion tool."""
+
     message: str = Field(description="The user message to send to ChatGPT")
     system_prompt: str | None = Field(
         default=None,
@@ -113,11 +116,13 @@ class ChatCompletionInput(BaseModel):
 
 class ListModelsInput(BaseModel):
     """No inputs needed — empty schema."""
+
     pass
 
 
 class ListProjectsInput(BaseModel):
     """No inputs needed — empty schema."""
+
     pass
 
 
@@ -152,6 +157,7 @@ class GetConversationInput(BaseModel):
 
 class ListConversationsInput(BaseModel):
     """Input for listing recent conversations."""
+
     limit: int = Field(
         default=28,
         description="Maximum number of conversations to return (default: 28)",
@@ -164,6 +170,7 @@ class ListConversationsInput(BaseModel):
 
 class DeleteConversationInput(BaseModel):
     """Input for deleting a conversation."""
+
     conversation_id: str = Field(
         description="UUID of the conversation to delete",
     )
@@ -171,10 +178,9 @@ class DeleteConversationInput(BaseModel):
 
 class CreateProjectInput(BaseModel):
     """Input for creating a new ChatGPT project."""
+
     name: str = Field(
-        description=(
-            "Display name for the project. This name appears in the ChatGPT sidebar."
-        ),
+        description=("Display name for the project. This name appears in the ChatGPT sidebar."),
     )
     instructions: str = Field(
         default="",
@@ -198,6 +204,7 @@ class CreateProjectInput(BaseModel):
 
 class UpdateProjectInstructionsInput(BaseModel):
     """Input for updating a project's custom instructions."""
+
     project_id: str = Field(
         description="Project gizmo ID (e.g. g-p-abc123)",
     )
@@ -212,6 +219,7 @@ class UpdateProjectInstructionsInput(BaseModel):
 
 class ArchiveConversationInput(BaseModel):
     """Input for archiving or unarchiving a conversation."""
+
     conversation_id: str = Field(description="UUID of the conversation")
     archive: bool = Field(
         default=True,
@@ -221,11 +229,13 @@ class ArchiveConversationInput(BaseModel):
 
 class ListMemoriesInput(BaseModel):
     """No inputs needed."""
+
     pass
 
 
 class CreateMemoryInput(BaseModel):
     """Input for creating a new ChatGPT memory."""
+
     content: str = Field(
         description=(
             "The fact or information to store in ChatGPT's memory. "
@@ -237,21 +247,25 @@ class CreateMemoryInput(BaseModel):
 
 class DeleteMemoryInput(BaseModel):
     """Input for deleting a ChatGPT memory."""
+
     memory_id: str = Field(description="ID of the memory to delete")
 
 
 class DeleteProjectInput(BaseModel):
     """Input for deleting a ChatGPT project."""
+
     project_id: str = Field(description="ID of the project to delete (g-p-...)")
 
 
 class ListGptsInput(BaseModel):
     """No inputs needed."""
+
     pass
 
 
 class ListProjectFilesInput(BaseModel):
     """Input for listing project files."""
+
     project_id: str = Field(
         description="Project gizmo ID to list files for",
     )
@@ -259,10 +273,10 @@ class ListProjectFilesInput(BaseModel):
 
 class ChatWithGptInput(BaseModel):
     """Input for chatting with a specific Custom GPT."""
+
     gpt_id: str = Field(
         description=(
-            "Custom GPT gizmo ID (e.g. g-hkJGhxxx). "
-            "Use list_gpts to discover available GPTs."
+            "Custom GPT gizmo ID (e.g. g-hkJGhxxx). Use list_gpts to discover available GPTs."
         ),
     )
     message: str = Field(description="The message to send to the GPT")
@@ -271,6 +285,7 @@ class ChatWithGptInput(BaseModel):
 # ═══════════════════════════════════════════════════════════════
 # Tool Name Enum — prevents typos (official pattern from mcp-server-git)
 # ═══════════════════════════════════════════════════════════════
+
 
 class ToolName(str, Enum):
     # Core chat
@@ -558,19 +573,23 @@ WRITE_ENV = "W2A_ENABLE_WRITE"
 DESTRUCTIVE_ENV = "W2A_ENABLE_DESTRUCTIVE"
 
 # Tools requiring W2A_ENABLE_WRITE=1 to be visible/callable
-_WRITE_GATED_TOOLS = frozenset({
-    ToolName.CREATE_PROJECT.value,
-    ToolName.UPDATE_PROJECT_INSTRUCTIONS.value,
-    ToolName.CREATE_MEMORY.value,
-    ToolName.ARCHIVE_CONVERSATION.value,
-})
+_WRITE_GATED_TOOLS = frozenset(
+    {
+        ToolName.CREATE_PROJECT.value,
+        ToolName.UPDATE_PROJECT_INSTRUCTIONS.value,
+        ToolName.CREATE_MEMORY.value,
+        ToolName.ARCHIVE_CONVERSATION.value,
+    }
+)
 
 # Tools requiring W2A_ENABLE_DESTRUCTIVE=1 (irreversible account changes)
-_DESTRUCTIVE_TOOLS = frozenset({
-    ToolName.DELETE_CONVERSATION.value,
-    ToolName.DELETE_MEMORY.value,
-    ToolName.DELETE_PROJECT.value,
-})
+_DESTRUCTIVE_TOOLS = frozenset(
+    {
+        ToolName.DELETE_CONVERSATION.value,
+        ToolName.DELETE_MEMORY.value,
+        ToolName.DELETE_PROJECT.value,
+    }
+)
 
 # Auth metadata advertised to clients. When api_keys is empty the
 # server genuinely has no authentication — saying so lets MCP clients
@@ -609,7 +628,8 @@ def warn_non_loopback(host: str, transport: str) -> None:
     logger.warning(
         "%s transport bound to %s with no authentication. Exposed tools "
         "are reachable from the network. Bind to 127.0.0.1 or set api_keys.",
-        transport, host,
+        transport,
+        host,
     )
 
 
@@ -638,28 +658,36 @@ def _visible_tool_names() -> set[str]:
 
 _driver: CDPDriver | None = None
 _config: Config | None = None
+# Phase 4 PR2: per-process breaker registry (MCP-local). MCP has no
+# ChromeProcess, so CHROME_CRASH_LOOP is never tripped here. Auth/composer/CDP
+# failures on MCP's own driver DO record into this registry. None until
+# run_mcp() sets it. No cross-process propagation to/from REST.
+_breakers: BreakerRegistry | None = None
 # Cross-process lock factory — creates a fresh CrossProcessLock per critical
 # section, keyed on the CDP port so all processes sharing a Chrome instance
 # serialize. None until run_mcp() sets it. Read-only tools run lock-free.
 _lock_cdp_port: int | None = None
 
 # Tools that mutate browser state — must hold the lock
-_MUTATING_TOOLS = frozenset({
-    ToolName.CHAT_COMPLETION.value,
-    ToolName.CHAT_WITH_GPT.value,
-    ToolName.DELETE_CONVERSATION.value,
-    ToolName.CREATE_PROJECT.value,
-    ToolName.UPDATE_PROJECT_INSTRUCTIONS.value,
-    ToolName.DELETE_PROJECT.value,
-    ToolName.ARCHIVE_CONVERSATION.value,
-    ToolName.CREATE_MEMORY.value,
-    ToolName.DELETE_MEMORY.value,
-})
+_MUTATING_TOOLS = frozenset(
+    {
+        ToolName.CHAT_COMPLETION.value,
+        ToolName.CHAT_WITH_GPT.value,
+        ToolName.DELETE_CONVERSATION.value,
+        ToolName.CREATE_PROJECT.value,
+        ToolName.UPDATE_PROJECT_INSTRUCTIONS.value,
+        ToolName.DELETE_PROJECT.value,
+        ToolName.ARCHIVE_CONVERSATION.value,
+        ToolName.CREATE_MEMORY.value,
+        ToolName.DELETE_MEMORY.value,
+    }
+)
 
 
 # ═══════════════════════════════════════════════════════════════
 # Business Logic — pure functions (official pattern from mcp-server-git)
 # ═══════════════════════════════════════════════════════════════
+
 
 async def _notify(on_progress: ProgressCallback | None, message: str) -> None:
     """Invoke a progress callback if present, swallowing any error.
@@ -677,19 +705,22 @@ async def _notify(on_progress: ProgressCallback | None, message: str) -> None:
     except Exception:
         logger.debug("progress notification dropped", exc_info=True)
 
+
 async def do_chat_completion(
-    driver: CDPDriver, args: dict, config: Config,
+    driver: CDPDriver,
+    args: dict,
+    config: Config,
     on_progress: ProgressCallback | None = None,
 ) -> dict:
     """Execute a chat completion through the CDP driver."""
     validated = ChatCompletionInput(**args)
-    project_id = validated.project_id or (
-        config.chatgpt.default_project_id if config else None
-    )
+    project_id = validated.project_id or (config.chatgpt.default_project_id if config else None)
 
     # Build the full text with optional system prompt
     if validated.system_prompt:
-        full_text = f"[System Instructions]\n{validated.system_prompt}\n\n[User]\n{validated.message}"
+        full_text = (
+            f"[System Instructions]\n{validated.system_prompt}\n\n[User]\n{validated.message}"
+        )
     else:
         full_text = validated.message
 
@@ -748,10 +779,7 @@ async def do_list_models(driver: CDPDriver) -> dict:
     """List available models."""
     models = await driver.get_models()
     return {
-        "models": [
-            {"id": m.get("slug", ""), "title": m.get("title", "")}
-            for m in models
-        ],
+        "models": [{"id": m.get("slug", ""), "title": m.get("title", "")} for m in models],
     }
 
 
@@ -892,16 +920,19 @@ async def do_list_memories(driver: CDPDriver) -> dict:
     result = []
     for m in memories:
         if isinstance(m, dict):
-            result.append({
-                "id": m.get("id", ""),
-                "content": m.get("content", m.get("text", "")),
-                "created_at": m.get("created_at", ""),
-            })
+            result.append(
+                {
+                    "id": m.get("id", ""),
+                    "content": m.get("content", m.get("text", "")),
+                    "created_at": m.get("created_at", ""),
+                }
+            )
     return {"memories": result}
 
 
 async def do_create_memory(
-    driver: CDPDriver, args: dict,
+    driver: CDPDriver,
+    args: dict,
     on_progress: ProgressCallback | None = None,
 ) -> dict:
     """Create a new ChatGPT memory.
@@ -951,7 +982,8 @@ async def do_list_project_files(driver: CDPDriver, args: dict) -> dict:
 
 
 async def do_chat_with_gpt(
-    driver: CDPDriver, args: dict,
+    driver: CDPDriver,
+    args: dict,
     on_progress: ProgressCallback | None = None,
 ) -> dict:
     """Chat with a specific Custom GPT."""
@@ -982,6 +1014,7 @@ async def do_chat_with_gpt(
 # ═══════════════════════════════════════════════════════════════
 # Tool Definitions — declarative list with full annotations
 # ═══════════════════════════════════════════════════════════════
+
 
 def _build_tools() -> list[mcp_types.Tool]:
     """Build the FULL list of tool definitions (all 15), unfiltered.
@@ -1361,6 +1394,7 @@ def build_tools() -> list[mcp_types.Tool]:
 # Server Factory
 # ═══════════════════════════════════════════════════════════════
 
+
 def create_server() -> Server:
     """Create and configure the MCP server with all capabilities."""
 
@@ -1423,16 +1457,16 @@ def create_server() -> Server:
     ) -> tuple[list[mcp_types.TextContent], dict] | list[mcp_types.TextContent] | dict:
         """Route tool calls to business logic functions."""
         if _driver is None:
-            raise ConnectionError(
-                "Not connected to Chrome. Run 'chatgpt-web2api' first."
-            )
+            raise ConnectionError("Not connected to Chrome. Run 'chatgpt-web2api' first.")
 
         # Build once per request: the callback reads server.request_context,
         # which is request-scoped. None when the client can't receive progress.
         on_progress = _make_progress_callback()
 
         handlers = {
-            ToolName.CHAT_COMPLETION.value: lambda: do_chat_completion(_driver, arguments, _config, on_progress),
+            ToolName.CHAT_COMPLETION.value: lambda: do_chat_completion(
+                _driver, arguments, _config, on_progress
+            ),
             ToolName.LIST_MODELS.value: lambda: do_list_models(_driver),
             ToolName.LIST_PROJECTS.value: lambda: do_list_projects(_driver),
             ToolName.GET_CONVERSATION.value: lambda: do_get_conversation(_driver, arguments),
@@ -1440,8 +1474,12 @@ def create_server() -> Server:
             ToolName.DELETE_CONVERSATION.value: lambda: do_delete_conversation(_driver, arguments),
             ToolName.CREATE_PROJECT.value: lambda: do_create_project(_driver, arguments),
             ToolName.DELETE_PROJECT.value: lambda: do_delete_project(_driver, arguments),
-            ToolName.UPDATE_PROJECT_INSTRUCTIONS.value: lambda: do_update_project_instructions(_driver, arguments),
-            ToolName.ARCHIVE_CONVERSATION.value: lambda: do_archive_conversation(_driver, arguments),
+            ToolName.UPDATE_PROJECT_INSTRUCTIONS.value: lambda: do_update_project_instructions(
+                _driver, arguments
+            ),
+            ToolName.ARCHIVE_CONVERSATION.value: lambda: do_archive_conversation(
+                _driver, arguments
+            ),
             ToolName.LIST_MEMORIES.value: lambda: do_list_memories(_driver),
             ToolName.CREATE_MEMORY.value: lambda: do_create_memory(_driver, arguments, on_progress),
             ToolName.DELETE_MEMORY.value: lambda: do_delete_memory(_driver, arguments),
@@ -1459,18 +1497,19 @@ def create_server() -> Server:
         # must be rejected rather than silently executed.
         gate = _tool_gate_env(name)
         if gate is not None and not _env_enabled(gate):
-            raise PermissionError(
-                f"Tool '{name}' is not enabled. Set {gate}=1 to expose it."
-            )
+            raise PermissionError(f"Tool '{name}' is not enabled. Set {gate}=1 to expose it.")
 
         # Tools whose business logic drives ChatGPT chat (and can hit the rate
         # limit). These get transparent retry: a transient "Too many requests"
         # pop-up is dismissed and retried so the agent never sees it. Only a
         # persistent limit surfaces — as a structured error result below.
-        _CHAT_TOOLS = frozenset({
-            ToolName.CHAT_COMPLETION.value, ToolName.CHAT_WITH_GPT.value,
-            ToolName.CREATE_MEMORY.value,  # uses send_and_stream internally
-        })
+        _CHAT_TOOLS = frozenset(
+            {
+                ToolName.CHAT_COMPLETION.value,
+                ToolName.CHAT_WITH_GPT.value,
+                ToolName.CREATE_MEMORY.value,  # uses send_and_stream internally
+            }
+        )
 
         async def _run() -> dict:
             """Execute the handler, with transparent rate-limit retry for chat tools."""
@@ -1497,13 +1536,15 @@ def create_server() -> Server:
             # structuredContent against the tool's outputSchema and this error
             # payload deliberately doesn't match any tool's success schema.
             return mcp_types.CallToolResult(
-                content=[mcp_types.TextContent(
-                    type="text",
-                    text=(
-                        f"ChatGPT rate limit reached. Retry in {e.retry_after}s. "
-                        f"(rate_limit_exceeded, retry_after={e.retry_after})"
-                    ),
-                )],
+                content=[
+                    mcp_types.TextContent(
+                        type="text",
+                        text=(
+                            f"ChatGPT rate limit reached. Retry in {e.retry_after}s. "
+                            f"(rate_limit_exceeded, retry_after={e.retry_after})"
+                        ),
+                    )
+                ],
                 isError=True,
             )
         except AuthExpiredError:
@@ -1514,10 +1555,12 @@ def create_server() -> Server:
             # structuredContent against the tool's outputSchema and this error
             # payload deliberately doesn't match any tool's success schema.
             return mcp_types.CallToolResult(
-                content=[mcp_types.TextContent(
-                    type="text",
-                    text="ChatGPT session expired — re-login required. (auth_expired)",
-                )],
+                content=[
+                    mcp_types.TextContent(
+                        type="text",
+                        text="ChatGPT session expired — re-login required. (auth_expired)",
+                    )
+                ],
                 isError=True,
             )
         except GenerationStuckError as e:
@@ -1525,23 +1568,27 @@ def create_server() -> Server:
             # from a slow generation (which keeps progressing and is allowed the
             # full timeout). Phase + duration in the text for diagnosis.
             return mcp_types.CallToolResult(
-                content=[mcp_types.TextContent(
-                    type="text",
-                    text=(
-                        f"Generation stuck in {e.phase} for {e.stalled_for_s:.0f}s "
-                        f"— no DOM progress. (generation_stuck)"
-                    ),
-                )],
+                content=[
+                    mcp_types.TextContent(
+                        type="text",
+                        text=(
+                            f"Generation stuck in {e.phase} for {e.stalled_for_s:.0f}s "
+                            f"— no DOM progress. (generation_stuck)"
+                        ),
+                    )
+                ],
                 isError=True,
             )
         except LockAcquisitionError:
             # Another process holds the cross-process lock for this Chrome tab
             # and didn't release it within the timeout. The caller should retry.
             return mcp_types.CallToolResult(
-                content=[mcp_types.TextContent(
-                    type="text",
-                    text="Browser busy — another operation in progress. Retry later. (lock_timeout)",
-                )],
+                content=[
+                    mcp_types.TextContent(
+                        type="text",
+                        text="Browser busy — another operation in progress. Retry later. (lock_timeout)",
+                    )
+                ],
                 isError=True,
             )
 
@@ -1804,21 +1851,26 @@ def create_server() -> Server:
 # ═══════════════════════════════════════════════════════════════
 
 
-async def run_mcp(
-    config: Config, transport: str = "stdio", port: int = 8090
-) -> None:
+async def run_mcp(config: Config, transport: str = "stdio", port: int = 8090) -> None:
     """Connect to Chrome and run the MCP server."""
-    global _driver, _config, _lock_cdp_port
+    global _driver, _config, _lock_cdp_port, _breakers
 
     _config = config
     _lock_cdp_port = config.chrome.cdp_port
+
+    # Phase 4 PR2: one MCP-local registry. Injected into MCP's own driver;
+    # auth/composer/CDP failures record here. CHROME_CRASH_LOOP is never
+    # tripped (MCP has no ChromeProcess). No cross-process propagation.
+    _breakers = BreakerRegistry()
 
     _driver = CDPDriver(
         cdp_port=config.chrome.cdp_port,
         tab_mode=config.chatgpt.tab_mode,
         instance_id=TabRegistry.derive_instance_id(
-            cdp_port=config.chrome.cdp_port, server_identity="mcp",
+            cdp_port=config.chrome.cdp_port,
+            server_identity="mcp",
         ),
+        breakers=_breakers,
     )
     try:
         await _driver.connect()
@@ -1847,9 +1899,7 @@ async def run_mcp(
         await _driver.close()
 
 
-async def _run_sse(
-    server: Server, init_options, config: Config, port: int
-) -> None:
+async def _run_sse(server: Server, init_options, config: Config, port: int) -> None:
     """Run MCP server with SSE transport via Starlette + uvicorn.
 
     The MCP library's ``SseServerTransport`` is ASGI-native (built on
@@ -1873,12 +1923,8 @@ async def _run_sse(
     sse = SseServerTransport("/messages")
 
     async def handle_sse(request):
-        async with sse.connect_sse(
-            request.scope, request.receive, request._send
-        ) as streams:
-            await server.run(
-                streams[0], streams[1], init_options, raise_exceptions=True
-            )
+        async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
+            await server.run(streams[0], streams[1], init_options, raise_exceptions=True)
         return Response()
 
     # handle_post_message is a raw ASGI app (scope, receive, send) that
@@ -1921,12 +1967,8 @@ def main() -> None:
         default="stdio",
         help="Transport layer (default: stdio)",
     )
-    parser.add_argument(
-        "--port", type=int, default=8090, help="SSE port (default: 8090)"
-    )
-    parser.add_argument(
-        "--cdp-port", type=int, help="Chrome CDP port (default: from config)"
-    )
+    parser.add_argument("--port", type=int, default=8090, help="SSE port (default: 8090)")
+    parser.add_argument("--cdp-port", type=int, help="Chrome CDP port (default: from config)")
     parser.add_argument(
         "--log-level",
         default="INFO",

--- a/src/chatgpt_web2api/service.py
+++ b/src/chatgpt_web2api/service.py
@@ -17,6 +17,7 @@ import sys
 import time
 
 from .api_server import APIServer
+from .breakers import BreakerRegistry
 from .cdp_driver import CDPDriver
 from .chrome import ChromeProcess
 from .config import Config
@@ -43,11 +44,18 @@ class Service:
         # Enable reactive diagnostics capture if the operator opted in.
         # Off by default; only writes artifacts when W2A_DIAGNOSE=1.
         from .diagnostics import apply_env_enablement
+
         apply_env_enablement()
+
+        # 0. Circuit-breaker registry (Phase 4 PR2) — one per REST process,
+        # shared by Chrome (crash-loop), the CDP driver (auth/composer/CDP),
+        # and the API server (snapshot + fail-fast). Constructed first so every
+        # component below can record into the same registry.
+        self._breakers = BreakerRegistry()
 
         # 1. Chrome
         logger.info("Ensuring Chrome is running...")
-        self._chrome = ChromeProcess(cfg)
+        self._chrome = ChromeProcess(cfg, breakers=self._breakers)
         await self._chrome.ensure_running()
         await self._chrome.start_monitor()
 
@@ -60,6 +68,7 @@ class Service:
                 cdp_port=cfg.chrome.cdp_port,
                 server_identity=f"rest:{cfg.server.port}",
             ),
+            breakers=self._breakers,
         )
 
         try:
@@ -71,7 +80,7 @@ class Service:
             await self._driver.connect()
 
         # 3. API server
-        self._server = APIServer(cfg, self._driver)
+        self._server = APIServer(cfg, self._driver, breakers=self._breakers)
         self._runner = await self._start_server()
 
         self._print_banner()
@@ -162,6 +171,7 @@ class Service:
         names it so a user who hits the failure knows the escape hatch.
         """
         import os
+
         # Normalize empty/None to explicit loopback — security defaults must
         # not rely on empty-string semantics (aiohttp's empty-host bind is
         # loopback today, but making it explicit avoids ambiguity).
@@ -174,7 +184,8 @@ class Service:
             logger.warning(
                 "API bound to loopback (%s) with no api_keys — local no-auth "
                 "mode. Safe for single-user local use; do NOT bind remotely "
-                "without setting api_keys.", host or "127.0.0.1",
+                "without setting api_keys.",
+                host or "127.0.0.1",
             )
         elif not loopback and has_keys:
             logger.warning(

--- a/tests/test_breaker_failfast.py
+++ b/tests/test_breaker_failfast.py
@@ -70,6 +70,7 @@ def _make_mcp_server_with_open_breaker():
     driver.navigate_new_chat = AsyncMock()
     driver.navigate_conversation = AsyncMock()
     driver.ensure_current_conversation = AsyncMock()
+    driver.recover_auth = AsyncMock(return_value=False)
     driver._current_conv_id = ""
     driver._current_model = None
 
@@ -135,6 +136,7 @@ async def test_mcp_closed_breaker_does_not_fail_fast(monkeypatch):
     driver.navigate_new_chat = AsyncMock()
     driver.navigate_conversation = AsyncMock()
     driver.ensure_current_conversation = AsyncMock()
+    driver.recover_auth = AsyncMock(return_value=False)
     driver._current_conv_id = ""
     driver._current_model = None
 
@@ -162,3 +164,250 @@ async def test_mcp_closed_breaker_does_not_fail_fast(monkeypatch):
         )
 
     assert result.isError is False
+
+
+# ── Blocker 1: post-lock re-check catches a race ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rest_post_lock_check_catches_race(monkeypatch):
+    """If a breaker trips while a request waits on the cross-process lock, the
+    post-lock check must catch it and return 503 without driving Chrome.
+
+    Simulates: breaker closed at pre-lock check → trip during lock wait →
+    post-lock check catches it. select_model / navigate_new_chat /
+    send_and_stream must NOT be called.
+    """
+    import chatgpt_web2api.api_server as srv
+
+    server = srv.APIServer.__new__(srv.APIServer)
+    server._last_conv_id = None
+    server._last_project_id = None
+    server._request_count = 0
+    server._cdp_port = 9222
+    server._config = srv.Config.load(None)
+    server._last_error = None
+    reg = BreakerRegistry()
+    server._breakers = reg
+
+    driver = MagicMock()
+    driver._current_conv_id = None
+    driver._current_model = None
+    driver.recover_auth = AsyncMock(return_value=False)
+    driver.select_model = AsyncMock(return_value=True)
+    driver.navigate_new_chat = AsyncMock()
+    driver.navigate_conversation = AsyncMock()
+    driver.ensure_current_conversation = AsyncMock()
+
+    async def _stream(text, timeout=120):
+        yield MagicMock()
+
+    driver.send_and_stream = _stream
+    server._driver = driver
+
+    # A lock wrapper that trips a breaker ONCE (simulating a concurrent request
+    # tripping it during the wait). The pre-lock check sees closed; the post-
+    # lock check sees open.
+    tripped = {"done": False}
+
+    class _RacingLock:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            if not tripped["done"]:
+                reg.trip(
+                    BreakerKind.COMPOSER_SEND_READINESS,
+                    "race trip",
+                    cooldown_s=300.0,
+                )
+                tripped["done"] = True
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    import chatgpt_web2api.api_server as mod
+
+    monkeypatch.setattr(mod, "CrossProcessLock", _RacingLock)
+
+    request = MagicMock()
+    request.json = AsyncMock(
+        return_value={
+            "messages": [{"role": "user", "content": "hello"}],
+            "model": "auto",
+            "stream": False,
+        }
+    )
+
+    resp = await server._handle_chat(request)
+
+    assert resp.status == 503
+    body = json.loads(resp.body)
+    assert body["error"]["code"] == "circuit_open"
+    # Chrome was NOT driven — the post-lock check fired first.
+    driver.select_model.assert_not_called()
+    driver.navigate_new_chat.assert_not_called()
+    driver.navigate_conversation.assert_not_called()
+
+
+# ── Blocker 2: AUTH_EXPIRED recovery probe ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rest_auth_recovery_probes_then_proceeds(monkeypatch):
+    """When AUTH_EXPIRED is open, the preflight probes recover_auth() before
+    failing fast. If recovery succeeds (user logged back in), the breaker is
+    reset and the request proceeds normally — no 503."""
+    import chatgpt_web2api.api_server as srv
+
+    server = srv.APIServer.__new__(srv.APIServer)
+    server._last_conv_id = None
+    server._last_project_id = None
+    server._request_count = 0
+    server._cdp_port = 9222
+    server._config = srv.Config.load(None)
+    server._last_error = None
+    server._last_successful_send_at = None
+    reg = BreakerRegistry()
+    reg.trip(BreakerKind.AUTH_EXPIRED, "401", cooldown_s=0)
+    server._breakers = reg
+
+    driver = MagicMock()
+    driver._current_conv_id = None
+    driver._current_model = None
+    # Recovery succeeds — auth is valid again. The mock mimics the real
+    # recover_auth() by resetting the breaker before returning True.
+    recover_called = {"count": 0}
+
+    async def _recover_ok():
+        recover_called["count"] += 1
+        reg.reset(BreakerKind.AUTH_EXPIRED)
+        return True
+
+    driver.recover_auth = _recover_ok
+    driver.select_model = AsyncMock(return_value=True)
+    driver.navigate_new_chat = AsyncMock()
+    driver.navigate_conversation = AsyncMock()
+    driver.ensure_current_conversation = AsyncMock()
+
+    reached = {"sent": False}
+
+    async def _full_response(*a, **kw):
+        reached["sent"] = True
+        resp = MagicMock()
+        resp.status = 200
+        return resp
+
+    server._full_response = _full_response
+    server._stream_response = _full_response
+    server._driver = driver
+
+    # Bypass the cross-process lock.
+    class _NullLock:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    import chatgpt_web2api.api_server as mod
+
+    monkeypatch.setattr(mod, "CrossProcessLock", _NullLock)
+
+    request = MagicMock()
+    request.json = AsyncMock(
+        return_value={
+            "messages": [{"role": "user", "content": "hello"}],
+            "model": "auto",
+            "stream": False,
+        }
+    )
+
+    await server._handle_chat(request)
+
+    # Recovery was probed and succeeded; the request proceeded.
+    assert reached["sent"] is True
+    assert recover_called["count"] >= 1
+    # Breaker was reset.
+    assert reg.is_open(BreakerKind.AUTH_EXPIRED) is False
+
+
+@pytest.mark.asyncio
+async def test_rest_auth_recovery_fails_still_fail_fasts():
+    """When AUTH_EXPIRED is open and recovery fails, the preflight still
+    fails fast with 503 circuit_open."""
+    import chatgpt_web2api.api_server as srv
+
+    server = srv.APIServer.__new__(srv.APIServer)
+    server._last_conv_id = None
+    server._last_project_id = None
+    server._request_count = 0
+    server._cdp_port = 9222
+    server._config = srv.Config.load(None)
+    server._last_error = None
+    reg = BreakerRegistry()
+    reg.trip(BreakerKind.AUTH_EXPIRED, "401", cooldown_s=0)
+    server._breakers = reg
+
+    driver = MagicMock()
+    driver._current_conv_id = None
+    driver._current_model = None
+    # Recovery fails — auth still invalid.
+    driver.recover_auth = AsyncMock(return_value=False)
+    driver.select_model = AsyncMock(return_value=True)
+    driver.navigate_new_chat = AsyncMock()
+    server._driver = driver
+
+    request = MagicMock()
+    request.json = AsyncMock(
+        return_value={
+            "messages": [{"role": "user", "content": "hello"}],
+            "model": "auto",
+            "stream": False,
+        }
+    )
+
+    resp = await server._handle_chat(request)
+
+    assert resp.status == 503
+    body = json.loads(resp.body)
+    assert body["error"]["code"] == "circuit_open"
+    driver.navigate_new_chat.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_driver_recover_auth_resets_on_successful_refresh(monkeypatch):
+    """driver.recover_auth() calls _refresh_token and resets AUTH_EXPIRED on
+    success; on failure leaves the breaker open."""
+    from chatgpt_web2api.cdp_driver import CDPDriver
+
+    driver = CDPDriver.__new__(CDPDriver)
+    driver._breakers = BreakerRegistry()
+    driver._access_token = ""
+
+    # Success path: _refresh_token returns (non-empty token) → reset.
+    driver._breakers.trip(BreakerKind.AUTH_EXPIRED, "401", cooldown_s=0)
+    assert driver._breakers.is_open(BreakerKind.AUTH_EXPIRED) is True
+
+    async def _ok_refresh():
+        driver._access_token = "newtoken"
+
+    driver._refresh_token = _ok_refresh
+    result = await driver.recover_auth()
+    assert result is True
+    assert driver._breakers.is_open(BreakerKind.AUTH_EXPIRED) is False
+
+    # Failure path: _refresh_token raises → breaker stays open.
+    driver._breakers.trip(BreakerKind.AUTH_EXPIRED, "401", cooldown_s=0)
+
+    async def _bad_refresh():
+        raise RuntimeError("No access token")
+
+    driver._refresh_token = _bad_refresh
+    result = await driver.recover_auth()
+    assert result is False
+    assert driver._breakers.is_open(BreakerKind.AUTH_EXPIRED) is True

--- a/tests/test_breaker_failfast.py
+++ b/tests/test_breaker_failfast.py
@@ -1,0 +1,164 @@
+"""Tests for the REST + MCP circuit-open fail-fast surface (Phase 4 PR2).
+
+When a breaker is open, both transports must refuse FAST — before touching
+Chrome — with a structured signal:
+
+  - REST: HTTP 503 with ``code: circuit_open`` (mirrors the lock_timeout 503).
+  - MCP: ``CallToolResult(isError=True)`` with a ``(circuit_open, kind=...)``
+    machine token (mirrors the RateLimitError result shape).
+
+These tests exercise the error-mapping seams directly and via the MCP
+in-memory transport. No live Chrome — all via fakes/fixtures, matching the
+patterns in ``test_api_rate_limit.py`` and ``test_mcp_rate_limit.py``.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import chatgpt_web2api.mcp_server as mod
+from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry, CircuitOpenError
+from chatgpt_web2api.config import Config
+
+# ── REST: _error_response maps CircuitOpenError → 503 ─────────────────
+
+
+def _server():
+    """An APIServer with a throwaway config + driver (only _error_response used)."""
+    from chatgpt_web2api.api_server import APIServer
+
+    return APIServer(Config.load(None), MagicMock())
+
+
+def test_rest_circuit_open_maps_to_503():
+    """CircuitOpenError → HTTP 503, code circuit_open, message names the kind
+    via kind.value (not the enum repr)."""
+    server = _server()
+    exc = CircuitOpenError(BreakerKind.COMPOSER_SEND_READINESS)
+    resp = server._error_response(exc)
+
+    assert resp.status == 503
+    body = json.loads(resp.body)
+    err = body["error"]
+    assert err["type"] == "server_error"
+    assert err["code"] == "circuit_open"
+    assert err["param"] is None
+    # kind rendered as its stable .value string, not <BreakerKind...>
+    assert "composer_send_readiness" in err["message"]
+
+
+def test_rest_circuit_open_each_kind_renders_value():
+    """Every BreakerKind renders its .value in the REST error message."""
+    server = _server()
+    for kind in BreakerKind:
+        resp = server._error_response(CircuitOpenError(kind))
+        body = json.loads(resp.body)
+        assert kind.value in body["error"]["message"]
+        assert resp.status == 503
+
+
+# ── MCP: open breaker → isError CallToolResult ────────────────────────
+
+
+def _make_mcp_server_with_open_breaker():
+    """Build a real MCP server whose breaker is OPEN (auth tripped), so the
+    preflight in _run() raises CircuitOpenError before the handler runs."""
+    driver = MagicMock()
+    driver.dismiss_rate_limit = AsyncMock(return_value=True)
+    driver.select_model = AsyncMock(return_value=True)
+    driver.navigate_new_chat = AsyncMock()
+    driver.navigate_conversation = AsyncMock()
+    driver.ensure_current_conversation = AsyncMock()
+    driver._current_conv_id = ""
+    driver._current_model = None
+
+    # If the handler somehow runs, yield a benign chunk (it should NOT).
+    async def _stream(text, timeout=120):
+        from chatgpt_web2api.cdp_driver import StreamChunk
+
+        yield StreamChunk(delta="should-not-reach")
+        yield StreamChunk(delta="", finish_reason="stop")
+
+    driver.send_and_stream = _stream
+
+    mod._driver = driver
+    mod._config = Config.load(None)
+    mod._lock = None
+    # Open the auth breaker → preflight must refuse.
+    reg = BreakerRegistry()
+    reg.trip(BreakerKind.AUTH_EXPIRED, "test trip", cooldown_s=0)
+    mod._breakers = reg
+    return mod.create_server(), driver
+
+
+@pytest.mark.asyncio
+async def test_mcp_open_breaker_returns_circuit_open_error():
+    """When a breaker is open, call_tool returns isError with the
+    (circuit_open, kind=...) machine token, and the driver handler never runs."""
+    server, driver = _make_mcp_server_with_open_breaker()
+
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    async with create_connected_server_and_client_session(server) as session:
+        await session.initialize()
+        result = await session.call_tool(
+            "chat_completion",
+            {
+                "message": "hello",
+                "model": "auto",
+            },
+        )
+
+    # isError=True, no structuredContent (error payloads don't match schemas)
+    assert result.isError is True
+    text = result.content[0].text
+    assert "circuit_open" in text
+    assert "auth_required" in text  # kind.value rendered, not enum repr
+    # The driver handler must NOT have run — send_and_stream is untouched.
+    # (If it ran it would have produced content; here there's only the error.)
+
+
+@pytest.mark.asyncio
+async def test_mcp_closed_breaker_does_not_fail_fast(monkeypatch):
+    """When all breakers are closed, tools proceed normally — no circuit_open."""
+    import chatgpt_web2api.resilience as res
+
+    async def _noop(_s):
+        return None
+
+    monkeypatch.setattr(res.asyncio, "sleep", _noop)
+
+    driver = MagicMock()
+    driver.dismiss_rate_limit = AsyncMock(return_value=True)
+    driver.select_model = AsyncMock(return_value=True)
+    driver.navigate_new_chat = AsyncMock()
+    driver.navigate_conversation = AsyncMock()
+    driver.ensure_current_conversation = AsyncMock()
+    driver._current_conv_id = ""
+    driver._current_model = None
+
+    async def _stream(text, timeout=120):
+        from chatgpt_web2api.cdp_driver import StreamChunk
+
+        yield StreamChunk(delta="ok")
+        yield StreamChunk(delta="", finish_reason="stop")
+
+    driver.send_and_stream = _stream
+
+    mod._driver = driver
+    mod._config = Config.load(None)
+    mod._lock = None
+    mod._breakers = BreakerRegistry()  # all closed
+
+    server = mod.create_server()
+    from mcp.shared.memory import create_connected_server_and_client_session
+
+    async with create_connected_server_and_client_session(server) as session:
+        await session.initialize()
+        result = await session.call_tool(
+            "chat_completion",
+            {"message": "hello", "model": "auto"},
+        )
+
+    assert result.isError is False

--- a/tests/test_breakers.py
+++ b/tests/test_breakers.py
@@ -110,23 +110,27 @@ def test_chrome_crash_loop_uses_300s_window(monkeypatch):
     assert snap["cdp_reconnect"]["failures_in_window"] == 2
 
 
-def test_record_failure_does_not_auto_trip():
-    """PR1 contract: record_failure only counts — reaching a threshold does NOT
-    open the breaker. Auto-trip is a PR2 policy decision."""
+def test_record_failure_auto_trips_at_threshold():
+    """PR2 contract: record_failure auto-trips once the per-kind threshold is
+    met within the rolling window. Below the threshold it stays closed."""
     reg = BreakerRegistry()
-    # CDP threshold is 5; record 10 — still must not trip in PR1.
-    for _ in range(10):
+    # CDP threshold is 5; 4 stays closed.
+    for _ in range(4):
         reg.record_failure(BreakerKind.CDP_RECONNECT)
     assert reg.is_open(BreakerKind.CDP_RECONNECT) is False
+    # The 5th trips it.
+    reg.record_failure(BreakerKind.CDP_RECONNECT)
+    assert reg.is_open(BreakerKind.CDP_RECONNECT) is True
 
 
 def test_record_success_clears_failure_history():
-    """A success clears the failure run for that kind (but does not close an
-    explicitly-tripped breaker — that's reset's job)."""
+    """A success clears the failure run for that kind (but does not close a
+    breaker still within its cooldown — see test_record_success_matrix)."""
     reg = BreakerRegistry()
-    for _ in range(4):
+    # 2 failures: below the chrome_crash_loop threshold of 3, so still closed.
+    for _ in range(2):
         reg.record_failure(BreakerKind.CHROME_CRASH_LOOP)
-    assert reg.snapshot()["chrome_crash_loop"]["failures_in_window"] == 4
+    assert reg.snapshot()["chrome_crash_loop"]["failures_in_window"] == 2
 
     reg.record_success(BreakerKind.CHROME_CRASH_LOOP)
     assert reg.snapshot()["chrome_crash_loop"]["failures_in_window"] == 0

--- a/tests/test_breakers.py
+++ b/tests/test_breakers.py
@@ -1,15 +1,19 @@
-"""Tests for the non-rate-limit breaker registry (Phase 4, PR1).
+"""Tests for the non-rate-limit breaker registry (Phase 4).
 
 Pure unit tests — the registry is pure logic (stdlib only), so no mocking of
 subprocesses or drivers is needed. A virtual clock drives cooldown/window math
 the same way ``tests/test_ensure.py`` does.
 
-PR1 is behavior-free: these tests pin the registry's contract so PR2's signal
-wiring has a stable foundation to call into.
+PR1 pinned the plumbing contract; PR2 activates auto-trip + half-open recovery.
+These tests cover both the inherited PR1 invariants and the new PR2 behavior.
 """
 
 import chatgpt_web2api.breakers as breakers_mod
-from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+from chatgpt_web2api.breakers import (
+    BreakerKind,
+    BreakerRegistry,
+    CircuitOpenError,
+)
 
 
 def _install_clock(monkeypatch, start: float = 1000.0):
@@ -194,6 +198,144 @@ def test_reset_clears_a_tripped_breaker():
     assert snap["open"] is False
     assert snap["reason"] is None
     assert snap["tripped_at"] is None
+
+
+# ── PR2: auto-trip, half-open recovery, fail-fast ─────────────────────
+
+
+def test_record_failure_auto_trips_per_kind_threshold(monkeypatch):
+    """Each kind trips at its own threshold; kind isolation holds — failures of
+    one kind never trip another."""
+    _install_clock(monkeypatch)
+    reg = BreakerRegistry()
+
+    # COMPOSER threshold is 3; 2 stays closed.
+    reg.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+    reg.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+    assert reg.is_open(BreakerKind.COMPOSER_SEND_READINESS) is False
+    # 3rd trips it.
+    reg.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+    assert reg.is_open(BreakerKind.COMPOSER_SEND_READINESS) is True
+
+    # CDP threshold is 5 — composer failures did not bleed into CDP.
+    assert reg.is_open(BreakerKind.CDP_RECONNECT) is False
+
+
+def test_auth_trip_is_immediate_and_indefinite(monkeypatch):
+    """Auth uses explicit trip() (not record_failure) and stays open
+    indefinitely — no rolling window, no half-open recovery."""
+    advance = _install_clock(monkeypatch)
+    reg = BreakerRegistry()
+
+    reg.trip(BreakerKind.AUTH_EXPIRED, "HTTP 401")
+    assert reg.is_open(BreakerKind.AUTH_EXPIRED) is True
+
+    advance(99999.0)
+    assert reg.is_open(BreakerKind.AUTH_EXPIRED) is True  # never half-opens
+
+
+# ── record_success 4-case matrix ──────────────────────────────────────
+
+
+def test_record_success_closed_clears_failures_only(monkeypatch):
+    """Case 1: a CLOSED breaker + success → clears failures, stays closed."""
+    _install_clock(monkeypatch)
+    reg = BreakerRegistry()
+    # 2 failures (below threshold 3), still closed.
+    reg.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+    reg.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+    assert reg.snapshot()["composer_send_readiness"]["failures_in_window"] == 2
+
+    reg.record_success(BreakerKind.COMPOSER_SEND_READINESS)
+
+    snap = reg.snapshot()["composer_send_readiness"]
+    assert snap["failures_in_window"] == 0
+    assert snap["open"] is False
+    assert snap["reason"] is None  # never tripped
+
+
+def test_record_success_within_cooldown_does_not_reset(monkeypatch):
+    """Case 2: open TIMED breaker still within cooldown + success → does NOT
+    reset. The breaker stays tripped; only failures clear."""
+    advance = _install_clock(monkeypatch)
+    reg = BreakerRegistry()
+
+    reg.trip(BreakerKind.COMPOSER_SEND_READINESS, "no composer", cooldown_s=300.0)
+    assert reg.is_open(BreakerKind.COMPOSER_SEND_READINESS) is True
+
+    advance(100.0)  # within the 300s cooldown
+    reg.record_success(BreakerKind.COMPOSER_SEND_READINESS)
+
+    assert reg.is_open(BreakerKind.COMPOSER_SEND_READINESS) is True
+    snap = reg.snapshot()["composer_send_readiness"]
+    assert snap["open"] is True
+    assert snap["reason"] == "no composer"  # trip state preserved
+
+
+def test_record_success_after_cooldown_resets_half_open(monkeypatch):
+    """Case 3: open TIMED breaker past cooldown (half-open) + success → RESETS
+    to closed. This is the recovery path: one successful trial closes it."""
+    advance = _install_clock(monkeypatch)
+    reg = BreakerRegistry()
+
+    reg.trip(BreakerKind.CDP_RECONNECT, "ws closed", cooldown_s=120.0)
+    assert reg.is_open(BreakerKind.CDP_RECONNECT) is True
+
+    advance(121.0)  # past the 120s cooldown → half-open
+    assert reg.is_open(BreakerKind.CDP_RECONNECT) is False  # half-open = not open
+
+    reg.record_success(BreakerKind.CDP_RECONNECT)
+
+    snap = reg.snapshot()["cdp_reconnect"]
+    assert snap["open"] is False
+    assert snap["reason"] is None  # fully reset
+    assert snap["tripped_at"] is None
+
+
+def test_record_success_indefinite_auth_does_not_reset(monkeypatch):
+    """Case 4: open INDEFINITE (auth) breaker + success → does NOT reset. Auth
+    only recovers via explicit reset(), never via record_success."""
+    advance = _install_clock(monkeypatch)
+    reg = BreakerRegistry()
+
+    reg.trip(BreakerKind.AUTH_EXPIRED, "401", cooldown_s=0)
+    assert reg.is_open(BreakerKind.AUTH_EXPIRED) is True
+
+    advance(99999.0)
+    reg.record_success(BreakerKind.AUTH_EXPIRED)
+
+    assert reg.is_open(BreakerKind.AUTH_EXPIRED) is True
+    snap = reg.snapshot()["auth_required"]
+    assert snap["open"] is True
+    assert snap["reason"] == "401"
+
+
+# ── first_open + CircuitOpenError ─────────────────────────────────────
+
+
+def test_first_open_returns_none_when_all_closed():
+    """No open breakers → first_open returns None."""
+    reg = BreakerRegistry()
+    assert reg.first_open() is None
+
+
+def test_first_open_returns_first_open_kind(monkeypatch):
+    """first_open returns the first open kind in BreakerKind order; callers
+    raise CircuitOpenError themselves (registry stays read-only)."""
+    _install_clock(monkeypatch)
+    reg = BreakerRegistry()
+    reg.trip(BreakerKind.CDP_RECONNECT, "ws closed", cooldown_s=60.0)
+
+    kind = reg.first_open()
+    assert kind is BreakerKind.CDP_RECONNECT
+
+
+def test_circuit_open_error_carries_kind():
+    """CircuitOpenError carries the offending kind and renders kind.value."""
+    err = CircuitOpenError(BreakerKind.COMPOSER_SEND_READINESS)
+    assert err.kind is BreakerKind.COMPOSER_SEND_READINESS
+    assert "composer_send_readiness" in str(err)
+    assert isinstance(err, RuntimeError)
 
 
 def test_is_open_false_for_never_tripped():

--- a/tests/test_conversation_guard.py
+++ b/tests/test_conversation_guard.py
@@ -246,6 +246,8 @@ async def test_rest_auto_continue_invokes_ensure_current(monkeypatch):
     server._request_count = 0
     server._cdp_port = 9222
     server._config = srv.Config.load(None)
+    server._breakers = srv.BreakerRegistry()  # Phase 4 PR2: preflight reads this
+    server._last_error = None
     driver = MagicMock()
     driver._current_conv_id = "conv-rest-1"
     driver._current_model = None


### PR DESCRIPTION
## Phase 4 PR2 — Breaker signal wiring + fail-fast

Builds on PR1 (`#18`, merged). Activates the breaker registry from plumbing-only into the live contract: real failure signals, threshold enforcement, half-open recovery, and REST/MCP fail-fast.

### What ships
- **Auto-trip**: `record_failure` now trips a breaker once the per-kind threshold is met (3 composer/120s, 5 CDP/120s, 3 crash/300s). Auth uses explicit `trip()` — not a rolling count.
- **Typed exceptions**: `SendReadinessError`, `CDPReconnectError` replace bare `RuntimeError` at the four composer sites and the reconnect site, so the breaker classifies explicitly (never via catch-all).
- **Half-open recovery**: `record_success` after a confirmed send / successful reconnect resets a past-cooldown breaker to closed. Auth stays indefinite until explicit `reset()`.
- **Per-process registry** (driver-owned DI): REST shares one registry across Chrome + CDPDriver + APIServer; MCP has its own for its driver. No singleton, no IPC, no cross-process propagation.
- **Fail-fast**: `CircuitOpenError` (in `breakers.py`, not the driver) drives REST 503 `circuit_open` + MCP `isError` `(circuit_open, kind=...)`, via `first_open()`. REST pre-locks; streaming pre-`prepare()` only.
- **`/health` status string unchanged** — snapshot only. Status-policy deferred to PR3.

### Not in scope (PR3)
- `/health` status downgrade (healthy→degraded on open breaker)
- Config tunables (`W2A_BREAKER_*`)
- Cross-process breaker propagation

### Test coverage (+13 tests, 382 total)
- `record_success` 4-case matrix pinned (closed/within-cooldown/half-open/indefinite-auth)
- Threshold auto-trip + kind isolation
- REST 503 `circuit_open` for every `BreakerKind` (`kind.value` rendered)
- MCP open breaker → `isError` + token; closed breaker → proceeds normally

### Verification
- ruff check ✓ (all changed files clean)
- ruff format ✓ (all changed files clean)
- Full unit suite: **382 passed**, 0 failures