### PR TITLE
fix: bounded _fetch_text 404 retry (no breaker signal)

### DIFF
--- a/src/chatgpt_web2api/backend_client.py
+++ b/src/chatgpt_web2api/backend_client.py
@@ -42,6 +42,17 @@ from .breakers import BreakerKind
 
 logger = logging.getLogger(__name__)
 
+
+class _Transient404(Exception):
+    """Sentinel raised by ``_fetch_text_once`` on a backend 404.
+
+    Internal to ``_fetch_text``'s bounded retry loop — never escapes this
+    module. The 404 is a transient race (conversation not yet persisted
+    immediately after a send), NOT an auth failure or persistent backend
+    fault, so it is deliberately not modeled as a breaker signal.
+    """
+
+
 # Re-check the access token if it's older than this. The observed ChatGPT
 # JWT has a ~10-day lifetime, so 1h is a conservative refresh interval: it
 # avoids unnecessary refetches on the happy path while guaranteeing a stale
@@ -203,6 +214,16 @@ class BackendClient:
 
     # ── Conversation fetch ────────────────────────────────────
 
+    # Bounded retry for the transient 404 returned by the backend-api
+    # immediately after a send, before the just-created conversation is
+    # persisted server-side. This is a transient race, NOT an auth failure or
+    # a persistent backend fault, so it is deliberately NOT a breaker signal
+    # (follow-up C decides separately whether persistent 404/5xx should ever
+    # trip a breaker). The bound stays small so a genuinely-missing
+    # conversation surfaces quickly.
+    _FETCH_TEXT_404_MAX_ATTEMPTS = 4
+    _FETCH_TEXT_404_BACKOFF_SECONDS = 0.5
+
     async def _fetch_text(self, conversation_id: str) -> str:
         """Fetch the latest assistant text from the conversation API.
 
@@ -212,6 +233,15 @@ class BackendClient:
         error. This parse-and-raise happens here, before any return reaches
         the caller, so callers never see a raw status blob as text.
 
+        A 404 specifically is treated as a transient race and retried a
+        bounded number of times: the backend-api returns 404 immediately
+        after a send while the just-created conversation is still
+        propagating server-side. Only 404 is retried — 401 still raises
+        ``AuthExpiredError`` immediately (with breaker trip) and any other
+        non-OK status still raises ``RuntimeError`` immediately. After the
+        retry bound is exhausted the 404 surfaces as ``RuntimeError`` so
+        callers see the same type they did pre-retry.
+
         Picks the newest assistant text message by ``create_time`` rather than
         trusting the API's ``current_node`` pointer: that pointer lags behind
         on continued conversations (it still points at the previous turn right
@@ -219,45 +249,86 @@ class BackendClient:
         request N-1's text. The newest-by-create-time selection is immune to
         that lag.
         """
+        from .cdp_driver import CDPJSError
+
+        last_error: Exception | None = None
+        for attempt in range(1, self._FETCH_TEXT_404_MAX_ATTEMPTS + 1):
+            try:
+                return await self._fetch_text_once(conversation_id)
+            except _Transient404 as e:
+                # Transient race — retry after a short backoff unless this was
+                # the final attempt, in which case it falls through to the
+                # RuntimeError raise below.
+                last_error = e
+                if attempt < self._FETCH_TEXT_404_MAX_ATTEMPTS:
+                    logger.debug(
+                        "_fetch_text 404 for %s (attempt %d/%d), retrying",
+                        conversation_id,
+                        attempt,
+                        self._FETCH_TEXT_404_MAX_ATTEMPTS,
+                    )
+                    await asyncio.sleep(self._FETCH_TEXT_404_BACKOFF_SECONDS)
+                continue
+            except CDPJSError as e:
+                # JS transport failure: not a 404 race. Preserve the pre-retry
+                # behavior of swallowing it and returning "" (callers retry
+                # the whole send poll loop).
+                logger.debug("_fetch_text JS failed: %s", e)
+                return ""
+        # Bound exhausted — surface the 404 as RuntimeError, matching the
+        # pre-retry behavior callers already handle.
+        raise RuntimeError(
+            f"_fetch_text HTTP 404 for {conversation_id} "
+            f"after {self._FETCH_TEXT_404_MAX_ATTEMPTS} attempts"
+        ) from last_error
+
+    async def _fetch_text_once(self, conversation_id: str) -> str:
+        """Single backend-api conversation fetch + status decode.
+
+        Returns the assistant text on success, raises ``_Transient404`` on a
+        404 (so the bounded retry loop in ``_fetch_text`` can catch it),
+        raises ``AuthExpiredError`` (with breaker trip) on 401, and raises
+        ``RuntimeError`` for any other non-OK status. Empty/blank bodies and
+        JS-transport failures are handled by the caller.
+
+        Status decode (the ``__status`` blob shape) lives here so it runs
+        before any text reaches the caller regardless of the retry wrapper.
+        """
         # Imported lazily to avoid a module-load circular dependency.
