### PR TITLE
feat: /health status-policy + breaker-aware ensure reconcile

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -9,5 +9,8 @@
   "default_project_id": null,
   "api_keys": [],
   "request_timeout": 120,
-  "log_level": "INFO"
+  "log_level": "INFO",
+  "ensure_degraded_poll_interval_s": 2.0,
+  "ensure_degraded_poll_budget_s": 20.0,
+  "ensure_breaker_cooldown_grace_s": 5.0
 }

--- a/src/chatgpt_web2api/__main__.py
+++ b/src/chatgpt_web2api/__main__.py
@@ -165,7 +165,8 @@ def main() -> None:
         )
         ensure_parser = subparsers.add_parser(
             "ensure",
-            help="Point-in-time reconcile: make REST + SSE healthy, then exit (for ZCode hooks)",
+            help="Point-in-time reconcile: make REST + SSE healthy, then exit (for ZCode hooks). "
+            "Exit codes: 0 ready, 1 reconcile failure, 2 auth/login needed.",
         )
         ensure_parser.add_argument(
             "--rest-port", type=int, default=8080, help="REST API port to reconcile (default: 8080)"

--- a/src/chatgpt_web2api/api_server.py
+++ b/src/chatgpt_web2api/api_server.py
@@ -158,6 +158,18 @@ class APIServer:
         else:
             status = "healthy"
 
+        # An open breaker can only DOWNGRADE starting|healthy -> degraded. It
+        # must never override "broken" (Chrome down is a harder failure than a
+        # tripped circuit) and never force "broken" — auth_required is serious,
+        # but "broken" invites a destructive supervisor restart, while
+        # "degraded" correctly signals "up but refusing some/all traffic". A
+        # disconnect-degraded stays degraded (not worse).
+        if status in ("starting", "healthy") and self._breakers.first_open() is not None:
+            status = "degraded"
+
+        # Current-state summary, distinct from the historical/latching last_error.
+        open_kinds = [k.value for k in BreakerKind if self._breakers.is_open(k)]
+
         return web.json_response(
             {
                 "status": status,
@@ -168,6 +180,7 @@ class APIServer:
                 "started_at": self._started_at,
                 "last_successful_send_at": self._last_successful_send_at,
                 "last_error": self._last_error,
+                "open_breakers": open_kinds,
                 "breakers": self._breakers.snapshot(),
             }
         )

--- a/src/chatgpt_web2api/breakers.py
+++ b/src/chatgpt_web2api/breakers.py
@@ -202,8 +202,22 @@ class BreakerRegistry:
     def snapshot(self) -> dict[str, dict]:
         """JSON-serializable view of all breakers. Every kind is always present
         (even when untouched) so the ``/health`` shape is stable for consumers
-        like ``ensure.py`` that branch on it."""
+        like ``ensure.py`` that branch on it.
+
+        ``cooldown_seconds_remaining`` is a server-side-computed *duration*
+        (not an opaque ``time.monotonic()`` timestamp) so a separate process
+        such as ``ensure.py`` can reason about cooldown without comparing
+        monotonic clocks across the process boundary:
+
+          - ``None``    → closed breaker, OR sticky/indefinite (e.g. auth_required)
+          - positive    → seconds remaining for a currently-open timed trip
+          - ``0.0``     → past cooldown (half-open window)
+
+        Because ``None`` is overloaded, callers must infer an auth condition
+        from ``kind == "auth_required" and entry["open"]``, never from
+        ``cooldown_seconds_remaining is None``."""
         out: dict[str, dict] = {}
+        now = time.monotonic()
         for kind in BreakerKind:
             state = self._states[kind]
             self._prune(kind, state)
@@ -212,6 +226,11 @@ class BreakerRegistry:
                 "reason": state.reason,
                 "tripped_at": state.tripped_at,
                 "cooldown_until": state.cooldown_until,
+                "cooldown_seconds_remaining": (
+                    max(0.0, state.cooldown_until - now)
+                    if state.cooldown_until is not None
+                    else None
+                ),
                 "failures_in_window": len(state.recent_failures),
             }
         return out

--- a/src/chatgpt_web2api/config.py
+++ b/src/chatgpt_web2api/config.py
@@ -86,11 +86,23 @@ class LogConfig:
 
 
 @dataclass
+class EnsureConfig:
+    """Tunables for ``chatgpt-web2api ensure`` reconcile policy.
+
+    Narrow on purpose: only the values ensure reads. Breaker thresholds/windows
+    stay hardcoded (not configurable here)."""
+    degraded_poll_interval_s: float = 2.0
+    degraded_poll_budget_s: float = 20.0
+    breaker_cooldown_grace_s: float = 5.0
+
+
+@dataclass
 class Config:
     chrome: ChromeConfig = field(default_factory=ChromeConfig)
     server: ServerConfig = field(default_factory=ServerConfig)
     chatgpt: ChatGPTConfig = field(default_factory=ChatGPTConfig)
     log: LogConfig = field(default_factory=LogConfig)
+    ensure: EnsureConfig = field(default_factory=EnsureConfig)
 
     @classmethod
     def load(cls, path: str | None = None) -> Config:
@@ -166,6 +178,15 @@ class Config:
         c = data.get("log_file")
         if c:
             self.log.file = c
+        c = data.get("ensure_degraded_poll_interval_s")
+        if c is not None:
+            self.ensure.degraded_poll_interval_s = float(c)
+        c = data.get("ensure_degraded_poll_budget_s")
+        if c is not None:
+            self.ensure.degraded_poll_budget_s = float(c)
+        c = data.get("ensure_breaker_cooldown_grace_s")
+        if c is not None:
+            self.ensure.breaker_cooldown_grace_s = float(c)
 
     def _apply_env(self) -> None:
         _env = os.environ.get
@@ -190,6 +211,12 @@ class Config:
             self.chrome.headless = v.lower() in ("true", "1", "yes")
         if v := _env("W2A_LOG_LEVEL"):
             self.log.level = v
+        if v := _env("W2A_ENSURE_DEGRADED_POLL_INTERVAL_S"):
+            self.ensure.degraded_poll_interval_s = float(v)
+        if v := _env("W2A_ENSURE_DEGRADED_POLL_BUDGET_S"):
+            self.ensure.degraded_poll_budget_s = float(v)
+        if v := _env("W2A_ENSURE_BREAKER_COOLDOWN_GRACE_S"):
+            self.ensure.breaker_cooldown_grace_s = float(v)
 
     def to_dict(self) -> dict:
         return {
@@ -205,4 +232,7 @@ class Config:
             "tab_mode": self.chatgpt.tab_mode,
             "request_timeout": self.server.request_timeout,
             "log_level": self.log.level,
+            "ensure_degraded_poll_interval_s": self.ensure.degraded_poll_interval_s,
+            "ensure_degraded_poll_budget_s": self.ensure.degraded_poll_budget_s,
+            "ensure_breaker_cooldown_grace_s": self.ensure.breaker_cooldown_grace_s,
         }

--- a/src/chatgpt_web2api/ensure.py
+++ b/src/chatgpt_web2api/ensure.py
@@ -11,8 +11,12 @@ Pinned design (ROADMAP Phase 3):
     reconnect — give it 20s of polling before bouncing the browser)
   - lock-protected so concurrent ``ensure`` runs don't double-launch
 
-Exit codes: 0 when both REST and SSE are ready, nonzero with a diagnostic
-otherwise.
+Exit codes:
+  - 0: REST and SSE are ready
+  - 1: generic reconcile failure (REST/SSE could not be made ready)
+  - 2: auth/login needed — REST degraded because the ``auth_required`` breaker
+       is open. REST is NOT restarted and SSE is NOT reconciled in this case;
+       a human re-auth is required.
 """
 
 from __future__ import annotations
@@ -27,6 +31,7 @@ import subprocess
 import sys
 import time
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 
 from mcp import ClientSession
@@ -38,15 +43,102 @@ logger = logging.getLogger(__name__)
 
 # Bounded wait for REST to resolve starting/degraded before we act.
 _REST_HEALTHY_TIMEOUT = 30.0
-# Degraded-REST grace window: poll every 2s for up to 20s before restarting.
-_DEGRADED_POLL_INTERVAL = 2.0
-_DEGRADED_POLL_BUDGET = 20.0
 # Startup lock: bounded contention wait.
 _LOCK_TIMEOUT = 10.0
 _LOCK_CONTENTION_RECHECK_INTERVAL = 3.0
 _LOCK_CONTENTION_RECHECK_TRIES = 3
 # SSE readiness: TCP preflight then real MCP handshake.
 _SSE_VERIFY_TIMEOUT = 15.0
+
+
+# Default ensure-policy tunables. Overridable via the ``ensure`` config section
+# / ``W2A_ENSURE_*`` env (see EnsureConfig). Module constants stay as the
+# built-in defaults used when no config is loaded.
+_DEFAULT_DEGRADED_POLL_INTERVAL = 2.0
+_DEFAULT_DEGRADED_POLL_BUDGET = 20.0
+_DEFAULT_BREAKER_COOLDOWN_GRACE = 5.0
+
+
+@dataclass(frozen=True)
+class EnsurePolicy:
+    """Ensure-side reconcile tunables, sourced from ``EnsureConfig``.
+
+    Kept separate from ``Config`` so the reconcile logic depends on a tiny
+    frozen value object rather than the whole config tree."""
+
+    degraded_poll_interval_s: float = _DEFAULT_DEGRADED_POLL_INTERVAL
+    degraded_poll_budget_s: float = _DEFAULT_DEGRADED_POLL_BUDGET
+    breaker_cooldown_grace_s: float = _DEFAULT_BREAKER_COOLDOWN_GRACE
+
+
+@dataclass(frozen=True)
+class DegradedBreakerState:
+    """Why REST is degraded, per the ``/health`` breaker snapshot.
+
+    - ``auth_open``: the sticky ``auth_required`` breaker is open (needs login).
+    - ``timed_open_kind``: a timed breaker (composer/cdp/chrome) is open.
+    - ``cooldown_remaining_s``: seconds left on that timed trip; ``None`` means
+      the value was missing/malformed (treat as legacy degraded).
+    """
+
+    auth_open: bool = False
+    timed_open_kind: str | None = None
+    cooldown_remaining_s: float | None = None
+
+
+@dataclass(frozen=True)
+class RestReconcileResult:
+    """Outcome of ``_reconcile_rest``. ``auth_needed`` short-circuits SSE."""
+
+    ok: bool
+    auth_needed: bool = False
+
+
+def _classify_degraded_breakers(breakers: dict) -> DegradedBreakerState:
+    """Classify a degraded-REST cause from the ``/health`` breaker snapshot.
+
+    Returns the first open breaker encountered. Auth is identified by
+    ``kind == "auth_required"`` — NEVER by ``cooldown_seconds_remaining is None``
+    (that field is overloaded: None also means a closed breaker). Any non-auth
+    open breaker is reported as a timed trip with its remaining cooldown.
+
+    Missing/malformed ``cooldown_seconds_remaining`` yields
+    ``cooldown_remaining_s=None``; the caller treats that as legacy degraded
+    behavior (no immediate restart). Health JSON is internal, but a partial
+    shape (older REST, hand-edited fixture) should fall back gracefully rather
+    than crash ``ensure``.
+    """
+    for kind, entry in breakers.items():
+        if not entry.get("open"):
+            continue
+        if kind == "auth_required":
+            return DegradedBreakerState(auth_open=True)
+        remaining = entry.get("cooldown_seconds_remaining")
+        try:
+            cooldown = float(remaining) if remaining is not None else None
+        except (TypeError, ValueError):
+            cooldown = None
+        return DegradedBreakerState(timed_open_kind=kind, cooldown_remaining_s=cooldown)
+    return DegradedBreakerState()
+
+
+def _load_ensure_policy(config_path: str | None) -> EnsurePolicy:
+    """Load the ensure-policy tunables from config. Reads ONLY ``cfg.ensure`` —
+    never lets ``cfg.server.port`` / ``cfg.chrome.cdp_port`` override the
+    explicit ``run_ensure`` port arguments (those remain authoritative). Falls
+    back to module defaults if config loading fails or the section is absent."""
+    try:
+        from chatgpt_web2api.config import Config
+
+        cfg = Config.load(config_path)
+        return EnsurePolicy(
+            degraded_poll_interval_s=cfg.ensure.degraded_poll_interval_s,
+            degraded_poll_budget_s=cfg.ensure.degraded_poll_budget_s,
+            breaker_cooldown_grace_s=cfg.ensure.breaker_cooldown_grace_s,
+        )
+    except Exception as e:
+        logger.debug("ensure config load failed (%s) — using defaults", e)
+        return EnsurePolicy()
 
 
 class _StartupLock:
@@ -407,43 +499,171 @@ async def _wait_rest_ready(rest_port: int, timeout: float) -> bool:
 
 
 async def _reconcile_rest(
-    rest_port: int, cdp_port: int, config_path: str | None, log_level: str | None
-) -> bool:
-    """Apply the degraded-REST policy and wait for ready. Returns True when
-    REST is ready for ensure, False if it can't be made ready."""
+    rest_port: int,
+    cdp_port: int,
+    config_path: str | None,
+    log_level: str | None,
+    policy: EnsurePolicy,
+) -> RestReconcileResult:
+    """Apply the degraded-REST policy and wait for ready.
+
+    Returns ``RestReconcileResult(ok=True)`` when REST is ready for ensure,
+    ``ok=False`` otherwise. ``auth_needed=True`` signals the sticky
+    ``auth_required`` breaker is open — REST must NOT be restarted and SSE must
+    NOT be reconciled; a human re-auth is required (``run_ensure`` returns 2)."""
     h = _rest_health(rest_port)
     if h is None:
         logger.info("REST missing — starting")
         _launch_detached(_build_rest_cmd(rest_port, cdp_port, config_path, log_level))
