### PR TITLE
refactor: extract cdp_transport.py (Phase 5 PR2, no behavior change)

### DIFF
--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -336,6 +336,12 @@ class CDPDriver:
         from .backend_client import BackendClient
 
         self._backend_client = BackendClient(self)
+        # Phase 5 PR2: CDP wire primitives extracted into CDPTransport. Lazy
+        # import for the same reason; the transport reaches through this driver
+        # for _ws/_msg_id/_pending and calls back into reconnect() on socket death.
+        from .cdp_transport import CDPTransport
+
+        self._transport = CDPTransport(self)
 
     async def connect(self) -> None:
         """Connect to Chrome's CDP and authenticate.
@@ -845,187 +851,59 @@ class CDPDriver:
     async def _reader_loop(self) -> None:
         """Background reader: sole consumer of self._ws.recv().
 
-        Routes each incoming CDP message to the matching pending Future by id.
-        Messages without an id (CDP events like Page.frameNavigated) are logged
-        at DEBUG and discarded — no caller subscribes to events today, but the
-        hook is here for future navigation-ready detection.
-
-        On ConnectionClosed, fails all pending futures so callers don't hang.
+        Delegated to CDPTransport (Phase 5 PR2 extraction). Preserved exactly:
+        sole ``_ws.recv()`` consumer, routes responses to ``_pending`` by id,
+        fails all pending futures on socket close.
         """
-        try:
-            while True:
-                raw = await self._ws.recv()
-                try:
-                    msg = json.loads(raw)
-                except (json.JSONDecodeError, TypeError):
-                    logger.debug("CDP reader: unparseable frame, discarding")
-                    continue
-                mid = msg.get("id")
-                if mid is None:
-                    # Unsolicited CDP event — no caller subscribes yet.
-                    logger.debug("CDP event: %s", msg.get("method", "?"))
-                    continue
-                fut = self._pending.pop(mid, None)
-                if fut and not fut.done():
-                    fut.set_result(msg)
-                else:
-                    logger.debug("CDP reader: response for unknown/stale id %s", mid)
-        except Exception as e:
-            # Socket closed or errored — fail all pending callers so they
-            # don't hang waiting for a response that will never arrive.
-            logger.warning("CDP reader loop ended: %s", e)
-            for mid, fut in list(self._pending.items()):
-                if not fut.done():
-                    fut.set_exception(e)
+        await self._transport._reader_loop()
 
     async def _cdp(
         self, method: str, params: dict = None, timeout: float = 15, _retry: bool = True
     ) -> dict:
         """Send a CDP command and await its response.
 