-        from .cdp_driver import AuthExpiredError, CDPJSError
+        from .cdp_driver import AuthExpiredError
 
         d = self._driver
         await self._driver.ensure_token()
-        try:
-            raw = await d._js_with_data_strict(
-                "(async function() {"
-                "  try {"
-                "    var r = await fetch('/backend-api/conversation/' + __D.conv_id + '?offset=0&limit=5', {"
-                "      headers: {'Authorization': 'Bearer ' + __D.token}"
-                "    });"
-                "    if (!r.ok) return JSON.stringify({__status: r.status});"
-                "    var conv = await r.json();"
-                "    var mapping = conv.mapping || {};"
-                # Find the NEWEST assistant text message by create_time.
-                # current_node lags on continued conversations, so we cannot
-                # trust it to point at the turn we just sent.
-                "    var best = null;"
-                "    var bestTime = -1;"
-                "    for (var k in mapping) {"
-                "      var n = mapping[k];"
-                "      var m = n.message;"
-                "      if (!m || !m.author || m.author.role !== 'assistant') continue;"
-                "      if (!m.content || m.content.content_type !== 'text') continue;"
-                "      var parts = m.content.parts || [];"
-                "      if (!parts.length || !parts.some(function(p){ return String(p).trim(); })) continue;"
-                "      var t = m.create_time || 0;"
-                "      if (t >= bestTime) { bestTime = t; best = parts.filter(function(p){ return String(p).trim(); }).join('\\n'); }"
-                "    }"
-                "    return best || '';"
-                "  } catch(e) { return ''; }"
-                "})()",
-                {"conv_id": conversation_id, "token": d._access_token},
-                timeout=15,
-            )
-        except CDPJSError as e:
-            logger.debug("_fetch_text JS failed (will retry): %s", e)
-            return ""
+        raw = await d._js_with_data_strict(
+            "(async function() {"
+            "  try {"
+            "    var r = await fetch('/backend-api/conversation/' + __D.conv_id + '?offset=0&limit=5', {"
+            "      headers: {'Authorization': 'Bearer ' + __D.token}"
+            "    });"
+            "    if (!r.ok) return JSON.stringify({__status: r.status});"
+            "    var conv = await r.json();"
+            "    var mapping = conv.mapping || {};"
+            # Find the NEWEST assistant text message by create_time.
+            # current_node lags on continued conversations, so we cannot
+            # trust it to point at the turn we just sent.
+            "    var best = null;"
+            "    var bestTime = -1;"
+            "    for (var k in mapping) {"
+            "      var n = mapping[k];"
+            "      var m = n.message;"
+            "      if (!m || !m.author || m.author.role !== 'assistant') continue;"
+            "      if (!m.content || m.content.content_type !== 'text') continue;"
+            "      var parts = m.content.parts || [];"
+            "      if (!parts.length || !parts.some(function(p){ return String(p).trim(); })) continue;"
+            "      var t = m.create_time || 0;"
+            "      if (t >= bestTime) { bestTime = t; best = parts.filter(function(p){ return String(p).trim(); }).join('\\n'); }"
+            "    }"
+            "    return best || '';"
+            "  } catch(e) { return ''; }"
+            "})()",
+            {"conv_id": conversation_id, "token": d._access_token},
+            timeout=15,
+        )
         if not raw:
             return ""
         # Detect the status-blob shape (non-OK response) and raise appropriately.
@@ -272,6 +343,10 @@ class BackendClient:
                 if d._breakers:
                     d._breakers.trip(BreakerKind.AUTH_EXPIRED, "HTTP 401 from backend-api")
                 raise AuthExpiredError()
+            if status == 404:
+                # Transient race: conversation not yet persisted after send.
+                # The bounded retry in _fetch_text catches this.
+                raise _Transient404(conversation_id)
             if status is not None:
                 raise RuntimeError(f"_fetch_text HTTP {status} for {conversation_id}")
         return raw

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -1980,9 +1980,10 @@ class CDPDriver:
     async def _fetch_text(self, conversation_id: str) -> str:
         """Fetch the latest assistant text from the conversation API.
 
-        Delegated to BackendClient (Phase 5 PR1 extraction). The 404→RuntimeError
-        and 401→AuthExpiredError+trip behavior is preserved exactly; the 404
-        bounded-retry is a separate follow-up (PR #23).
+        Delegated to BackendClient (Phase 5 PR1 extraction). The 401→
+        AuthExpiredError+trip behavior is preserved exactly; a transient 404
+        (conversation not yet persisted after send) is now retried a bounded
+        number of times before surfacing as RuntimeError (PR #23).
         """
         return await self._backend_client._fetch_text(conversation_id)
 