-        return await _wait_rest_ready(rest_port, _REST_HEALTHY_TIMEOUT)
+        ok = await _wait_rest_ready(rest_port, _REST_HEALTHY_TIMEOUT)
+        return RestReconcileResult(ok=ok)
 
     status = h.get("status", "broken")
     if status in ("healthy", "starting") and _rest_ready_for_ensure(h):
         logger.info("REST ready (status=%s)", status)
-        return True
+        return RestReconcileResult(ok=True)
 
     if status == "broken":
         logger.info("REST broken (Chrome down) — restarting")
-        return await _restart_rest(rest_port, cdp_port, config_path, log_level)
+        ok = await _restart_rest(rest_port, cdp_port, config_path, log_level)
+        return RestReconcileResult(ok=ok)
 
     if status == "degraded":
-        # PINNED: degraded may be a transient CDP reconnect. Wait before bouncing.
-        logger.info("REST degraded — waiting up to %.0fs before restart", _DEGRADED_POLL_BUDGET)
-        deadline = time.monotonic() + _DEGRADED_POLL_BUDGET
-        while time.monotonic() < deadline:
-            await asyncio.sleep(_DEGRADED_POLL_INTERVAL)
-            h = _rest_health(rest_port)
-            if _rest_ready_for_ensure(h):
-                logger.info("REST recovered from degraded/starting")
-                return True
-            if h and h.get("status") == "broken":
-                break  # fall through to restart
-        logger.info("REST still degraded after %.0fs — restarting", _DEGRADED_POLL_BUDGET)
-        return await _restart_rest(rest_port, cdp_port, config_path, log_level)
+        return await _reconcile_degraded(rest_port, cdp_port, config_path, log_level, policy, h)
 
     # starting without full connectivity — wait for it to resolve
     logger.info("REST starting (not fully connected) — waiting")