-        Uses the background reader + id-keyed Future table (#7 fix) so
-        concurrent _cdp calls each receive their own response without
-        cross-eating each other's frames.
-
-        Auto-reconnect: if the underlying WebSocket is dead (ConnectionClosed
-        on send — the ``no close frame`` case), attempt ONE ``reconnect()``
-        then retry the call. Without this, a single mid-session socket drop
-        permanently bricks a long-running bridge: ``reconnect()`` exists but
-        nothing wired it in, so every subsequent call re-raised the dead
-        socket error forever. ``_retry`` guards against recursion: a call that
-        fails again after reconnect propagates instead of looping.
+        Delegated to CDPTransport (Phase 5 PR2 extraction). Preserved exactly:
+        id-keyed future routing, one reconnect-and-retry through
+        ``self.reconnect()`` on socket death (Layer-2 breaker semantics stay
+        there), ``_retry`` recursion guard.
         """
-        self._msg_id += 1
-        mid = self._msg_id
-        fut: asyncio.Future = asyncio.get_event_loop().create_future()
-        self._pending[mid] = fut
-        try:
-            await self._ws.send(json.dumps({"id": mid, "method": method, "params": params or {}}))
-        except Exception as e:
-            self._pending.pop(mid, None)
-            if _retry and self._should_reconnect(e):
-                logger.warning("CDP send failed (%s); reconnecting and retrying once", e)
-                await self.reconnect()
-                return await self._cdp(method, params, timeout, _retry=False)
-            raise
-        try:
-            return await asyncio.wait_for(fut, timeout)
-        except TimeoutError:
-            self._pending.pop(mid, None)
-            raise TimeoutError(f"CDP timeout: {method}")
+        return await self._transport._cdp(method, params, timeout, _retry)
 
     @staticmethod
     def _should_reconnect(exc: Exception) -> bool:
-        """True for errors that mean the WebSocket is dead/tearing down.
+        """True for socket-death signatures; False otherwise.
 
-        ConnectionClosed (and its subclasses) and the ``no close frame``
-        InvalidState are the socket-death signatures; everything else
-        (TimeoutError, application errors) must NOT trigger a reconnect.
-        """
-        # websockets.ConnectionClosed + subclasses (ConnectionClosedError,
-        # ConnectionClosedOK). Imported lazily so a missing/renamed class in
-        # other websockets versions degrades to a name check instead of ImportError.
-        name = type(exc).__name__
-        if name in {"ConnectionClosed", "ConnectionClosedError", "ConnectionClosedOK"}:
-            return True
-        msg = str(exc).lower()
-        return "no close frame" in msg or "connection closed" in msg
+        Delegated to CDPTransport (Phase 5 PR2 extraction). Pure classifier,
+        no state."""
+        from .cdp_transport import CDPTransport
+
+        return CDPTransport._should_reconnect(exc)
 
     async def _js(self, expr: str, timeout: float = 15) -> str:
-        resp = await self._cdp(
-            "Runtime.evaluate",
-            {
-                "expression": expr,
-                "awaitPromise": True,
-                "returnByValue": True,
-                "timeout": int(timeout * 1000),
-            },
-            timeout=timeout,
-        )
-        return resp.get("result", {}).get("result", {}).get("value", "")
+        """Soft ``Runtime.evaluate`` — returns "" on failure.
+
+        Delegated to CDPTransport (Phase 5 PR2 extraction)."""
+        return await self._transport._js(expr, timeout)
 
     async def _js_with_data(self, expr_template: str, data: dict, timeout: float = 15) -> str:
-        """Evaluate JS with safely injected data variables.
+        """Evaluate JS with safely injected ``__D`` data variables (soft).
 
-        Injects *data* as the ``__D`` argument of an async IIFE so the
-        templates can reference ``__D.keyName`` for any key.  The data is
-        passed as a JSON-serialized call argument (never string-concatenated
-        into the body), which eliminates injection vectors entirely.
-
-        Earlier versions emitted a top-level ``const __D = ...;``, which
-        collides with the global ``__D`` that chatgpt.com's own page defines
-        and raised ``SyntaxError: Identifier '__D' has already been
-        declared`` — silently returning empty for every
-        memory/project/conversation read.  Passing ``__D`` as a function
-        parameter sidesteps the collision completely: there is no
-        declaration to conflict, and the parameter shadows the global
-        within the IIFE's scope.
-
-        *expr_template* is evaluated as an expression in a position where
-        its return value becomes the IIFE's result, so existing templates
-        (which are self-invoking like ``(async () => {...})()``) keep
-        working unchanged.
-        """
-        # Pass __D as an argument. Using `void ` makes `__D=>(...)` an
-        # arrow expression body, so the template's value is returned.
-        wrapped = f"( (__D) => ({expr_template}) )({json.dumps(data)})"
-        return await self._js(wrapped, timeout=timeout)
+        Delegated to CDPTransport (Phase 5 PR2 extraction)."""
+        return await self._transport._js_with_data(expr_template, data, timeout)
 
     async def _js_strict(self, expr: str, timeout: float = 15) -> str:
-        """Strict JS evaluation — raises CDPJSError on failure instead of "".
+        """Strict ``Runtime.evaluate`` — raises CDPJSError on failure.
 
-        Inspects the CDP response for:
-        - ``error`` (CDP-level error, e.g. execution context destroyed)
-        - ``exceptionDetails`` (JS threw an exception)
-        - missing ``result.result`` (undefined return, type mismatch)
-
-        On any of these, raises CDPJSError with the detail. On success,
-        returns the value string (same as _js).
-
-        Callers that already handle exceptions benefit immediately. Callers
-        that depend on the ""-on-error contract must wrap in try/except.
-        """
-        resp = await self._cdp(
-            "Runtime.evaluate",
-            {
-                "expression": expr,
-                "awaitPromise": True,
-                "returnByValue": True,
-                "timeout": int(timeout * 1000),
-            },
-            timeout=timeout,
-        )
-        # CDP-level error (e.g. "Execution context was destroyed")
-        if "error" in resp:
-            err = resp["error"]
-            raise CDPJSError(
-                f"CDP error evaluating JS: {err.get('message', err)}",
-                details=err,
-            )
-        result = resp.get("result", {})
-        # JS exception
-        if result.get("exceptionDetails"):
-            exd = result["exceptionDetails"]
-            exc_text = exd.get("exception", {}).get("description", "") or exd.get("text", "")
-            raise CDPJSError(
-                f"JS exception: {exc_text[:500]}",
-                details=exd,
-            )
-        inner = result.get("result", {})
-        # Undefined or unserializable return
-        if inner.get("type") in ("undefined",) or "value" not in inner:
-            raise CDPJSError(
-                f"JS returned {inner.get('type', 'unknown')} (no value)",
-                details={"type": inner.get("type")},
-            )
-        return inner.get("value", "")
+        Delegated to CDPTransport (Phase 5 PR2 extraction)."""
+        return await self._transport._js_strict(expr, timeout)
 
     async def _js_with_data_strict(
         self, expr_template: str, data: dict, timeout: float = 15
     ) -> str:
-        """Strict variant of _js_with_data — raises CDPJSError on failure."""
-        wrapped = f"( (__D) => ({expr_template}) )({json.dumps(data)})"
-        return await self._js_strict(wrapped, timeout=timeout)
+        """Strict variant of _js_with_data — raises CDPJSError on failure.
+
+        Delegated to CDPTransport (Phase 5 PR2 extraction)."""
+        return await self._transport._js_with_data_strict(expr_template, data, timeout)
 
     # ── Model Selection ───────────────────────────────────────
 

--- a/src/chatgpt_web2api/cdp_transport.py
+++ b/src/chatgpt_web2api/cdp_transport.py
@@ -1,0 +1,259 @@
+"""CDP transport — Chrome DevTools Protocol wire primitives.
+
+Phase 5 PR2 extraction (no behavior change). Owns the active page-websocket
+wire layer that was previously inlined in ``CDPDriver``:
+
+  - ``_reader_loop`` — background reader; sole consumer of ``_ws.recv()``,
+    routes each CDP response to its id-keyed pending Future.
+  - ``_cdp`` — send a CDP command + await its response via the future table;
+    auto-reconnects once through ``driver.reconnect()`` on socket death.
+  - ``_should_reconnect`` — pure error classifier for socket-death signatures.
+  - ``_js`` / ``_js_strict`` — soft / strict ``Runtime.evaluate`` wrappers.
+  - ``_js_with_data`` / ``_js_with_data_strict`` — safe ``__D`` data injection.
+
+The driver-reference collaborator seam: ``CDPTransport`` holds a reference to
+its owning ``CDPDriver`` and reaches through it for the live CDP socket and
+the id-keyed response table. None of that state migrates into this module —
+it stays on the driver so external attribute reads (connect/reconnect/close,
+``is_connected``) and test stubs that poke ``driver._ws`` /
+``driver._pending`` / ``driver._reader_task`` keep working unchanged.
+
+Boundary (Layer 1 only): this module is the ACTIVE page-websocket wire layer.
+Connection lifecycle, tab discovery (``connect``/``reconnect``/
+``_find_*_ws``/``_create_owned_tab``/``_browser_cdp``), and ``close`` stay in
+``cdp_driver.py`` (Layer 2). ``reconnect`` owns breaker semantics; this module
+calls back into ``driver.reconnect()`` but never duplicates or moves breaker
+handling.
+
+Call-rule inside CDPTransport method bodies:
+
+  transport state:         self._driver._ws
+                           self._driver._msg_id
+                           self._driver._pending
+  layer-2 callback:        self._driver.reconnect()
+  sibling wire helpers:    self._cdp(...)
+                           self._js(...)
+                           self._js_strict(...)
+
+Internal wire-to-wire calls (``_js`` → ``_cdp``, ``_js_with_data`` → ``_js``)
+go through ``self._driver`` (not ``self``) so driver monkeypatches of
+``driver._cdp`` / ``driver._js`` keep intercepting — the same driver-facing
+seam BackendClient relies on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class CDPTransport:
+    """Active page-websocket CDP wire primitives, composed by ``CDPDriver``.
+
+    Constructed once in ``CDPDriver.__init__`` and stored as
+    ``self._transport``. The driver keeps thin delegating methods for every
+    method here so its public/private API surface is byte-identical to
+    pre-extraction.
+    """
+
+    def __init__(self, driver) -> None:
+        self._driver = driver
+
+    # ── CDP primitives ────────────────────────────────────────
+
+    async def _reader_loop(self) -> None:
+        """Background reader: sole consumer of self._ws.recv().
+
+        Routes each incoming CDP message to the matching pending Future by id.
+        Messages without an id (CDP events like Page.frameNavigated) are logged
+        at DEBUG and discarded — no caller subscribes to events today, but the
+        hook is here for future navigation-ready detection.
+
+        On ConnectionClosed, fails all pending futures so callers don't hang.
+        """
+        d = self._driver
+        try:
+            while True:
+                raw = await d._ws.recv()
+                try:
+                    msg = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    logger.debug("CDP reader: unparseable frame, discarding")
+                    continue
+                mid = msg.get("id")
+                if mid is None:
+                    # Unsolicited CDP event — no caller subscribes yet.
+                    logger.debug("CDP event: %s", msg.get("method", "?"))
+                    continue
+                fut = d._pending.pop(mid, None)
+                if fut and not fut.done():
+                    fut.set_result(msg)
+                else:
+                    logger.debug("CDP reader: response for unknown/stale id %s", mid)
+        except Exception as e:
+            # Socket closed or errored — fail all pending callers so they
+            # don't hang waiting for a response that will never arrive.
+            logger.warning("CDP reader loop ended: %s", e)
+            for mid, fut in list(d._pending.items()):
+                if not fut.done():
+                    fut.set_exception(e)
+
+    async def _cdp(
+        self, method: str, params: dict = None, timeout: float = 15, _retry: bool = True
+    ) -> dict:
+        """Send a CDP command and await its response.
+
+        Uses the background reader + id-keyed Future table (#7 fix) so
+        concurrent _cdp calls each receive their own response without
+        cross-eating each other's frames.
+
+        Auto-reconnect: if the underlying WebSocket is dead (ConnectionClosed
+        on send — the ``no close frame`` case), attempt ONE ``reconnect()``
+        then retry the call. Without this, a single mid-session socket drop
+        permanently bricks a long-running bridge: ``reconnect()`` exists but
+        nothing wired it in, so every subsequent call re-raised the dead
+        socket error forever. ``_retry`` guards against recursion: a call that
+        fails again after reconnect propagates instead of looping.
+
+        ``reconnect()`` is a Layer-2 driver method and owns breaker semantics;
+        this module never duplicates or moves breaker handling — it only calls
+        back into the driver for the one-shot reconnect-and-retry.
+        """
+        d = self._driver
+        d._msg_id += 1
+        mid = d._msg_id
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        d._pending[mid] = fut
+        try:
+            await d._ws.send(json.dumps({"id": mid, "method": method, "params": params or {}}))
+        except Exception as e:
+            d._pending.pop(mid, None)
+            if _retry and self._should_reconnect(e):
+                logger.warning("CDP send failed (%s); reconnecting and retrying once", e)
+                await d.reconnect()
+                return await self._cdp(method, params, timeout, _retry=False)
+            raise
+        try:
+            return await asyncio.wait_for(fut, timeout)
+        except TimeoutError:
+            d._pending.pop(mid, None)
+            raise TimeoutError(f"CDP timeout: {method}")
+
+    @staticmethod
+    def _should_reconnect(exc: Exception) -> bool:
+        """True for errors that mean the WebSocket is dead/tearing down.
+
+        ConnectionClosed (and its subclasses) and the ``no close frame``
+        InvalidState are the socket-death signatures; everything else
+        (TimeoutError, application errors) must NOT trigger a reconnect.
+        """
+        # websockets.ConnectionClosed + subclasses (ConnectionClosedError,
+        # ConnectionClosedOK). Imported lazily so a missing/renamed class in
+        # other websockets versions degrades to a name check instead of ImportError.
+        name = type(exc).__name__
+        if name in {"ConnectionClosed", "ConnectionClosedError", "ConnectionClosedOK"}:
+            return True
+        msg = str(exc).lower()
+        return "no close frame" in msg or "connection closed" in msg
+
+    async def _js(self, expr: str, timeout: float = 15) -> str:
+        resp = await self._driver._cdp(
+            "Runtime.evaluate",
+            {
+                "expression": expr,
+                "awaitPromise": True,
+                "returnByValue": True,
+                "timeout": int(timeout * 1000),
+            },
+            timeout=timeout,
+        )
+        return resp.get("result", {}).get("result", {}).get("value", "")
+
+    async def _js_with_data(self, expr_template: str, data: dict, timeout: float = 15) -> str:
+        """Evaluate JS with safely injected data variables.
+
+        Injects *data* as the ``__D`` argument of an async IIFE so the
+        templates can reference ``__D.keyName`` for any key.  The data is
+        passed as a JSON-serialized call argument (never string-concatenated
+        into the body), which eliminates injection vectors entirely.
+
+        Earlier versions emitted a top-level ``const __D = ...;``, which
+        collides with the global ``__D`` that chatgpt.com's own page defines
+        and raised ``SyntaxError: Identifier '__D' has already been
+        declared`` — silently returning empty for every
+        memory/project/conversation read.  Passing ``__D`` as a function
+        parameter sidesteps the collision completely: there is no
+        declaration to conflict, and the parameter shadows the global
+        within the IIFE's scope.
+
+        *expr_template* is evaluated as an expression in a position where
+        its return value becomes the IIFE's result, so existing templates
+        (which are self-invoking like ``(async () => {...})()``) keep
+        working unchanged.
+        """
+        # Pass __D as an argument. Using `void ` makes `__D=>(...)` an
+        # arrow expression body, so the template's value is returned.
+        wrapped = f"( (__D) => ({expr_template}) )({json.dumps(data)})"
+        return await self._driver._js(wrapped, timeout=timeout)
+
+    async def _js_strict(self, expr: str, timeout: float = 15) -> str:
+        """Strict JS evaluation — raises CDPJSError on failure instead of "".
+
+        Inspects the CDP response for:
+        - ``error`` (CDP-level error, e.g. execution context destroyed)
+        - ``exceptionDetails`` (JS threw an exception)
+        - missing ``result.result`` (undefined return, type mismatch)
+
+        On any of these, raises CDPJSError with the detail. On success,
+        returns the value string (same as _js).
+
+        Callers that already handle exceptions benefit immediately. Callers
+        that depend on the ""-on-error contract must wrap in try/except.
+        """
+        # Imported lazily to avoid a module-load circular dependency.
+        from .cdp_driver import CDPJSError
+
+        resp = await self._driver._cdp(
+            "Runtime.evaluate",
+            {
+                "expression": expr,
+                "awaitPromise": True,
+                "returnByValue": True,
+                "timeout": int(timeout * 1000),
+            },
+            timeout=timeout,
+        )
+        # CDP-level error (e.g. "Execution context was destroyed")
+        if "error" in resp:
+            err = resp["error"]
+            raise CDPJSError(
+                f"CDP error evaluating JS: {err.get('message', err)}",
+                details=err,
+            )
+        result = resp.get("result", {})
+        # JS exception
+        if result.get("exceptionDetails"):
+            exd = result["exceptionDetails"]
+            exc_text = exd.get("exception", {}).get("description", "") or exd.get("text", "")
+            raise CDPJSError(
+                f"JS exception: {exc_text[:500]}",
+                details=exd,
+            )
+        inner = result.get("result", {})
+        # Undefined or unserializable return
+        if inner.get("type") in ("undefined",) or "value" not in inner:
+            raise CDPJSError(
+                f"JS returned {inner.get('type', 'unknown')} (no value)",
+                details={"type": inner.get("type")},
+            )
+        return inner.get("value", "")
+
+    async def _js_with_data_strict(
+        self, expr_template: str, data: dict, timeout: float = 15
+    ) -> str:
+        """Strict variant of _js_with_data — raises CDPJSError on failure."""
+        wrapped = f"( (__D) => ({expr_template}) )({json.dumps(data)})"
+        return await self._driver._js_strict(wrapped, timeout=timeout)

--- a/tests/test_cdp_transport.py
+++ b/tests/test_cdp_transport.py
@@ -1,0 +1,299 @@
+"""Wiring tests for CDPTransport (Phase 5 PR2 extraction).
+
+These verify the extraction moved the 7 wire-primitive methods onto
+CDPTransport and that the transport reaches the driver's socket + id table
+through the correct seam. They are NOT behavioral tests — the behavior of
+each method is already covered exhaustively by test_cdp_foundation
+(concurrent _cdp, pending cleanup, reader-on-socket-close) and the broad
+suite, which stub the driver's transport methods and confirm the delegators
+preserve the surface. This file guards the wiring: no method is dropped, the
+transport talks to the driver (not to itself) for socket/id-table state, and
+the driver wires the transport in __init__.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.cdp_transport import CDPTransport
+
+
+class FakeWebSocket:
+    """Fake websocket that delivers id-matched responses once their command is
+    sent. Mirrors test_cdp_foundation's helper so _cdp + a reader task resolve
+    through the real future-table wiring."""
+
+    def __init__(self):
+        self._response_map: dict[int, str] = {}
+        self._delivered: set[int] = set()
+        self.sent: list[str] = []
+        self.state = MagicMock()
+        self.state.name = "OPEN"
+
+    def enqueue(self, msg_id: int, result: dict):
+        self._response_map[msg_id] = json.dumps({"id": msg_id, "result": result})
+
+    async def recv(self):
+        while True:
+            for mid, resp_str in self._response_map.items():
+                if mid in self._delivered:
+                    continue
+                for sent_raw in self.sent:
+                    sent = json.loads(sent_raw)
+                    if sent.get("id") == mid:
+                        self._delivered.add(mid)
+                        return resp_str
+            await asyncio.sleep(0.05)
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def close(self):
+        self.state.name = "CLOSED"
+
+
+def _make_transport():
+    """A CDPTransport backed by a mock driver with the attributes/seam the
+    transport reaches through. The driver's socket/id-table are minimal mocks
+    so individual tests override only what they assert on."""
+    driver = MagicMock()
+    driver._ws = MagicMock()
+    driver._ws.send = AsyncMock()
+    driver._ws.recv = AsyncMock()
+    driver._msg_id = 0
+    driver._pending = {}
+    driver.reconnect = AsyncMock()
+    return CDPTransport(driver), driver
+
+
+# ── 1. Every moved method exists on CDPTransport ──────────────────────
+
+
+def test_transport_has_all_moved_methods():
+    """The extraction must not drop a method. Each of these is delegated by
+    CDPDriver and must live on CDPTransport."""
+    transport, _ = _make_transport()
+    expected = [
+        "_reader_loop",
+        "_cdp",
+        "_should_reconnect",
+        "_js",
+        "_js_strict",
+        "_js_with_data",
+        "_js_with_data_strict",
+    ]
+    missing = [name for name in expected if not callable(getattr(transport, name, None))]
+    assert missing == [], f"CDPTransport is missing moved methods: {missing}"
+
+
+def test_should_reconnect_is_staticmethod():
+    """_should_reconnect must remain callable without an instance (the driver
+    delegates to it as CDPTransport._should_reconnect(exc))."""
+    assert CDPTransport._should_reconnect(Exception("connection closed")) is True
+    assert CDPTransport._should_reconnect(TimeoutError()) is False
+
+
+# ── 2. State seam: transport reaches driver._ws / _msg_id / _pending ──
+
+
+@pytest.mark.asyncio
+async def test_cdp_reaches_driver_ws_msg_id_pending():
+    """_cdp must send on the driver's socket and register its future in the
+    driver's pending table keyed by the driver's msg id. The reader task
+    (sole recv consumer) resolves the future — mirroring the real wiring."""
+    transport, driver = _make_transport()
+    ws = FakeWebSocket()
+    ws.enqueue(1, {"ok": True})
+    driver._ws = ws
+    driver._reader_task = asyncio.create_task(transport._reader_loop())
+
+    result = await transport._cdp("Test.Method", {"a": 1}, timeout=5)
+
+    driver._reader_task.cancel()
+    try:
+        await driver._reader_task
+    except asyncio.CancelledError:
+        pass
+
+    assert result["result"] == {"ok": True}
+    # Sent on the driver's socket, with the driver's id.
+    assert len(ws.sent) == 1
+    sent = ws.sent[0]
+    assert '"Test.Method"' in sent
+    # msg_id advanced on the driver (not a transport-local counter).
+    assert driver._msg_id == 1
+
+
+@pytest.mark.asyncio
+async def test_reader_loop_consumes_driver_ws_recv_and_routes_to_pending():
+    """_reader_loop must be the sole recv() consumer and route responses into
+    the driver's _pending table by id."""
+    transport, driver = _make_transport()
+
+    fut: asyncio.Future = asyncio.get_event_loop().create_future()
+    driver._pending[42] = fut
+
+    frames = iter([
+        '{"id": 42, "result": {"value": "hello"}}',
+        # An event (no id) — must be discarded, not routed.
+        '{"method": "Page.frameNavigated"}',
+    ])
+
+    async def _fake_recv():
+        try:
+            return next(frames)
+        except StopIteration:
+            raise asyncio.CancelledError()
+
+    driver._ws.recv = _fake_recv
+    with pytest.raises(asyncio.CancelledError):
+        await transport._reader_loop()
+    assert fut.result() == {"id": 42, "result": {"value": "hello"}}
+
+
+@pytest.mark.asyncio
+async def test_cdp_calls_driver_reconnect_on_socket_death_then_retries():
+    """On a socket-death send failure, _cdp must call back into
+    driver.reconnect() exactly once and retry once (the _retry guard). The
+    reader task resolves the retry attempt's future."""
+    transport, driver = _make_transport()
+
+    send_calls = {"n": 0}
+
+    async def _flaky_send(payload):
+        send_calls["n"] += 1
+        ws.sent.append(payload)
+        if send_calls["n"] == 1:
+            raise ConnectionError("connection closed")
+
+    ws = FakeWebSocket()
+    ws.enqueue(2, {"ok": True})  # response for the retried (second) attempt
+    ws.send = _flaky_send  # first send raises, second succeeds
+    driver._ws = ws
+    driver._reader_task = asyncio.create_task(transport._reader_loop())
+
+    await transport._cdp("Test.A", {}, timeout=5, _retry=True)
+
+    driver._reader_task.cancel()
+    try:
+        await driver._reader_task
+    except asyncio.CancelledError:
+        pass
+
+    driver.reconnect.assert_awaited_once()
+    assert send_calls["n"] == 2  # failed once, retried once after reconnect
+
+
+# ── 3. JS wrappers reach the driver-facing _cdp / _js seam ────────────
+#
+# The transport's _js → _cdp and _js_with_data → _js internal routing goes
+# through self._driver (the driver-facing seam), NOT self. This preserves
+# monkeypatch interception: tests patch driver._cdp / driver._js and expect
+# them to intercept — the same seam BackendClient relies on for its driver
+# transport calls.
+
+
+@pytest.mark.asyncio
+async def test_js_reaches_driver_cdp_and_unwraps_value():
+    transport, driver = _make_transport()
+
+    async def _fake_cdp(method, params=None, timeout=15, _retry=True):
+        return {"result": {"result": {"value": "v"}}}
+
+    driver._cdp = _fake_cdp
+    assert await transport._js("expr") == "v"
+
+
+@pytest.mark.asyncio
+async def test_js_with_data_injects_data_as___D():
+    """_js_with_data wraps the template into an IIFE passing __D as a JSON
+    argument (never string-concatenated), then delegates to driver._js."""
+    transport, driver = _make_transport()
+    captured = {}
+
+    async def _fake_js(expr, timeout=15):
+        captured["expr"] = expr
+        return "wrapped-seen"
+
+    driver._js = _fake_js
+    out = await transport._js_with_data("doThing(__D.x)", {"x": 'esc"aped'})
+    assert out == "wrapped-seen"
+    # The data must be JSON-serialized, not concatenated raw.
+    assert '__D) => (doThing(__D.x))' in captured["expr"]
+    assert '{"x": "esc\\"aped"}' in captured["expr"]
+
+
+@pytest.mark.asyncio
+async def test_js_strict_raises_cdp_error_on_error_blob():
+    from chatgpt_web2api.cdp_driver import CDPJSError
+
+    transport, driver = _make_transport()
+
+    async def _fake_cdp(method, params=None, timeout=15, _retry=True):
+        return {"error": {"message": "execution context destroyed"}}
+
+    driver._cdp = _fake_cdp
+    with pytest.raises(CDPJSError):
+        await transport._js_strict("expr")
+
+
+@pytest.mark.asyncio
+async def test_js_with_data_strict_delegates_to_driver_js_strict():
+    transport, driver = _make_transport()
+    seen = {}
+
+    async def _fake_js_strict(expr, timeout=15):
+        seen["expr"] = expr
+        return "strict-seen"
+
+    driver._js_strict = _fake_js_strict
+    out = await transport._js_with_data_strict("t(__D.n)", {"n": 1})
+    assert out == "strict-seen"
+    assert "(__D) => (t(__D.n))" in seen["expr"]
+
+
+# ── 4. State stays on the driver (not migrated into the transport) ────
+
+
+def test_transport_holds_no_socket_state():
+    """The transport must NOT own _ws / _msg_id / _pending / _reader_task —
+    those stay on the driver so connect/reconnect/close and test stubs that
+    poke driver._ws / driver._pending keep working."""
+    transport, _ = _make_transport()
+    for attr in ("_ws", "_msg_id", "_pending", "_reader_task"):
+        assert not hasattr(transport, attr), (
+            f"CDPTransport must not own driver state '{attr}' (Phase 5 PR2 contract)"
+        )
+
+
+# ── 5. Integration: CDPDriver wires CDPTransport in __init__ ──────────
+
+
+def test_driver_wires_cdp_transport():
+    """CDPDriver.__init__ constructs a CDPTransport and delegates through it."""
+    from chatgpt_web2api.cdp_driver import CDPDriver
+
+    d = CDPDriver(cdp_port=9222)
+    assert isinstance(d._transport, CDPTransport)
+    assert d._transport._driver is d
+
+
+def test_driver_delegators_preserve_signatures():
+    """All 7 moved methods remain callable on the driver (delegators), so
+    internal call sites and test stubs that patch driver._js / driver._cdp
+    etc. keep working unchanged."""
+    from chatgpt_web2api.cdp_driver import CDPDriver
+
+    d = CDPDriver(cdp_port=9222)
+    for name in (
+        "_reader_loop",
+        "_cdp",
+        "_js",
+        "_js_strict",
+        "_js_with_data",
+        "_js_with_data_strict",
+    ):
+        assert callable(getattr(d, name, None)), f"CDPDriver lost delegator {name}"
+    assert callable(CDPDriver._should_reconnect)

--- a/tests/test_js_injection.py
+++ b/tests/test_js_injection.py
@@ -9,28 +9,8 @@ A live integration test surfaced it; these tests guard the fix.
 """
 
 import json
-from unittest.mock import MagicMock
 
 import pytest
-
-
-def _capture_generated_expr(monkeypatch):
-    """Return the JS expression that _js_with_data would send to CDP.
-
-    We intercept ``CDPDriver._js`` to capture the assembled expression so we
-    can assert on its structure (IIFE scoping) without a live browser.
-    """
-
-    captured: dict = {}
-
-    async def fake_js(expr, timeout=15):
-        captured["expr"] = expr
-        return ""
-
-    driver = MagicMock()
-    driver._js = fake_js
-    return driver, captured
-
 
 # ── The fix: __D must be block-scoped, not global ─────────────
 
@@ -44,16 +24,14 @@ async def test_js_with_data_does_not_declare_global___D():
     (IIFE) so __D is local.
     """
     from chatgpt_web2api.cdp_driver import CDPDriver
-    driver = MagicMock()
+    driver = CDPDriver(cdp_port=9222)
     captured = {}
     async def fake_js(expr, timeout=15):
         captured["expr"] = expr
         return "ok"
     driver._js = fake_js
 
-    await CDPDriver._js_with_data(
-        driver, "return __D.x;", {"x": 1}
-    )
+    await driver._js_with_data("return __D.x;", {"x": 1})
 
     expr = captured["expr"]
     # The dangerous form: a top-level "const __D = ..." declaration.
@@ -81,7 +59,7 @@ async def test_js_with_data_still_passes_data_through():
     and the body text is preserved.
     """
     from chatgpt_web2api.cdp_driver import CDPDriver
-    driver = MagicMock()
+    driver = CDPDriver(cdp_port=9222)
     captured = {}
     async def fake_js(expr, timeout=15):
         captured["expr"] = expr
@@ -89,7 +67,7 @@ async def test_js_with_data_still_passes_data_through():
     driver._js = fake_js
 
     payload = {"token": "abc123", "conv_id": "xyz"}
-    await CDPDriver._js_with_data(driver, "__D.token + __D.conv_id", payload)
+    await driver._js_with_data("__D.token + __D.conv_id", payload)
 
     expr = captured["expr"]
     # The data must be embedded (json-serialized) somewhere in the expression
@@ -102,10 +80,10 @@ async def test_js_with_data_still_passes_data_through():
 async def test_js_with_data_returns_driver_value():
     """The return value of _js_with_data is whatever _js returns."""
     from chatgpt_web2api.cdp_driver import CDPDriver
-    driver = MagicMock()
+    driver = CDPDriver(cdp_port=9222)
     async def fake_js(expr, timeout=15):
         return "RESULT"
     driver._js = fake_js
 
-    out = await CDPDriver._js_with_data(driver, "1", {"a": 1})
+    out = await driver._js_with_data("1", {"a": 1})
     assert out == "RESULT"


### PR DESCRIPTION
Extracts the **Layer-1 CDP wire primitives** from `CDPDriver` into a new `CDPTransport` collaborator, following the exact `backend_client.py` (PR1) convention: method bodies move, thin delegators stay on `CDPDriver`, all shared state stays on the driver.

## Moved to `CDPTransport`

| Method | Role |
|---|---|
| `_reader_loop` | Sole `_ws.recv()` consumer; routes by id to `_pending` |
| `_cdp` | Send + await via future table; one reconnect-retry on socket death |
| `_should_reconnect` | Pure socket-death error classifier (staticmethod) |
| `_js` | Soft `Runtime.evaluate` (returns `""` on failure) |
| `_js_strict` | Strict `Runtime.evaluate` (raises `CDPJSError`) |
| `_js_with_data` | Safe `__D` data injection (soft) |
| `_js_with_data_strict` | Strict variant |

## Layer 2 stays in `cdp_driver.py`

`connect`, `reconnect`, tab discovery (`_find_page_ws` / `_find_owned_tab_ws` / `_adopt_existing_chatgpt_tab` / `_create_owned_tab`), `_browser_cdp`, `_live_target_ids`, `_wait_for_chatgpt_ready`, `close`, heartbeat methods. **`reconnect` owns breaker semantics (`CDP_RECONNECT` record_success/failure) and is NOT moved or duplicated** — `_cdp` calls back into `driver.reconnect()` for the one-shot reconnect-retry but transports no breaker logic. `_browser_cdp` stays with the tab-orchestration path (browser-domain CDP, not the active page-WS wire layer).

## Convention (identical to PR1)

- State stays on `CDPDriver`: `_ws`, `_msg_id`, `_pending`, `_reader_task`. `CDPTransport` reaches through `self._driver`, exactly as `BackendClient` reaches through `self._driver._access_token`.
- **Driver-facing seam preserved**: `_js` routes to `self._driver._cdp` (not `self._cdp`) and `_js_with_data` routes to `self._driver._js`, so monkeypatches of `driver._cdp` / `driver._js` keep intercepting — the same seam `BackendClient` and the test suite rely on.
- `CDPDriver` keeps thin delegators for all 7 methods with byte-identical signatures; `self._transport = CDPTransport(self)` wired in `__init__`.

## Verification against acceptance bar

| Requirement | Status |
|---|---|
| add `cdp_transport.py` | ✅ |
| wire `self._transport = CDPTransport(self)` in `__init__` | ✅ |
| 7 `CDPDriver` delegators, same signatures | ✅ |
| `_ws`/`_msg_id`/`_pending`/`_reader_task` stay on `CDPDriver` | ✅ (grep audit: no transport-local socket state) |
| `_browser_cdp` stays in `cdp_driver.py` | ✅ (docstring-only ref in transport) |
| `reconnect` + breaker semantics stay in `cdp_driver.py` | ✅ (no breaker code in transport) |
| no `backend_client.py` edits | ✅ (zero diff) |
| `_cdp` still retries once through `driver.reconnect()` | ✅ (test guards this) |
| `_reader_loop` still sole recv consumer / pending resolver | ✅ (test guards this) |

## Tests

- **`tests/test_cdp_transport.py`** (new, 12 tests): every method exists on `CDPTransport`; `_should_reconnect` is a staticmethod; transport reaches `driver._ws`/`_msg_id`/`_pending` (not local); `_js` routes through `driver._cdp`; `_js_with_data` injects `__D` as a JSON arg; `_js_strict` raises `CDPJSError` on error blob; reconnect-on-socket-death calls `driver.reconnect()` once and retries; state stays on driver; driver wires `_transport` in `__init__`; delegators preserved on driver.
- **`tests/test_js_injection.py`**: construct a real `CDPDriver` instead of a raw `MagicMock` so the `_transport` seam resolves. The IIFE-wrapping assertions are unchanged — this fixes construction, not behavior.
- **Behavior is covered by existing `test_cdp_foundation.py`** (concurrent `_cdp`, pending cleanup, reader-on-socket-close) which exercises the methods through the driver facade — green, unchanged.

## Verification

- `ruff check` on all 4 changed files: **clean** (24 pre-existing errors elsewhere, identical on `master`).
- `pytest`: **446 passed** (was 434; +12 new transport tests).

## Changed files (4)
- `src/chatgpt_web2api/cdp_transport.py` — **new**, 7 method bodies + lazy `CDPJSError` import
- `src/chatgpt_web2api/cdp_driver.py` — bodies → delegators; `self._transport` wired in `__init__`
- `tests/test_cdp_transport.py` — **new**, 12 wiring tests
- `tests/test_js_injection.py` — construct real driver (seam fix), assertions unchanged

Follows ROADMAP Phase 5 PR2.