--- a/tests/test_backend_client.py
+++ b/tests/test_backend_client.py
@@ -250,3 +250,120 @@ async def test_create_memory_success_false_when_get_memories_no_match():
     result = await client.create_memory("remember this please")
     assert result["success"] is False
     driver.get_memories.assert_awaited_once()
+
+
+# ── 8. _fetch_text bounded 404 retry (PR #23) ──────────────────────────
+#
+# The backend-api returns 404 immediately after a send while the just-created
+# conversation is still propagating server-side. _fetch_text treats 404 as a
+# transient race: bounded retry, NOT a breaker. 401 still raises immediately
+# (with breaker trip) and other non-OK statuses still raise RuntimeError
+# immediately — only 404 is retried.
+
+
+@pytest.mark.asyncio
+async def test_fetch_text_404_retries_then_succeeds():
+    """A transient 404 followed by a real body returns the body, not an error.
+    The fetch is retried until the conversation is persisted server-side."""
+    client, driver = _make_client()
+    client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0  # keep the test fast
+
+    responses = ['{"__status": 404}', '{"__status": 404}', "the assistant reply"]
+    calls = {"i": 0}
+
+    async def _fake(js_template, data, timeout=15):
+        r = responses[calls["i"]]
+        calls["i"] += 1
+        return r
+
+    driver._js_with_data_strict = _fake
+    result = await client._fetch_text("conv-1")
+    assert result == "the assistant reply"
+    assert calls["i"] == 3  # two 404s retried, third succeeded
+
+
+@pytest.mark.asyncio
+async def test_fetch_text_404_raises_after_bound():
+    """When 404 persists past the retry bound, it surfaces as RuntimeError
+    carrying the code, so callers see the same exception type as pre-retry."""
+    client, driver = _make_client()
+    client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0
+    calls = {"n": 0}
+
+    async def _fake(js_template, data, timeout=15):
+        calls["n"] += 1
+        return '{"__status": 404}'
+
+    driver._js_with_data_strict = _fake
+    with pytest.raises(RuntimeError) as ei:
+        await client._fetch_text("conv-1")
+    assert "404" in str(ei.value)
+    assert calls["n"] == client._FETCH_TEXT_404_MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_fetch_text_401_not_retried_trips_breaker():
+    """401 is NOT a transient race: it must raise AuthExpiredError on the
+    first hit (no retry) and trip AUTH_EXPIRED. Guards against the 404 retry
+    accidentally swallowing auth failures."""
+    from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+    from chatgpt_web2api.cdp_driver import AuthExpiredError
+
+    client, driver = _make_client()
+    driver._breakers = BreakerRegistry()
+    client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0
+    calls = {"n": 0}
+
+    async def _fake(js_template, data, timeout=15):
+        calls["n"] += 1
+        return '{"__status": 401}'
+
+    driver._js_with_data_strict = _fake
+    with pytest.raises(AuthExpiredError):
+        await client._fetch_text("conv-1")
+    # No retry: exactly one fetch attempt.
+    assert calls["n"] == 1
+    assert driver._breakers.is_open(BreakerKind.AUTH_EXPIRED)
+
+
+@pytest.mark.asyncio
+async def test_fetch_text_other_status_not_retried():
+    """Non-404 non-401 statuses (e.g. 500) raise RuntimeError immediately —
+    only the 404 propagation race is retried."""
+    client, driver = _make_client()
+    client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0
+    calls = {"n": 0}
+
+    async def _fake(js_template, data, timeout=15):
+        calls["n"] += 1
+        return '{"__status": 500}'
+
+    driver._js_with_data_strict = _fake
+    with pytest.raises(RuntimeError) as ei:
+        await client._fetch_text("conv-1")
+    assert "500" in str(ei.value)
+    assert calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_text_404_no_breaker_signal(monkeypatch):
+    """A transient 404 must NOT trip any breaker — it is a propagation race,
+    not an auth failure or persistent backend fault (follow-up C decides
+    breaker policy for backend errors separately)."""
+    from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+
+    client, driver = _make_client()
+    reg = BreakerRegistry()
+    driver._breakers = reg
+    client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0
+
+    # Trip is the only mutation path; fail the test if anything tries it.
+    monkeypatch.setattr(reg, "trip", lambda *a, **k: pytest.fail("404 must not trip a breaker"))
+
+    async def _fake(js_template, data, timeout=15):
+        return '{"__status": 404}'
+
+    driver._js_with_data_strict = _fake
+    with pytest.raises(RuntimeError):
+        await client._fetch_text("conv-1")
+    assert not reg.is_open(BreakerKind.AUTH_EXPIRED)

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -122,17 +122,25 @@ async def test_fetch_text_401_raises_auth_expired():
 
 @pytest.mark.asyncio
 async def test_fetch_text_404_raises_runtime_error():