-    return await _wait_rest_ready(rest_port, _REST_HEALTHY_TIMEOUT)
+    ok = await _wait_rest_ready(rest_port, _REST_HEALTHY_TIMEOUT)
+    return RestReconcileResult(ok=ok)
+
+
+async def _reconcile_degraded(
+    rest_port: int,
+    cdp_port: int,
+    config_path: str | None,
+    log_level: str | None,
+    policy: EnsurePolicy,
+    h: dict,
+) -> RestReconcileResult:
+    """Breaker-aware degraded-REST reconcile.
+
+    Dispatch on the ``/health`` breaker snapshot (read fresh each poll):
+
+      - ``auth_required`` open → login needed. Do NOT restart, do NOT poll.
+        Return ``auth_needed`` immediately.
+      - a timed breaker open with a known cooldown → wait up to
+        ``cooldown + grace`` for it to half-open/recover before restarting.
+      - a timed breaker open with an unknown/missing cooldown (legacy/malformed
+        health) OR no open breaker → legacy degraded behavior: poll the existing
+        ``degraded_poll_budget_s`` window, then restart.
+
+    A timed breaker that is still open past ``cooldown + grace`` is stuck
+    (half-open recovery isn't progressing) → restart. At the exact cooldown
+    boundary (``cooldown_seconds_remaining <= 0`` but still open) we re-fetch
+    health once before restarting, to avoid racing a recovery in flight.
+    """
+    cls = _classify_degraded_breakers(h.get("breakers", {}))
+
+    # Auth: sticky breaker, needs human login. Never restart for this.
+    if cls.auth_open:
+        logger.warning(
+            "REST degraded: auth_required breaker open — login needed "
+            "(manual re-auth required); not restarting REST"
+        )
+        return RestReconcileResult(ok=False, auth_needed=True)
+
+    # Timed breaker with a known cooldown: wait for it to recover.
+    if cls.timed_open_kind is not None and cls.cooldown_remaining_s is not None:
+        return await _wait_timed_breaker(
+            rest_port, cdp_port, config_path, log_level, policy, cls
+        )
+
+    # Legacy degraded: no open breaker info (transient CDP reconnect, older
+    # REST, or malformed snapshot). Poll the standard budget before bouncing.
+    logger.info(
+        "REST degraded — waiting up to %.0fs before restart", policy.degraded_poll_budget_s
+    )
+    deadline = time.monotonic() + policy.degraded_poll_budget_s
+    while time.monotonic() < deadline:
+        await asyncio.sleep(policy.degraded_poll_interval_s)
+        h = _rest_health(rest_port)
+        if _rest_ready_for_ensure(h):
+            logger.info("REST recovered from degraded")
+            return RestReconcileResult(ok=True)
+        if h and h.get("status") == "broken":
+            break  # fall through to restart
+        # An auth breaker may open mid-poll (e.g. session lapsed during wait).
+        cls = _classify_degraded_breakers((h or {}).get("breakers", {}))
+        if cls.auth_open:
+            logger.warning(
+                "REST degraded: auth_required breaker open — login needed; not restarting"
+            )
+            return RestReconcileResult(ok=False, auth_needed=True)
+    logger.info("REST still degraded after %.0fs — restarting", policy.degraded_poll_budget_s)
+    ok = await _restart_rest(rest_port, cdp_port, config_path, log_level)
+    return RestReconcileResult(ok=ok)
+
+
+async def _wait_timed_breaker(
+    rest_port: int,
+    cdp_port: int,
+    config_path: str | None,
+    log_level: str | None,
+    policy: EnsurePolicy,
+    cls: DegradedBreakerState,
+) -> RestReconcileResult:
+    """Wait for a timed breaker to half-open/recover, then fall back to restart.
+
+    Deadline is ``cooldown_remaining + grace``. On each tick: recovered → ok;
+    status ``broken`` → restart immediately; still open at ``cooldown<=0`` →
+    re-fetch health once (a recovery may be in flight at the boundary) and only
+    restart if it is still open after that re-fetch.
+    """
+    cooldown = cls.cooldown_remaining_s or 0.0
+    budget = cooldown + policy.breaker_cooldown_grace_s
+    logger.info(
+        "REST degraded: timed breaker '%s' open — waiting up to %.1fs "
+        "(cooldown %.1fs + grace %.1fs) for recovery",
+        cls.timed_open_kind,
+        budget,
+        cooldown,
+        policy.breaker_cooldown_grace_s,
+    )
+    deadline = time.monotonic() + budget
+    while time.monotonic() < deadline:
+        await asyncio.sleep(policy.degraded_poll_interval_s)
+        h = _rest_health(rest_port)
+        if _rest_ready_for_ensure(h):
+            logger.info("REST recovered from degraded (breaker closed)")
+            return RestReconcileResult(ok=True)
+        if h and h.get("status") == "broken":
+            break  # fall through to restart
+        cur = _classify_degraded_breakers((h or {}).get("breakers", {}))
+        if cur.auth_open:
+            logger.warning(
+                "REST degraded: auth_required breaker open — login needed; not restarting"
+            )
+            return RestReconcileResult(ok=False, auth_needed=True)
+        remaining = cur.cooldown_remaining_s
+        if (
+            cur.timed_open_kind is not None
+            and remaining is not None
+            and remaining <= 0
+        ):
+            # Boundary: cooldown just elapsed and a half-open probe may be in
+            # flight. Re-fetch once before deciding to restart.
+            logger.info("Timed breaker at cooldown boundary — re-fetching health once")
+            h2 = _rest_health(rest_port)
+            if _rest_ready_for_ensure(h2):
+                return RestReconcileResult(ok=True)
+            cur2 = _classify_degraded_breakers((h2 or {}).get("breakers", {}))
+            if not cur2.timed_open_kind and not cur2.auth_open:
+                # Breaker cleared on the re-fetch — recovered.
+                return RestReconcileResult(ok=True)
+            break  # still open → restart
+    logger.info("Timed breaker still open past cooldown+grace — restarting")
+    ok = await _restart_rest(rest_port, cdp_port, config_path, log_level)
+    return RestReconcileResult(ok=ok)
 
 
 async def _reconcile_sse(
@@ -486,7 +706,17 @@ async def run_ensure(
     config_path: str | None = None,
     log_level: str | None = None,
 ) -> int:
-    """Point-in-time reconcile of REST + SSE. Returns 0 on ready, nonzero on failure."""
+    """Point-in-time reconcile of REST + SSE.
+
+    Exit codes:
+      - 0: REST + SSE ready
+      - 1: generic reconcile failure
+      - 2: auth/login needed (auth_required breaker open; REST not restarted,
+           SSE not reconciled)
+    """
+    # Ensure-policy tunables come from config (cfg.ensure ONLY); explicit
+    # run_ensure port args remain authoritative and are never overridden.
+    policy = _load_ensure_policy(config_path)
     lock = _StartupLock(sse_port)
     try:
         await lock.__aenter__()
@@ -496,11 +726,20 @@ async def run_ensure(
         logger.info("Startup lock held — waiting for another ensure to finish")
         for _ in range(_LOCK_CONTENTION_RECHECK_TRIES):
             await asyncio.sleep(_LOCK_CONTENTION_RECHECK_INTERVAL)
-            rest_ok = _rest_ready_for_ensure(_rest_health(rest_port))
+            h = _rest_health(rest_port)
+            rest_ok = _rest_ready_for_ensure(h)
             sse_ok = _sse_tcp_up(sse_port) and await _sse_verify(sse_port)
             if rest_ok and sse_ok:
                 print("REST + SSE ready (another ensure succeeded)")
                 return 0
+            # Surface the auth case distinctly even under contention.
+            if h and h.get("status") == "degraded":
+                if _classify_degraded_breakers(h.get("breakers", {})).auth_open:
+                    print(
+                        "REST degraded: auth_required breaker open — login needed.",
+                        file=sys.stderr,
+                    )
+                    return 2
         print(
             "ERROR: another ensure is running and services are still not ready.",
             file=sys.stderr,
@@ -508,7 +747,15 @@ async def run_ensure(
         return 1
 
     try:
-        if not await _reconcile_rest(rest_port, cdp_port, config_path, log_level):
+        result = await _reconcile_rest(rest_port, cdp_port, config_path, log_level, policy)
+        if not result.ok:
+            if result.auth_needed:
+                # Auth needed: do NOT reconcile SSE — a login is required first.
+                print(
+                    "REST degraded: auth_required breaker open — login needed.",
+                    file=sys.stderr,
+                )
+                return 2
             print("ERROR: REST did not become healthy.", file=sys.stderr)
             return 1
         if not await _reconcile_sse(sse_port, cdp_port, config_path, log_level):

--- a/src/chatgpt_web2api/ensure.py
+++ b/src/chatgpt_web2api/ensure.py
@@ -592,13 +592,26 @@ async def _reconcile_degraded(
             return RestReconcileResult(ok=True)
         if h and h.get("status") == "broken":
             break  # fall through to restart
-        # An auth breaker may open mid-poll (e.g. session lapsed during wait).
+        # A breaker may open mid-poll (e.g. session lapsed or a timed trip
+        # fires during the wait). Reclassify and dispatch accordingly.
         cls = _classify_degraded_breakers((h or {}).get("breakers", {}))
         if cls.auth_open:
             logger.warning(
                 "REST degraded: auth_required breaker open — login needed; not restarting"
             )
             return RestReconcileResult(ok=False, auth_needed=True)
+        # A timed breaker opened with a known cooldown: switch to the
+        # cooldown+grace wait rather than letting the (possibly shorter)
+        # legacy budget expire into a premature restart.
+        if cls.timed_open_kind is not None and cls.cooldown_remaining_s is not None:
+            logger.info(
+                "Timed breaker '%s' opened during degraded poll — switching to "
+                "cooldown+grace wait",
+                cls.timed_open_kind,
+            )
+            return await _wait_timed_breaker(
+                rest_port, cdp_port, config_path, log_level, policy, cls
+            )
     logger.info("REST still degraded after %.0fs — restarting", policy.degraded_poll_budget_s)
     ok = await _restart_rest(rest_port, cdp_port, config_path, log_level)
     return RestReconcileResult(ok=ok)
@@ -656,11 +669,21 @@ async def _wait_timed_breaker(
             h2 = _rest_health(rest_port)
             if _rest_ready_for_ensure(h2):
                 return RestReconcileResult(ok=True)
+            if h2 and h2.get("status") == "broken":
+                break  # fall through to restart
             cur2 = _classify_degraded_breakers((h2 or {}).get("breakers", {}))
-            if not cur2.timed_open_kind and not cur2.auth_open:
-                # Breaker cleared on the re-fetch — recovered.
-                return RestReconcileResult(ok=True)
-            break  # still open → restart
+            if cur2.auth_open:
+                logger.warning(
+                    "REST degraded: auth_required breaker open — login needed; not restarting"
+                )
+                return RestReconcileResult(ok=False, auth_needed=True)
+            if cur2.timed_open_kind is not None:
+                break  # still timed-open after boundary re-fetch → restart
+            # No breaker open on h2, but REST is still not ready (e.g.
+            # driver_connected=false). Do NOT return ok=True — keep polling
+            # the remaining deadline so we don't proceed to SSE on an
+            # unready REST.
+    logger.info("Timed breaker still open past cooldown+grace — restarting")
     logger.info("Timed breaker still open past cooldown+grace — restarting")
     ok = await _restart_rest(rest_port, cdp_port, config_path, log_level)
     return RestReconcileResult(ok=ok)

--- a/tests/test_breakers.py
+++ b/tests/test_breakers.py
@@ -55,6 +55,7 @@ def test_snapshot_closed_initially():
         assert entry["reason"] is None
         assert entry["tripped_at"] is None
         assert entry["cooldown_until"] is None
+        assert entry["cooldown_seconds_remaining"] is None
         assert entry["failures_in_window"] == 0
 
 
@@ -185,6 +186,41 @@ def test_trip_records_reason_and_tripped_at(monkeypatch):
     assert snap["tripped_at"] == 500.0
     assert snap["cooldown_until"] == 530.0
     assert snap["open"] is True
+
+
+def test_snapshot_cooldown_seconds_remaining_counts_down(monkeypatch):
+    """cooldown_seconds_remaining is a duration (not a monotonic timestamp) that
+    decreases as the clock advances and hits 0.0 once past cooldown (half-open).
+    A separate process like ensure.py can reason about it without comparing
+    monotonic clocks across the boundary."""
+    advance = _install_clock(monkeypatch, start=1000.0)
+    reg = BreakerRegistry()
+
+    reg.trip(BreakerKind.CDP_RECONNECT, "ws closed", cooldown_s=60.0)
+    snap = reg.snapshot()["cdp_reconnect"]
+    assert snap["open"] is True
+    assert snap["cooldown_seconds_remaining"] == 60.0
+
+    advance(20.0)  # 40s left
+    assert reg.snapshot()["cdp_reconnect"]["cooldown_seconds_remaining"] == 40.0
+
+    advance(40.0)  # exactly past cooldown → half-open, floored to 0.0
+    snap = reg.snapshot()["cdp_reconnect"]
+    assert snap["cooldown_seconds_remaining"] == 0.0
+    assert snap["open"] is False
+
+
+def test_snapshot_auth_trip_cooldown_seconds_remaining_is_none(monkeypatch):
+    """A sticky (indefinite) auth trip has cooldown_seconds_remaining == None —
+    the same value a CLOSED breaker yields. Callers must infer auth from
+    kind=='auth_required' & open, never from cooldown_seconds_remaining is None."""
+    _install_clock(monkeypatch)
+    reg = BreakerRegistry()
+
+    reg.trip(BreakerKind.AUTH_EXPIRED, "401", cooldown_s=0)
+    snap = reg.snapshot()["auth_required"]
+    assert snap["open"] is True
+    assert snap["cooldown_seconds_remaining"] is None
 
 
 def test_reset_clears_a_tripped_breaker():

--- a/tests/test_config_bind.py
+++ b/tests/test_config_bind.py
@@ -117,3 +117,53 @@ def test_bind_safety_error_names_the_override():
     except RuntimeError as e:
         assert "W2A_ALLOW_UNAUTH_REMOTE" in str(e)
 
+
+# ── A3: ensure config tunables (PR3) ───────────────────────────────────
+
+
+def test_ensure_config_defaults_when_absent(tmp_path, monkeypatch):
+    """No ensure_* keys in config → built-in EnsureConfig defaults."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    cfg = Config.load(None)
+    assert cfg.ensure.degraded_poll_interval_s == 2.0
+    assert cfg.ensure.degraded_poll_budget_s == 20.0
+    assert cfg.ensure.breaker_cooldown_grace_s == 5.0
+
+
+def test_ensure_config_loaded_from_file(tmp_path, monkeypatch):
+    """ensure_* keys in a config file populate EnsureConfig."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    cfg_file = tmp_path / "cfg.json"
+    cfg_file.write_text(json.dumps({
+        "ensure_degraded_poll_interval_s": 1.5,
+        "ensure_degraded_poll_budget_s": 7.0,
+        "ensure_breaker_cooldown_grace_s": 3.0,
+    }))
+    cfg = Config.load(str(cfg_file))
+    assert cfg.ensure.degraded_poll_interval_s == 1.5
+    assert cfg.ensure.degraded_poll_budget_s == 7.0
+    assert cfg.ensure.breaker_cooldown_grace_s == 3.0
+
+
+def test_ensure_config_env_overrides(monkeypatch, tmp_path):
+    """W2A_ENSURE_* env vars override config + defaults."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("W2A_ENSURE_DEGRADED_POLL_BUDGET_S", "9.0")
+    monkeypatch.setenv("W2A_ENSURE_BREAKER_COOLDOWN_GRACE_S", "2.0")
+    cfg = Config.load(None)
+    assert cfg.ensure.degraded_poll_budget_s == 9.0
+    assert cfg.ensure.breaker_cooldown_grace_s == 2.0
+
+
+def test_ensure_config_to_dict_roundtrip():
+    """to_dict serializes the ensure tunables (flat keys)."""
+    cfg = Config()
+    cfg.ensure.degraded_poll_budget_s = 11.0
+    d = cfg.to_dict()
+    assert d["ensure_degraded_poll_interval_s"] == 2.0
+    assert d["ensure_degraded_poll_budget_s"] == 11.0
+    assert d["ensure_breaker_cooldown_grace_s"] == 5.0
+

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -996,3 +996,139 @@ async def test_config_does_not_override_explicit_ports(monkeypatch, tmp_path):
     assert all(p == 8080 for p in seen_ports), (
         f"config port must not override explicit arg: {seen_ports}"
     )
+
+
+# ── 20. PR3 review blockers: boundary & legacy-loop edge cases ────────
+
+
+@pytest.mark.asyncio
+async def test_timed_boundary_not_ready_does_not_return_ok(monkeypatch):
+    """Blocker 1 regression: at the cooldown boundary, the re-fetch (h2) may
+    show degraded + no open breaker + driver disconnected. That is NOT ready,
+    so the boundary branch must NOT return ok=True. It must keep polling (or
+    restart) rather than proceeding to SSE on an unready REST.
+
+    Sequence:
+      idx0: initial health in _reconcile_rest — timed open, cooldown=0.0
+            (boundary) → _wait_timed_breaker entered, first poll tick consumes idx1
+      idx1: still timed-open at cooldown 0.0 → boundary re-fetch consumes idx2
+      idx2: degraded, NO open breaker, driver_connected=False (not ready)
+            → must NOT return ok=True here; continue polling
+      idx3+: healthy → recovers legitimately via _rest_ready_for_ensure
+    """
+    _install_virtual_clock(monkeypatch)
+    boundary = _timed_open_health("cdp_reconnect", 0.0)
+    not_ready_no_breaker = {
+        "status": "degraded",
+        "chrome_running": True,
+        "cdp_connected": False,
+        "driver_connected": False,  # not ready
+        "breakers": {
+            "auth_required": _breaker_entry(False),
+            "composer_send_readiness": _breaker_entry(False),
+            "cdp_reconnect": _breaker_entry(False),  # breaker cleared
+            "chrome_crash_loop": _breaker_entry(False),
+        },
+    }
+    health_calls = _patch_health(
+        monkeypatch,
+        [boundary, boundary, not_ready_no_breaker, {"status": "healthy"}],
+    )
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    # It must NOT have short-circuited ok=True at idx2 (the unready no-breaker
+    # health). Proof: it consumed MORE than 3 health calls (kept polling past
+    # the boundary re-fetch until idx3 returned genuinely healthy).
+    assert health_calls["n"] > 3, (
+        f"must keep polling past the unready boundary re-fetch (calls={health_calls['n']})"
+    )
+    assert launches == [], "must not restart — it recovered via continued polling"
+
+
+@pytest.mark.asyncio
+async def test_timed_boundary_not_ready_eventually_restarts(monkeypatch):
+    """Blocker 1 regression (restart variant): boundary re-fetch is unready +
+    no breaker, and REST never recovers → must restart rather than exit 0 on
+    an unready REST."""
+    _install_virtual_clock(monkeypatch)
+    boundary = _timed_open_health("cdp_reconnect", 0.0)
+    not_ready_no_breaker = {
+        "status": "degraded",
+        "chrome_running": True,
+        "cdp_connected": False,
+        "driver_connected": False,
+        "breakers": {
+            "auth_required": _breaker_entry(False),
+            "composer_send_readiness": _breaker_entry(False),
+            "cdp_reconnect": _breaker_entry(False),
+            "chrome_crash_loop": _breaker_entry(False),
+        },
+    }
+    # boundary → boundary → unready-no-breaker, then stays unready until the
+    # timed deadline (cooldown 0 + grace 5 = 5s budget) expires → restart →
+    # _wait_rest_ready → healthy.
+    _patch_health(
+        monkeypatch,
+        [boundary, boundary, not_ready_no_breaker] + [not_ready_no_breaker] * 10 + [{"status": "healthy"}],
+    )
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+    _patch_listener_stop(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    # Must have restarted (never returned ok=True on the unready health).
+    assert len(launches) == 1, "must restart when REST stays unready past the timed budget"
+
+
+@pytest.mark.asyncio
+async def test_legacy_degraded_loop_dispatches_timed_breaker_mid_poll(monkeypatch):
+    """Blocker 2 regression: a timed breaker that opens during the legacy
+    degraded poll (with a cooldown LARGER than the legacy budget) must dispatch
+    to _wait_timed_breaker instead of restarting at the legacy budget. The
+    legacy budget is 20s; a cooldown of 30s would be cut short without the fix.
+
+    Sequence:
+      idx0: degraded, no open breakers → enters legacy loop
+      idx1: first poll — timed breaker now open, cooldown_remaining=30.0
+            → dispatches to _wait_timed_breaker (NOT legacy restart)
+      idx2: recovered healthy (within cooldown+grace wait)
+    """
+    t = _install_virtual_clock(monkeypatch)
+    no_breaker_degraded = {
+        "status": "degraded",
+        "breakers": {
+            "auth_required": _breaker_entry(False),
+            "composer_send_readiness": _breaker_entry(False),
+            "cdp_reconnect": _breaker_entry(False),
+            "chrome_crash_loop": _breaker_entry(False),
+        },
+    }
+    _patch_health(
+        monkeypatch,
+        [
+            no_breaker_degraded,  # idx0: legacy degraded, no breakers
+            _timed_open_health("cdp_reconnect", 30.0),  # idx1: timed opens mid-poll
+            {"status": "healthy"},  # idx2: recovers
+        ],
+    )
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert launches == [], "must NOT restart — dispatched to timed wait and recovered"
+    # Must NOT have restarted at the 20s legacy budget (the timed wait was used
+    # instead). It recovered on the first timed poll tick, well under 20s.
+    assert t[0] < 20.0, (
+        f"must use timed-wait dispatch, not legacy 20s budget (t={t[0]})"
+    )

--- a/tests/test_ensure.py
+++ b/tests/test_ensure.py
@@ -725,3 +725,274 @@ def test_find_listener_pid_ss_picks_correct_pid_among_many(monkeypatch):
     with patch.object(ensure_mod.subprocess, "check_output", return_value=ss_output):
         assert ensure_mod._find_listener_pid_ss(80) == 7
         assert ensure_mod._find_listener_pid_ss(8080) == 123
+
+
+# ── 19. PR3: breaker-aware degraded reconcile ───────────────────────────
+
+
+def _breaker_entry(open_: bool, cooldown_remaining=None):
+    """Minimal breaker snapshot entry."""
+    return {"open": open_, "cooldown_seconds_remaining": cooldown_remaining}
+
+
+def _auth_open_health():
+    return {
+        "status": "degraded",
+        "breakers": {
+            "auth_required": _breaker_entry(True, None),
+            "composer_send_readiness": _breaker_entry(False),
+            "cdp_reconnect": _breaker_entry(False),
+            "chrome_crash_loop": _breaker_entry(False),
+        },
+    }
+
+
+def _timed_open_health(kind, cooldown_remaining):
+    entries = {
+        "auth_required": _breaker_entry(False),
+        "composer_send_readiness": _breaker_entry(False),
+        "cdp_reconnect": _breaker_entry(False),
+        "chrome_crash_loop": _breaker_entry(False),
+    }
+    entries[kind] = _breaker_entry(True, cooldown_remaining)
+    return {"status": "degraded", "breakers": entries}
+
+
+@pytest.mark.asyncio
+async def test_degraded_open_auth_returns_exit_2(monkeypatch):
+    """degraded + open auth_required → exit 2, no restart, no listener stop,
+    no 20s wait."""
+    t = _install_virtual_clock(monkeypatch)
+    _patch_health(monkeypatch, [_auth_open_health()])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+    stop_calls = _patch_listener_stop(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 2
+    assert launches == [], "must NOT restart REST for auth_required"
+    assert stop_calls["stopped_ports"] == [], "must NOT stop listener for auth_required"
+    # No 20s wait — auth short-circuits immediately
+    assert t[0] < 5.0, f"must not poll for auth case (t={t[0]})"
+
+
+@pytest.mark.asyncio
+async def test_auth_needed_skips_sse_reconcile(monkeypatch):
+    """auth_needed must short-circuit BEFORE _reconcile_sse — SSE is not
+    reconciled when a login is required."""
+    _install_virtual_clock(monkeypatch)
+    _patch_health(monkeypatch, [_auth_open_health()])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    sse_calls = []
+    original_sse = ensure_mod._reconcile_sse
+
+    async def tracking_sse(*a, **kw):
+        sse_calls.append(a)
+        return await original_sse(*a, **kw)
+
+    monkeypatch.setattr(ensure_mod, "_reconcile_sse", tracking_sse)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 2
+    assert sse_calls == [], "_reconcile_sse must NOT be called when auth is needed"
+
+
+@pytest.mark.asyncio
+async def test_lock_contention_degraded_open_auth_returns_2(monkeypatch):
+    """Under lock contention, degraded + open auth → exit 2 (not generic 1),
+    so concurrent hooks see the auth case distinctly."""
+    _install_virtual_clock(monkeypatch)
+
+    class HeldLock:
+        async def __aenter__(self):
+            raise ensure_mod.LockAcquisitionError("held")
+
+        async def __aexit__(self, *a):
+            pass
+
+    monkeypatch.setattr(ensure_mod, "_StartupLock", lambda *a, **kw: HeldLock())
+    _patch_health(monkeypatch, [_auth_open_health()])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 2
+    assert launches == []
+
+
+@pytest.mark.asyncio
+async def test_degraded_open_timed_breaker_waits_then_recovers(monkeypatch):
+    """degraded + open timed breaker with known cooldown → waits cooldown+grace,
+    breaker closes → recovers without restart."""
+    t = _install_virtual_clock(monkeypatch)
+    # idx0: initial health in _reconcile_rest (timed open, cooldown=3.0)
+    # idx1: first poll (still open, cooldown=1.0)
+    # idx2: second poll (recovered → healthy)
+    _patch_health(
+        monkeypatch,
+        [
+            _timed_open_health("cdp_reconnect", 3.0),
+            _timed_open_health("cdp_reconnect", 1.0),
+            {"status": "healthy"},
+        ],
+    )
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert launches == [], "should NOT restart — timed breaker recovered"
+    # Must have waited at least one poll tick (cooldown was 3.0, grace 5.0)
+    assert t[0] >= 2.0
+
+
+@pytest.mark.asyncio
+async def test_timed_breaker_stuck_past_cooldown_restarts(monkeypatch):
+    """Timed breaker stays open past cooldown+grace → restart."""
+    t = _install_virtual_clock(monkeypatch)
+    # cooldown=2.0, grace=5.0 → budget=7.0, polls at t=2,4,6. Still open each
+    # time. After deadline → restart → _wait_rest_ready → healthy.
+    stuck = _timed_open_health("cdp_reconnect", 2.0)
+    _patch_health(monkeypatch, [stuck] * 10 + [{"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+    stop_calls = _patch_listener_stop(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert len(launches) == 1, "must restart when timed breaker is stuck"
+    assert stop_calls["stopped_ports"] == [8080]
+    # Must have waited past cooldown before restarting
+    assert t[0] >= 2.0
+
+
+@pytest.mark.asyncio
+async def test_timed_breaker_cooldown_boundary_race_refetches(monkeypatch):
+    """At cooldown<=0 but still open, ensure re-fetches health once before
+    deciding to restart (a recovery may be in flight at the boundary)."""
+    _install_virtual_clock(monkeypatch)
+    # cooldown_remaining=0.0 (boundary). Still open. Re-fetch also open → restart.
+    boundary = _timed_open_health("cdp_reconnect", 0.0)
+    _patch_health(monkeypatch, [boundary] * 5 + [{"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+    _patch_listener_stop(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    # Should have restarted after the boundary re-fetch confirmed still-open
+    assert len(launches) == 1
+
+
+@pytest.mark.asyncio
+async def test_degraded_timed_breaker_missing_cooldown_is_legacy(monkeypatch):
+    """A timed open breaker with missing cooldown_seconds_remaining (legacy/
+    malformed health) falls back to legacy degraded behavior — NOT an immediate
+    restart."""
+    t = _install_virtual_clock(monkeypatch)
+    # open timed breaker but cooldown_seconds_remaining is None (malformed)
+    malformed = {
+        "status": "degraded",
+        "breakers": {
+            "auth_required": _breaker_entry(False),
+            "cdp_reconnect": {"open": True},  # no cooldown_seconds_remaining key
+            "composer_send_readiness": _breaker_entry(False),
+            "chrome_crash_loop": _breaker_entry(False),
+        },
+    }
+    _patch_health(monkeypatch, [malformed] * 20 + [{"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+    _patch_listener_stop(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    # Legacy path: polled the full 20s budget before restarting
+    assert t[0] >= 20.0
+    assert len(launches) == 1
+
+
+@pytest.mark.asyncio
+async def test_degraded_no_breakers_key_preserves_old_behavior(monkeypatch):
+    """Legacy health (no breakers key at all) → existing degraded-poll-then-
+    -restart behavior. Backward-compat guard."""
+    t = _install_virtual_clock(monkeypatch)
+    _patch_health(monkeypatch, [{"status": "degraded"}] * 20 + [{"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+    _patch_listener_stop(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090)
+    assert code == 0
+    assert t[0] >= 20.0
+    assert len(launches) == 1
+
+
+@pytest.mark.asyncio
+async def test_custom_ensure_config_honored(monkeypatch, tmp_path):
+    """A config file with ensure_degraded_poll_budget_s overrides the default
+    poll budget."""
+    t = _install_virtual_clock(monkeypatch)
+    cfg_file = tmp_path / "cfg.json"
+    cfg_file.write_text(
+        '{"ensure_degraded_poll_budget_s": 6.0, "ensure_degraded_poll_interval_s": 2.0}'
+    )
+    # degraded for the whole 6s window, then healthy after restart
+    _patch_health(monkeypatch, [{"status": "degraded"}] * 10 + [{"status": "healthy"}])
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    launches = _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+    _patch_listener_stop(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090, config_path=str(cfg_file))
+    assert code == 0
+    assert len(launches) == 1
+    # Custom budget is 6.0, not the default 20.0
+    assert t[0] >= 6.0
+    assert t[0] < 20.0, f"must use custom 6s budget, not 20s (t={t[0]})"
+
+
+@pytest.mark.asyncio
+async def test_config_does_not_override_explicit_ports(monkeypatch, tmp_path):
+    """Config port/cdp_port must NOT override explicit run_ensure port args.
+    _rest_health must be called with the explicit rest_port, not cfg.server.port."""
+    cfg_file = tmp_path / "cfg.json"
+    cfg_file.write_text('{"port": 9999, "cdp_port": 9333}')
+
+    _install_virtual_clock(monkeypatch)
+    seen_ports = []
+
+    def tracking_health(rest_port, timeout=3.0):
+        seen_ports.append(rest_port)
+        return {"status": "healthy"}
+
+    monkeypatch.setattr(ensure_mod, "_rest_health", tracking_health)
+    _patch_sse_tcp(monkeypatch, [True])
+    _patch_sse_verify(monkeypatch, True)
+    _patch_launch(monkeypatch)
+    _patch_lock(monkeypatch)
+
+    code = await run_ensure(rest_port=8080, sse_port=8090, config_path=str(cfg_file))
+    assert code == 0
+    # Every health check must target 8080 (explicit), never 9999 (config)
+    assert all(p == 8080 for p in seen_ports), (
+        f"config port must not override explicit arg: {seen_ports}"
+    )

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -18,11 +18,11 @@ from chatgpt_web2api.api_server import APIServer
 from chatgpt_web2api.config import Config
 
 
-def _make_server(driver_connected: bool = True):
+def _make_server(driver_connected: bool = True, breakers=None):
     """Build an APIServer with a mock driver + chrome probe controlled by params."""
     driver = MagicMock()
     driver.is_connected = driver_connected
-    server = APIServer(Config.load(None), driver)
+    server = APIServer(Config.load(None), driver, breakers=breakers)
     return server
 
 
@@ -135,3 +135,118 @@ async def test_health_includes_breakers_snapshot():
     for entry in breakers.values():
         assert entry["open"] is False
         assert entry["failures_in_window"] == 0
+
+
+# ── PR3: status-policy — open breakers downgrade starting|healthy → degraded ──
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kind,cooldown",
+    [
+        ("auth_required", 0.0),  # sticky
+        ("composer_send_readiness", 300.0),
+        ("cdp_reconnect", 120.0),
+        ("chrome_crash_loop", 300.0),
+    ],
+)
+async def test_open_breaker_downgrades_healthy_to_degraded(kind, cooldown):
+    """Every BreakerKind, when open, downgrades healthy → degraded (never broken)."""
+    from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+
+    reg = BreakerRegistry()
+    # Map the exposure name back to the enum member.
+    bk = next(k for k in BreakerKind if k.value == kind)
+    reg.trip(bk, f"test {kind}", cooldown_s=cooldown)
+
+    server = _make_server(driver_connected=True, breakers=reg)
+    server._request_count = 1
+    server._last_successful_send_at = 12345.0
+    body = await _health_body(server, chrome_running=True)
+    assert body["status"] == "degraded", f"{kind} open should downgrade to degraded"
+    assert body["status"] != "broken"
+
+
+@pytest.mark.asyncio
+async def test_open_breaker_downgrades_starting_to_degraded():
+    """An open breaker also downgrades starting → degraded."""
+    from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+
+    reg = BreakerRegistry()
+    reg.trip(BreakerKind.CDP_RECONNECT, "ws down", cooldown_s=60.0)
+
+    server = _make_server(driver_connected=True, breakers=reg)
+    # No requests yet → would normally be "starting".
+    body = await _health_body(server, chrome_running=True)
+    assert body["status"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_broken_status_not_overridden_by_open_breaker():
+    """Chrome down (broken) stays broken even with an open breaker — broken is
+    a harder failure than a tripped circuit and must not be masked."""
+    from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+
+    reg = BreakerRegistry()
+    reg.trip(BreakerKind.AUTH_EXPIRED, "401", cooldown_s=0)
+
+    server = _make_server(driver_connected=True, breakers=reg)
+    body = await _health_body(server, chrome_running=False)
+    assert body["status"] == "broken"
+
+
+@pytest.mark.asyncio
+async def test_disconnect_degraded_not_worsened_by_open_breaker():
+    """A disconnect-degraded (Chrome up, driver dead) + open breaker stays
+    degraded — the breaker does not make it worse (not broken)."""
+    from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+
+    reg = BreakerRegistry()
+    reg.trip(BreakerKind.CHROME_CRASH_LOOP, "crashes", cooldown_s=300.0)
+
+    server = _make_server(driver_connected=False, breakers=reg)
+    body = await _health_body(server, chrome_running=True)
+    assert body["status"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_no_open_breakers_remains_healthy():
+    """Regression guard: no open breakers + served → healthy (downgrade does
+    not fire spuriously)."""
+    from chatgpt_web2api.breakers import BreakerRegistry
+
+    reg = BreakerRegistry()
+    server = _make_server(driver_connected=True, breakers=reg)
+    server._request_count = 1
+    server._last_successful_send_at = 12345.0
+    body = await _health_body(server, chrome_running=True)
+    assert body["status"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_open_breakers_list_matches_tripped_kinds():
+    """open_breakers is a current-state list of exactly the open kinds."""
+    from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+
+    reg = BreakerRegistry()
+    reg.trip(BreakerKind.AUTH_EXPIRED, "401", cooldown_s=0)
+    reg.trip(BreakerKind.CDP_RECONNECT, "ws", cooldown_s=60.0)
+
+    server = _make_server(driver_connected=True, breakers=reg)
+    server._request_count = 1
+    server._last_successful_send_at = 12345.0
+    body = await _health_body(server, chrome_running=True)
+    assert set(body["open_breakers"]) == {"auth_required", "cdp_reconnect"}
+
+
+@pytest.mark.asyncio
+async def test_open_breakers_empty_when_all_closed():
+    """open_breakers is empty when no breaker is tripped."""
+    from chatgpt_web2api.breakers import BreakerRegistry
+
+    reg = BreakerRegistry()
+    server = _make_server(driver_connected=True, breakers=reg)
+    server._request_count = 1
+    server._last_successful_send_at = 12345.0
+    body = await _health_body(server, chrome_running=True)
+    assert body["open_breakers"] == []


### PR DESCRIPTION
## Phase 4 PR3 — `/health` status-policy + breaker-aware ensure reconcile

Builds on PR2 (`dd97f91`). Makes `/health.status` reflect open breaker state and teaches `ensure` to distinguish an auth-needed condition from a generic failure — without changing driver send/retry semantics.

### Changes

**`/health` status-policy** (`api_server.py`)
- Open breaker **downgrades** `starting`|`healthy` → `degraded`. Never forces `broken`; never overrides `broken`; disconnect-degraded stays degraded.
- New top-level `open_breakers` list (current state), distinct from the historical/latching `last_error`.

**Breaker snapshot** (`breakers.py`)
- New `cooldown_seconds_remaining` field: a **duration** (not an opaque `time.monotonic()` timestamp) so a separate process (`ensure.py`) can reason about cooldown without comparing monotonic clocks across the process boundary. `None` = closed OR sticky (auth); positive = seconds left; `0.0` = past cooldown (half-open).

**Breaker-aware ensure** (`ensure.py`)
- `degraded` + open `auth_required` → **exit 2** (login needed). REST is NOT restarted; SSE is NOT reconciled. Short-circuits immediately (no 20s poll).
- `degraded` + open **timed** breaker (known cooldown) → waits `cooldown + grace`, then recovers or restarts. Boundary race (`cooldown ≤ 0` still open) re-fetches health once before restarting.
- `degraded` without breaker info (missing `breakers` key, malformed cooldown, or no open breaker) → **legacy 20s-poll-then-restart** behavior (backward compatible).
- Lock-contention path also surfaces exit 2 for auth.
- `auth_needed` short-circuits **before** `_reconcile_sse`.

**Narrow config tunables** (`config.py`)
- New `EnsureConfig`: `degraded_poll_interval_s`, `degraded_poll_budget_s`, `breaker_cooldown_grace_s`. Flat keys + `W2A_ENSURE_*` env.
- `run_ensure` loads `cfg.ensure.*` ONLY — `cfg.server.port`/`cfg.chrome.cdp_port` never override explicit port args.
- `BreakerPolicy` thresholds stay hardcoded (out of scope).

**Exit codes:** `0` ready · `1` generic failure · `2` auth/login needed.

### Tests
- **test_breakers:** snapshot has `cooldown_seconds_remaining`; timed counts down → `0.0`; sticky auth → `None`.
- **test_health:** each BreakerKind downgrades healthy→degraded; auth→degraded not broken; broken stays broken; disconnect-degraded stays degraded; no-open→healthy; `open_breakers` matches tripped kinds.
- **test_ensure:** auth→exit 2 (no restart/listener-stop/wait); auth skips SSE; contention auth→2; timed waits+recovers; timed stuck→restart; `cooldown≤0` boundary re-fetch; malformed cooldown→legacy; missing key→legacy; custom config honored; config ports don't override explicit args.
- **test_config_bind:** `ensure_*` parse + defaults + env override + `to_dict`.

### Verification
- `ruff check src/ tests/` — clean
- `pytest tests/ -q` — **412 passed** (31 e2e deselected)
- 99 tests in the four touched files green

### Out of scope (follow-up issues)
- `_fetch_text` 404 transient-retry (driver resilience)
- `requests_served` semantics / `successful_requests` counter
- non-401 backend-error breaker wiring
- MCP `/messages` trailing-slash redirect
- `BreakerPolicy` threshold/window/cooldown config tunables

### Runtime baseline
PR2 smoke was green on `dd97f91` (REST non-stream/stream, SSE/MCP, /health healthy). No driver send/retry diff in this PR — observability/policy only.