-    """Non-401 non-OK status surfaces as RuntimeError with the code, not silent ''."""
+    """A persistent 404 (bound exhausted) surfaces as RuntimeError with the
+    code. The bounded retry in backend_client._fetch_text is exercised, but
+    backoff is zeroed here to keep the test fast."""
     d = _make_driver()
+    calls = {"n": 0}
 
     async def _fake(js_template, data, timeout=15):
+        calls["n"] += 1
         return '{"__status": 404}'
 
     d._js_with_data_strict = _fake
     d.ensure_token = AsyncMock(return_value="tok")
+    # Zero the backoff so the bound is exhausted without real sleeping.
+    d._backend_client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0
     with pytest.raises(RuntimeError) as ei:
         await d._fetch_text("conv-1")
     assert "404" in str(ei.value)
+    # Bound exhausted → one fetch per attempt.
+    assert calls["n"] == d._backend_client._FETCH_TEXT_404_MAX_ATTEMPTS
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Resolves roadmap follow-up **A. _fetch_text transient 404 retry** (`docs/ROADMAP.md`).

## Problem

The backend-api returns `404` immediately after a send, before the just-created conversation is persisted server-side. Pre-PR `_fetch_text` raised `RuntimeError` on the first 404, so the send-poll loop in `cdp_driver.send_and_stream` (which calls `_fetch_text` up to 60× to capture final API text) could lose the assistant reply to a transient propagation race.

## Fix

`_fetch_text` now treats **404 only** as a transient race: bounded retry, **not** a breaker signal.

- 4 attempts max, 0.5s backoff between attempts
- only `404` is retried
- after the bound, 404 surfaces as `RuntimeError` (same type callers already handled)

Implementation: `_fetch_text` is split into a bounded retry wrapper + `_fetch_text_once` (single attempt + status decode). A module-private `_Transient404` sentinel carries the 404 through the loop and never escapes the module.

## Behavior preserved exactly (verified by tests)

| Path | Behavior |
|---|---|
| `401` | raises `AuthExpiredError` immediately + trips `AUTH_EXPIRED` — **no retry** |
| other non-OK (e.g. `500`) | raises `RuntimeError` immediately — **no retry** |
| JS transport failure (`CDPJSError`) | swallowed → `""` (callers retry the send poll loop) |
| 404 after bound | `RuntimeError` (same type as pre-retry) |

No breaker signal is emitted for 404/5xx. Whether persistent backend errors should ever trip a breaker is **follow-up C** (ROADMAP) and is decided separately.

## Tests

New in `tests/test_backend_client.py` (§8):
- `test_fetch_text_404_retries_then_succeeds` — two 404s then a real body returns the body
- `test_fetch_text_404_raises_after_bound` — persistent 404 → `RuntimeError`, one fetch per attempt
- `test_fetch_text_401_not_retried_trips_breaker` — 401 raises + trips on first hit, exactly one fetch
- `test_fetch_text_other_status_not_retried` — 500 raises immediately, one fetch
- `test_fetch_text_404_no_breaker_signal` — `BreakerRegistry.trip` is patched to fail if called

Updated in `tests/test_reliability.py`:
- `test_fetch_text_404_raises_runtime_error` — updated for the retry (zeroed backoff), asserts fetch count == bound

## Verification

- `ruff check` on all 4 changed files: **clean** (24 pre-existing errors elsewhere unchanged on `master`)
- `pytest`: **434 passed**

## Changed files (4)
- `src/chatgpt_web2api/backend_client.py` — `_fetch_text` retry wrapper + `_fetch_text_once` + `_Transient404` + retry constants
- `src/chatgpt_web2api/cdp_driver.py` — delegator docstring updated
- `tests/test_backend_client.py` — §8 retry tests
- `tests/test_reliability.py` — existing 404 test updated