### PR TITLE
refactor: extract chatgpt_dom.py (Phase 5 PR3, no behavior change)

### DIFF
--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -74,31 +74,17 @@ PHASE_STALL_SECONDS = 90
 # matches ``navigate_new_chat``.
 _CONNECT_READY_TIMEOUT = 10
 
-# ChatGPT composer selectors (post-2026 composer redesign).
+# ChatGPT composer / send-button selectors.
 #
-# The old composer was a real <textarea id="prompt-textarea">. The new
-# composer is a contenteditable ProseMirror div; the element that still
-# carries id="prompt-textarea" is a HIDDEN fallback (<textarea
-# class="wcDTda_fallbackTextarea">) that overlays the real composer when
-# JS is off. Typing into it does not reach the composer, so the message
-# never lands — every send then fails with "no send button" because the
-# composer is empty. These selectors target the real, interactive nodes.
-#
-# COMPOSER_SELECTOR is the primary target; the #prompt-textarea fallback
-# is kept as a last-resort so the driver still works if ChatGPT rolls
-# the composer back (or on an A/B holdout that hasn't shipped the new
-# UI). Both are tried in preference order by the helpers below.
-COMPOSER_SELECTOR = 'div[role="textbox"]#prompt-textarea, div[role="textbox"].ProseMirror'
-COMPOSER_FALLBACK_SELECTOR = "textarea#prompt-textarea"
-
-# The send button. The new composer has no data-testid="send-button" —
-# its affordances are composer-plus-btn and dictation, plus a
-# stop-button while generating. The send affordance is the submit
-# <button> inside the composer form whose aria-label is "send" (and
-# which is not the stop button). We match by aria-label first, then by
-# the legacy testid for older deployments.
-SEND_BUTTON_SELECTOR = 'button[aria-label*="Send" i]:not([data-testid="stop-button"])'
-SEND_BUTTON_FALLBACK_SELECTOR = 'button[data-testid="send-button"]'
+# Canonical home moved to chatgpt_dom.py in Phase 5 PR3; re-exported here for
+# back-compat (tests import these from cdp_driver, and the navigation methods
+# that stay here still reference them).
+from .chatgpt_dom import (  # noqa: E402,F401
+    COMPOSER_FALLBACK_SELECTOR,
+    COMPOSER_SELECTOR,
+    SEND_BUTTON_FALLBACK_SELECTOR,
+    SEND_BUTTON_SELECTOR,
+)
 
 
 class RateLimitError(RuntimeError):
@@ -342,6 +328,13 @@ class CDPDriver:
         from .cdp_transport import CDPTransport
 
         self._transport = CDPTransport(self)
+        # Phase 5 PR3: ChatGPT composer DOM interaction extracted into
+        # ChatGPTDom. Lazy import for the same reason; the DOM layer reaches
+        # through this driver for _js/_cdp/_breakers and calls back into
+        # navigate_new_chat() for the send-readiness path.
+        from .chatgpt_dom import ChatGPTDom
+
+        self._dom = ChatGPTDom(self)
 
     async def connect(self) -> None:
         """Connect to Chrome's CDP and authenticate.
@@ -1048,70 +1041,23 @@ class CDPDriver:
     async def _has_composer(self) -> bool:
         """Is a send-capable composer present on the live tab?
 
-        True only when one of the known composer selectors matches. The home/
-        landing page is auth-valid but NOT send-valid: it has a different,
-        unnamed textarea that none of these selectors match, so a tab on
-        ``chatgpt.com/`` (or any non-chat page) returns False. Authentication
-        and send-readiness are separate invariants — this one is send-readiness.
-        """
-        try:
-            result = await self._js(
-                "(function(){"
-                f"  return JSON.stringify({{"
-                f"    ready: !!document.querySelector('{COMPOSER_SELECTOR}')"
-                f"         || !!document.querySelector('{COMPOSER_FALLBACK_SELECTOR}')"
-                "  });"  # {{ opens the object literal; a single } closes it
-                "})()"
-            )
-            return json.loads(result).get("ready") is True
-        except (json.JSONDecodeError, TypeError, CDPJSError):
-            return False
+        Delegated to ChatGPTDom (Phase 5 PR3 extraction)."""
+        return await self._dom._has_composer()
 
     async def _ensure_send_ready(self) -> None:
         """Guarantee the live tab can accept a typed message.
 
-        ``connect()`` may attach to a ``chatgpt.com/`` home/landing tab (or
-        adopt an arbitrary existing ChatGPT tab). Such a tab is auth-valid but
-        not send-valid: it lacks the real composer, so the very next
-        ``type_message`` would raise "No composer found" and — through the REST
-        layer — surface as an opaque "no close frame received or sent" 500.
-        This normalizes the tab into a usable chat page before ``connect()``
-        returns, establishing the invariant the rest of the driver assumes:
-        a connected driver is a send-capable driver.
-
-        The composer renders lazily on the home shell (the sidebar hydrates
-        first, the composer seconds later), so a single ``_has_composer``
-        probe races the render. We poll briefly first; only if that window
-        passes without a composer do we navigate (to ``?model=auto``, which
-        renders the real composer — see ``navigate_new_chat``) and re-check.
+        Delegated to ChatGPTDom (Phase 5 PR3 extraction). Preserved exactly:
+        poll-then-navigate-via-``navigate_new_chat``, COMPOSER_SEND_READINESS
+        breaker record_failure on persistent failure (registry stays on driver).
         """
-        if await self._wait_for_composer(timeout=8):
-            return
-        logger.info(
-            "Attached tab has no composer after waiting; navigating to a new chat "
-            "to become send-ready"
-        )
-        await self.navigate_new_chat()  # navigates to ?model=auto + polls composer
-        if not await self._wait_for_composer(timeout=5):
-            await self._capture_selector_diagnostic("composer (connect send-ready)")
-            if self._breakers:
-                self._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
-            raise SendReadinessError("No composer found after navigating to a new chat")
+        await self._dom._ensure_send_ready()
 
     async def _wait_for_composer(self, timeout: float = 8) -> bool:
         """Poll until a composer appears, or *timeout* seconds elapse.
 
-        Returns True if a composer is present within the window, False on
-        timeout. Never raises — callers decide fail-closed behavior. The
-        composer on the home shell hydrates a few seconds after the sidebar,
-        so a single probe races it; this wait absorbs that render delay.
-        """
-        deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
-            if await self._has_composer():
-                return True
-            await asyncio.sleep(0.5)
-        return False
+        Delegated to ChatGPTDom (Phase 5 PR3 extraction)."""
+        return await self._dom._wait_for_composer(timeout)
 
     async def navigate_conversation(self, conversation_id: str) -> None:
         """Navigate to an existing conversation for multi-turn.
@@ -1223,235 +1169,33 @@ class CDPDriver:
     async def type_message(self, text: str) -> None:
         """Type text into the ChatGPT composer.
 
-        The new composer is a contenteditable ProseMirror div; the legacy
-        composer was a <textarea id="prompt-textarea">. We focus the new
-        textbox first (COMPOSER_SELECTOR), falling back to the textarea
-        for older deployments. Once focused, ``Input.insertText`` routes
-        the text to whichever element holds focus, so the same insert
-        works for both layouts.
+        Delegated to ChatGPTDom (Phase 5 PR3 extraction). Preserved exactly:
+        focus → platform-aware select-all → CDP insertText → canonical verify
+        with one retry; COMPOSER_SEND_READINESS breaker record_failure on
+        persistent failure (registry stays on driver).
         """
-        # Focus the composer. Try the ProseMirror textbox first, then the
-        # legacy textarea fallback. Returns which one was focused (or
-        # 'no composer') so the verify step reads the right element.
-        focus_result = await self._js(
-            "(function() {"
-            f"  var el = document.querySelector('{COMPOSER_SELECTOR}');"
-            "  if (el) { el.focus(); return 'composer'; }"
-            f"  var fb = document.querySelector('{COMPOSER_FALLBACK_SELECTOR}');"
-            "  if (fb) { fb.focus(); return 'fallback'; }"
-            "  return 'no composer';"
-            "})()"
-        )
-        if focus_result == "no composer":
-            await self._capture_selector_diagnostic("composer (type_message)")
-            if self._breakers:
-                self._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
-            raise SendReadinessError("No composer found")
-        focused_target = focus_result  # 'composer' or 'fallback'
-
-        # Clear existing text and insert. Prefer a platform-aware select-all
-        # via keyboard events (modifiers: 2 = Ctrl on Win/Linux, 4 = Cmd on
-        # macOS — detected at runtime so select-all doesn't silently no-op on
-        # Mac). Insert via CDP, dispatched to the focused composer.
-        select_all_mods = await self._detect_select_all_modifier()
-        await self._cdp(
-            "Input.dispatchKeyEvent",
-            {
-                "type": "rawKeyDown",
-                "key": "a",
-                "code": "KeyA",
-                "windowsVirtualKeyCode": 65,
-                "modifiers": select_all_mods,
-            },
-        )
-        await self._cdp(
-            "Input.dispatchKeyEvent",
-            {
-                "type": "keyUp",
-                "key": "a",
-                "code": "KeyA",
-                "windowsVirtualKeyCode": 65,
-                "modifiers": select_all_mods,
-            },
-        )
-        await asyncio.sleep(0.1)
-        await self._cdp("Input.insertText", {"text": text})
-        await asyncio.sleep(0.5)
-
-        # Verify the composer holds EXACTLY the intended input (canonicalized),
-        # not just "is non-empty". With ProseMirror contenteditable, a stale or
-        # partially-cleared composer passes a non-empty check while corrupting
-        # the prompt — so we compare canonical editor-visible text. On mismatch,
-        # retry once: clear via execCommand('selectAll') + delete (ProseMirror
-        # sees editor-like input events), re-insert, re-verify. Only then raise.
-        verify_selector = (
-            COMPOSER_SELECTOR if focused_target == "composer" else COMPOSER_FALLBACK_SELECTOR
-        )
-        if not await self._verify_composer_text(verify_selector, text):
-            logger.warning(
-                "Composer text mismatch on first insert; retrying with execCommand clear"
-            )
-            await self._js_strict(
-                "(function(){"
-                f"  var el = document.querySelector('{verify_selector}');"
-                "  if (el) {"
-                "    if (el.tagName === 'TEXTAREA') {"
-                "      el.focus(); el.select();"
-                "      try { document.execCommand('delete'); } catch(e) {}"
-                "    } else {"
-                "      el.focus();"
-                "      var sel = window.getSelection(); sel.removeAllRanges();"
-                "      var range = document.createRange(); range.selectNodeContents(el);"
-                "      sel.addRange(range);"
-                "      try { document.execCommand('delete'); } catch(e) {}"
-                "    }"
-                "  }"
-                "  return true;"
-                "})()"
-            )
-            await asyncio.sleep(0.1)
-            await self._cdp("Input.insertText", {"text": text})
-            await asyncio.sleep(0.5)
-            if not await self._verify_composer_text(verify_selector, text):
-                if self._breakers:
-                    self._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
-                raise SendReadinessError(
-                    f"Composer text verification failed after retry; expected {text[:60]!r}"
-                )
-        logger.info("Typed: %s", text[:80])
+        await self._dom.type_message(text)
 
     async def _detect_select_all_modifier(self) -> int:
         """Return the CDP modifiers value for select-all on the live platform.
 
-        ``2`` = Ctrl (Windows/Linux), ``4`` = Cmd (macOS). Probed once via
-        ``navigator.userAgentData``/``navigator.platform`` so the keyboard
-        select-all doesn't silently no-op on macOS (where Cmd, not Ctrl,
-        selects all). Falls back to Ctrl (2) on any probe failure.
-        """
-        try:
-            ua = await self._js_strict(
-                "(navigator.userAgentData && navigator.userAgentData.platform)"
-                " || navigator.platform || ''"
-            )
-            if ua and "mac" in ua.lower():
-                return 4
-        except CDPJSError:
-            pass
-        return 2
+        Delegated to ChatGPTDom (Phase 5 PR3 extraction)."""
+        return await self._dom._detect_select_all_modifier()
 
     async def _verify_composer_text(self, selector: str, expected: str) -> bool:
         """Canonical-equality check: does the composer hold *expected*?
 
-        Compares editor-visible text with canonical normalization (CRLF→LF,
-        NBSP→space, tolerate a trailing block newline ProseMirror adds) — but
-        does NOT broadly collapse internal whitespace, since that would hide
-        real corruption of code/YAML/Markdown indentation.
-
-        For a contenteditable ProseMirror div, neither ``innerText`` nor
-        ``textContent`` reconstructs what the user typed across line breaks:
-        ``\n`` in the input becomes a new ``<p>`` block, and ProseMirror
-        renders blank-line paragraphs as ``<p><br></p>``. ``innerText`` then
-        emits *several* newlines per block boundary (measured: a 2-newline
-        input read back as 5), while ``textContent`` joins blocks with
-        *nothing* (0 newlines). Both fail canonical equality for any
-        multi-line prompt. The fix is a block-aware extractor: join each
-        top-level block child's text with a single ``\n``, and treat an
-        empty block (the ``<br>``-only paragraph from a blank line) as one
-        newline. This reconstructs the typed text faithfully for both
-        single-line and multi-line input. Legacy ``<textarea>`` still reads
-        ``.value``, which is already exact.
-        """
-        try:
-            actual = await self._js_strict(
-                "(function(){"
-                f"  var el = document.querySelector('{selector}');"
-                "  if (!el) return '';"
-                "  if (el.tagName === 'TEXTAREA') return el.value;"
-                # Block-aware read for contenteditable. Walk the immediate
-                # child nodes; each element block contributes its text plus
-                # one trailing newline, each text node contributes itself.
-                # An empty block (the <br>-only paragraph from a blank line)
-                # collapses to a single blank line, matching a typed "\n\n".
-                # This yields exactly the number of newlines the user typed.
-                "  var parts = [];"
-                "  function blockText(node) {"
-                "    return (node.textContent || '').replace(/\\u00a0/g, ' ');"
-                "  }"
-                "  for (var i = 0; i < el.childNodes.length; i++) {"
-                "    var child = el.childNodes[i];"
-                "    if (child.nodeType === 3) { parts.push(child.nodeValue || ''); }"
-                "    else if (child.nodeType === 1) {"
-                "      parts.push(blockText(child));"
-                "    }"
-                "  }"
-                "  var joined = parts.join('\\n');"
-                # ProseMirror may append a trailing empty <p>/<br> block that
-                # adds a stray trailing newline; strip at most one to mirror
-                # the single-trailing-newline tolerance below.
-                "  return joined.replace(/\\n$/, '');"
-                "})()"
-            )
-        except CDPJSError:
-            return False
-        if not actual:
-            return False
-        canon_actual = actual.replace("\r\n", "\n").replace("\r", "\n").replace("\u00a0", " ")
-        canon_expected = expected.replace("\r\n", "\n").replace("\r", "\n").replace("\u00a0", " ")
-        # ProseMirror wraps input in a <p> and may append a trailing block
-        # newline. Tolerate AT MOST ONE editor-added trailing newline — but
-        # never strip a user-intended trailing newline. So accept an exact
-        # match, OR actual == expected + one editor newline. (Stripping
-        # unconditionally would corrupt prompts that legitimately end in \n.)
-        return canon_actual == canon_expected or canon_actual == canon_expected + "\n"
+        Delegated to ChatGPTDom (Phase 5 PR3 extraction)."""
+        return await self._dom._verify_composer_text(selector, expected)
 
     async def click_send(self) -> None:
         """Click the send button via JS MouseEvent sequence.
 
-        The new composer has no ``data-testid="send-button"``; its send
-        affordance is the submit ``<button aria-label="Send ...">`` inside
-        the composer form. We prefer that, falling back to the legacy
-        testid selector for older deployments. The stop button (which
-        appears during generation) is explicitly excluded — it also
-        carries an aria-label, but never "Send".
-        """
-        # Wait for the send button to appear and be enabled. Try the new
-        # aria-label selector first, then the legacy testid fallback.
-        for _ in range(10):
-            has_btn = await self._js(
-                "(function() {"
-                f"  var btn = document.querySelector('{SEND_BUTTON_SELECTOR}')"
-                f"       || document.querySelector('{SEND_BUTTON_FALLBACK_SELECTOR}');"
-                "  return btn && !btn.disabled ? 'yes' : 'no';"
-                "})()"
-            )
-            if has_btn == "yes":
-                break
-            await asyncio.sleep(0.3)
-
-        result = await self._js(
-            "(function() {"
-            f"  var btn = document.querySelector('{SEND_BUTTON_SELECTOR}')"
-            f"       || document.querySelector('{SEND_BUTTON_FALLBACK_SELECTOR}');"
-            "  if (!btn) return 'no send button';"
-            "  if (btn.disabled) return 'button disabled';"
-            "  var evts = ['pointerdown','mousedown','pointerup','mouseup','click'];"
-            "  for (var i = 0; i < evts.length; i++) {"
-            "    btn.dispatchEvent(new MouseEvent(evts[i], {bubbles:true, cancelable:true, view:window}));"
-            "  }"
-            "  return 'sent';"
-            "})()"
-        )
-        if result != "sent":
-            await self._capture_selector_diagnostic("send-button (click_send)")
-            if self._breakers:
-                self._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
-            raise SendReadinessError(f"Send failed: {result}")
-        logger.info("Message sent")
-        # Success: clear composer failure history and recover a half-open
-        # breaker. Only after the message is confirmed sent — not after
-        # type_message alone, since a successful type can still fail to send.
-        if self._breakers:
-            self._breakers.record_success(BreakerKind.COMPOSER_SEND_READINESS)
+        Delegated to ChatGPTDom (Phase 5 PR3 extraction). Preserved exactly:
+        aria-label-then-legacy selector, COMPOSER_SEND_READINESS breaker
+        record_failure on miss / record_success on confirmed send (registry
+        stays on driver)."""
+        await self._dom.click_send()
 
     # ── Response Retrieval ────────────────────────────────────
 
@@ -1887,60 +1631,10 @@ class CDPDriver:
     async def dismiss_rate_limit(self) -> bool:
         """Dismiss ChatGPT's 'Too many requests' pop-up by clicking 'Got it'.
 
-        Targets the pop-up by its text ('Too many requests') rather than fragile
-        class names: find the ``[role=dialog]`` whose text matches, then click
-        the button inside it whose text is 'Got it'. After clicking, re-scan the
-        page to confirm the pop-up cleared.
-
-        Best-effort: never raises. Returns True if the pop-up is gone after the
-        attempt, False if it couldn't be dismissed (button missing, or the
-        limit persists), None if the status is unknown (scan error — the
-        click may have succeeded but we can't confirm). Callers should retry
-        on False but NOT on None, to avoid hammering an already-dismissed pop-up.
+        Delegated to ChatGPTDom (Phase 5 PR3 extraction). Preserved exactly:
+        text-targeted click + re-scan, tri-state return (True/False/None).
         """
-        click_js = (
-            "(function(){"
-            "  try {"
-            "    var dlgs = document.querySelectorAll('[role=dialog]');"
-            "    var target = null;"
-            "    for (var i = 0; i < dlgs.length; i++) {"
-            "      if (/too many requests/i.test(dlgs[i].innerText || '')) { target = dlgs[i]; break; }"
-            "    }"
-            "    if (!target) return JSON.stringify({clicked: false});"
-            "    var btns = target.querySelectorAll('button');"
-            "    var btn = null;"
-            "    for (var j = 0; j < btns.length; j++) {"
-            "      if ((btns[j].innerText || '').trim().toLowerCase() === 'got it') { btn = btns[j]; break; }"
-            "    }"
-            "    if (!btn) return JSON.stringify({clicked: false});"
-            "    btn.click();"
-            "    return JSON.stringify({clicked: true});"
-            "  } catch(e) { return JSON.stringify({clicked: false, error: e.message}); }"
-            "})()"
-        )
-        try:
-            click_raw = await self._js_strict(click_js, timeout=10)
-            clicked = json.loads(click_raw).get("clicked", False) if click_raw else False
-        except Exception:  # best-effort: never raise
-            logger.warning("dismiss_rate_limit: click failed", exc_info=True)
-            return None  # unknown — don't trigger retry storm
-        if not clicked:
-            return False
-
-        # Re-scan to confirm the pop-up cleared.
-        try:
-            scan = await self._js_strict(
-                "(function(){var t=(document.body&&document.body.innerText)||'';"
-                "return JSON.stringify({text:t.slice(0,4000)});})()",
-                timeout=10,
-            )
-            text = json.loads(scan).get("text", "") if scan else ""
-        except Exception:
-            # #19: If the re-scan errors, the status is unknown (not False).
-            # Returning False would trigger a retry storm against an already-
-            # dismissed pop-up; returning None lets callers skip the retry.
-            return None
-        return not is_rate_limited_text(text)
+        return await self._dom.dismiss_rate_limit()
 
     def _check_auth_in_raw(self, raw: str) -> None:
         """#20: Detect auth failure in raw response text and raise.
@@ -1951,27 +1645,9 @@ class CDPDriver:
     async def _capture_selector_diagnostic(self, selector_name: str) -> None:
         """#5: Capture DOM state when a selector fails to match.
 
-        Logs a diagnostic snapshot (URL, title, body text preview, button count)
-        so selector drift is diagnosable without W2A_DIAGNOSE=1. Called at
-        the point of selector failure (e.g. 'no send button', 'No textarea').
-        Best-effort — never raises.
-        """
-        try:
-            snapshot = await self._js_strict(
-                "(function(){"
-                "  return JSON.stringify({"
-                "    url: location.href,"
-                "    title: document.title,"
-                "    body_preview: (document.body && document.body.innerText || '').slice(0, 300),"
-                "    button_count: document.querySelectorAll('button').length,"
-                "    textarea_count: document.querySelectorAll('textarea').length"
-                "  });"
-                "})()",
-                timeout=5,
-            )
-            logger.warning("Selector drift diagnostic (%s): %s", selector_name, snapshot)
-        except Exception:
-            logger.warning("Selector drift diagnostic (%s): capture failed", selector_name)
+        Delegated to ChatGPTDom (Phase 5 PR3 extraction). Best-effort — never
+        raises."""
+        await self._dom._capture_selector_diagnostic(selector_name)
 
     # ── API helpers ───────────────────────────────────────────
 

--- a/src/chatgpt_web2api/chatgpt_dom.py
+++ b/src/chatgpt_web2api/chatgpt_dom.py
@@ -1,0 +1,518 @@
+"""ChatGPT DOM interaction — composer/send-button/rate-limit DOM helpers.
+
+Phase 5 PR3 extraction (no behavior change). Owns the ChatGPT-composer
+interaction surface that was previously inlined in ``CDPDriver``:
+
+  - composer selectors (``COMPOSER_SELECTOR`` etc.)
+  - composer presence / send-readiness (``_has_composer``,
+    ``_wait_for_composer``, ``_ensure_send_ready``)
+  - message typing / verification (``type_message``,
+    ``_detect_select_all_modifier``, ``_verify_composer_text``)
+  - send button click (``click_send``)
+  - rate-limit popup dismissal (``dismiss_rate_limit``)
+  - selector-drift diagnostics (``_capture_selector_diagnostic``)
+
+The driver-reference collaborator seam: ``ChatGPTDom`` holds a reference to
+its owning ``CDPDriver`` and reaches through it for the CDP transport
+(``_js`` / ``_js_strict`` / ``_cdp``), for shared mutable state
+(``_breakers``, ``_current_conv_id``), and for navigation peers
+(``navigate_new_chat``). None of that state migrates into this module — it
+stays on the driver so external attribute reads and test stubs keep working
+unchanged.
+
+Boundary: this module is the ChatGPT page DOM-interaction layer. Connection
+lifecycle, navigation (``navigate_new_chat`` / ``navigate_conversation`` /
+``navigate_gpt`` / ``select_model``), ``send_and_stream`` orchestration, and
+conversation-id ownership stay in ``cdp_driver.py``.
+
+Breaker rule: three methods record ``BreakerKind.COMPOSER_SEND_READINESS``
+failures/successes. The breaker registry STAYS on the driver; this module
+only calls ``record_failure`` / ``record_success`` through
+``self._driver._breakers``. No breaker-policy code moves.
+
+Call-rule inside ChatGPTDom method bodies — every internal call routes
+through ``self._driver`` (NOT ``self``) to preserve monkeypatch interception
+on the driver-facing seam (the PR2 lesson):
+
+  transport:        self._driver._js(...)
+                    self._driver._js_strict(...)
+                    self._driver._cdp(...)
+  moved DOM peers:  self._driver._verify_composer_text(...)
+                    self._driver._detect_select_all_modifier(...)
+                    self._driver._has_composer(...)
+                    self._driver._capture_selector_diagnostic(...)
+  navigation:       self._driver.navigate_new_chat(...)
+  breaker:          self._driver._breakers.record_failure(...)
+                    self._driver._breakers.record_success(...)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+
+from .breakers import BreakerKind
+
+logger = logging.getLogger(__name__)
+
+
+# ChatGPT composer selectors (post-2026 composer redesign).
+#
+# The old composer was a real <textarea id="prompt-textarea">. The new
+# composer is a contenteditable ProseMirror div; the element that still
+# carries id="prompt-textarea" is a HIDDEN fallback (<textarea
+# class="wcDTda_fallbackTextarea">) that overlays the real composer when
+# JS is off. Typing into it does not reach the composer, so the message
+# never lands — every send then fails with "no send button" because the
+# composer is empty. These selectors target the real, interactive nodes.
+#
+# COMPOSER_SELECTOR is the primary target; the #prompt-textarea fallback
+# is kept as a last-resort so the driver still works if ChatGPT rolls
+# the composer back (or on an A/B holdout that hasn't shipped the new
+# UI). Both are tried in preference order by the helpers below.
+COMPOSER_SELECTOR = 'div[role="textbox"]#prompt-textarea, div[role="textbox"].ProseMirror'
+COMPOSER_FALLBACK_SELECTOR = "textarea#prompt-textarea"
+
+# The send button. The new composer has no data-testid="send-button" —
+# its affordances are composer-plus-btn and dictation, plus a
+# stop-button while generating. The send affordance is the submit
+# <button> inside the composer form whose aria-label is "send" (and
+# which is not the stop button). We match by aria-label first, then by
+# the legacy testid for older deployments.
+SEND_BUTTON_SELECTOR = 'button[aria-label*="Send" i]:not([data-testid="stop-button"])'
+SEND_BUTTON_FALLBACK_SELECTOR = 'button[data-testid="send-button"]'
+
+
+class ChatGPTDom:
+    """ChatGPT-composer DOM interaction, composed by ``CDPDriver``.
+
+    Constructed once in ``CDPDriver.__init__`` and stored as
+    ``self._dom``. The driver keeps thin delegating methods for every
+    method here so its public/private API surface is byte-identical to
+    pre-extraction.
+    """
+
+    def __init__(self, driver) -> None:
+        self._driver = driver
+
+    # ── Send readiness ────────────────────────────────────────
+
+    async def _has_composer(self) -> bool:
+        """Is a send-capable composer present on the live tab?
+
+        True only when one of the known composer selectors matches. The home/
+        landing page is auth-valid but NOT send-valid: it has a different,
+        unnamed textarea that none of these selectors match, so a tab on
+        ``chatgpt.com/`` (or any non-chat page) returns False. Authentication
+        and send-readiness are separate invariants — this one is send-readiness.
+        """
+        # Imported lazily to avoid a module-load circular dependency.
+        from .cdp_driver import CDPJSError
+
+        d = self._driver
+        try:
+            result = await d._js(
+                "(function(){"
+                f"  return JSON.stringify({{"
+                f"    ready: !!document.querySelector('{COMPOSER_SELECTOR}')"
+                f"         || !!document.querySelector('{COMPOSER_FALLBACK_SELECTOR}')"
+                "  });"  # {{ opens the object literal; a single } closes it
+                "})()"
+            )
+            return json.loads(result).get("ready") is True
+        except (json.JSONDecodeError, TypeError, CDPJSError):
+            return False
+
+    async def _wait_for_composer(self, timeout: float = 8) -> bool:
+        """Poll until a composer appears, or *timeout* seconds elapse.
+
+        Returns True if a composer is present within the window, False on
+        timeout. Never raises — callers decide fail-closed behavior. The
+        composer on the home shell hydrates a few seconds after the sidebar,
+        so a single probe races it; this wait absorbs that render delay.
+        """
+        d = self._driver
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if await d._has_composer():
+                return True
+            await asyncio.sleep(0.5)
+        return False
+
+    async def _ensure_send_ready(self) -> None:
+        """Guarantee the live tab can accept a typed message.
+
+        ``connect()`` may attach to a ``chatgpt.com/`` home/landing tab (or
+        adopt an arbitrary existing ChatGPT tab). Such a tab is auth-valid but
+        not send-valid: it lacks the real composer, so the very next
+        ``type_message`` would raise "No composer found" and — through the REST
+        layer — surface as an opaque "no close frame received or sent" 500.
+        This normalizes the tab into a usable chat page before ``connect()``
+        returns, establishing the invariant the rest of the driver assumes:
+        a connected driver is a send-capable driver.
+
+        The composer renders lazily on the home shell (the sidebar hydrates
+        first, the composer seconds later), so a single ``_has_composer``
+        probe races the render. We poll briefly first; only if that window
+        passes without a composer do we navigate (to ``?model=auto``, which
+        renders the real composer — see ``navigate_new_chat``) and re-check.
+        """
+        d = self._driver
+        if await d._wait_for_composer(timeout=8):
+            return
+        logger.info(
+            "Attached tab has no composer after waiting; navigating to a new chat "
+            "to become send-ready"
+        )
+        await d.navigate_new_chat()  # navigates to ?model=auto + polls composer
+        if not await d._wait_for_composer(timeout=5):
+            await d._capture_selector_diagnostic("composer (connect send-ready)")
+            if d._breakers:
+                d._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+            from .cdp_driver import SendReadinessError
+
+            raise SendReadinessError("No composer found after navigating to a new chat")
+
+    # ── Message typing ────────────────────────────────────────
+
+    async def type_message(self, text: str) -> None:
+        """Type text into the ChatGPT composer.
+
+        The new composer is a contenteditable ProseMirror div; the legacy
+        composer was a <textarea id="prompt-textarea">. We focus the new
+        textbox first (COMPOSER_SELECTOR), falling back to the textarea
+        for older deployments. Once focused, ``Input.insertText`` routes
+        the text to whichever element holds focus, so the same insert
+        works for both layouts.
+        """
+        d = self._driver
+        # Focus the composer. Try the ProseMirror textbox first, then the
+        # legacy textarea fallback. Returns which one was focused (or
+        # 'no composer') so the verify step reads the right element.
+        focus_result = await d._js(
+            "(function() {"
+            f"  var el = document.querySelector('{COMPOSER_SELECTOR}');"
+            "  if (el) { el.focus(); return 'composer'; }"
+            f"  var fb = document.querySelector('{COMPOSER_FALLBACK_SELECTOR}');"
+            "  if (fb) { fb.focus(); return 'fallback'; }"
+            "  return 'no composer';"
+            "})()"
+        )
+        if focus_result == "no composer":
+            await d._capture_selector_diagnostic("composer (type_message)")
+            if d._breakers:
+                d._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+            from .cdp_driver import SendReadinessError
+
+            raise SendReadinessError("No composer found")
+        focused_target = focus_result  # 'composer' or 'fallback'
+
+        # Clear existing text and insert. Prefer a platform-aware select-all
+        # via keyboard events (modifiers: 2 = Ctrl on Win/Linux, 4 = Cmd on
+        # macOS — detected at runtime so select-all doesn't silently no-op on
+        # Mac). Insert via CDP, dispatched to the focused composer.
+        select_all_mods = await d._detect_select_all_modifier()
+        await d._cdp(
+            "Input.dispatchKeyEvent",
+            {
+                "type": "rawKeyDown",
+                "key": "a",
+                "code": "KeyA",
+                "windowsVirtualKeyCode": 65,
+                "modifiers": select_all_mods,
+            },
+        )
+        await d._cdp(
+            "Input.dispatchKeyEvent",
+            {
+                "type": "keyUp",
+                "key": "a",
+                "code": "KeyA",
+                "windowsVirtualKeyCode": 65,
+                "modifiers": select_all_mods,
+            },
+        )
+        await asyncio.sleep(0.1)
+        await d._cdp("Input.insertText", {"text": text})
+        await asyncio.sleep(0.5)
+
+        # Verify the composer holds EXACTLY the intended input (canonicalized),
+        # not just "is non-empty". With ProseMirror contenteditable, a stale or
+        # partially-cleared composer passes a non-empty check while corrupting
+        # the prompt — so we compare canonical editor-visible text. On mismatch,
+        # retry once: clear via execCommand('selectAll') + delete (ProseMirror
+        # sees editor-like input events), re-insert, re-verify. Only then raise.
+        verify_selector = (
+            COMPOSER_SELECTOR if focused_target == "composer" else COMPOSER_FALLBACK_SELECTOR
+        )
+        if not await d._verify_composer_text(verify_selector, text):
+            logger.warning(
+                "Composer text mismatch on first insert; retrying with execCommand clear"
+            )
+            await d._js_strict(
+                "(function(){"
+                f"  var el = document.querySelector('{verify_selector}');"
+                "  if (el) {"
+                "    if (el.tagName === 'TEXTAREA') {"
+                "      el.focus(); el.select();"
+                "      try { document.execCommand('delete'); } catch(e) {}"
+                "    } else {"
+                "      el.focus();"
+                "      var sel = window.getSelection(); sel.removeAllRanges();"
+                "      var range = document.createRange(); range.selectNodeContents(el);"
+                "      sel.addRange(range);"
+                "      try { document.execCommand('delete'); } catch(e) {}"
+                "    }"
+                "  }"
+                "  return true;"
+                "})()"
+            )
+            await asyncio.sleep(0.1)
+            await d._cdp("Input.insertText", {"text": text})
+            await asyncio.sleep(0.5)
+            if not await d._verify_composer_text(verify_selector, text):
+                if d._breakers:
+                    d._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+                from .cdp_driver import SendReadinessError
+
+                raise SendReadinessError(
+                    f"Composer text verification failed after retry; expected {text[:60]!r}"
+                )
+        logger.info("Typed: %s", text[:80])
+
+    async def _detect_select_all_modifier(self) -> int:
+        """Return the CDP modifiers value for select-all on the live platform.
+
+        ``2`` = Ctrl (Windows/Linux), ``4`` = Cmd (macOS). Probed once via
+        ``navigator.userAgentData``/``navigator.platform`` so the keyboard
+        select-all doesn't silently no-op on macOS (where Cmd, not Ctrl,
+        selects all). Falls back to Ctrl (2) on any probe failure.
+        """
+        # Imported lazily to avoid a module-load circular dependency.
+        from .cdp_driver import CDPJSError
+
+        d = self._driver
+        try:
+            ua = await d._js_strict(
+                "(navigator.userAgentData && navigator.userAgentData.platform)"
+                " || navigator.platform || ''"
+            )
+            if ua and "mac" in ua.lower():
+                return 4
+        except CDPJSError:
+            pass
+        return 2
+
+    async def _verify_composer_text(self, selector: str, expected: str) -> bool:
+        """Canonical-equality check: does the composer hold *expected*?
+
+        Compares editor-visible text with canonical normalization (CRLF→LF,
+        NBSP→space, tolerate a trailing block newline ProseMirror adds) — but
+        does NOT broadly collapse internal whitespace, since that would hide
+        real corruption of code/YAML/Markdown indentation.
+
+        For a contenteditable ProseMirror div, neither ``innerText`` nor
+        ``textContent`` reconstructs what the user typed across line breaks:
+        ``\\n`` in the input becomes a new ``<p>`` block, and ProseMirror
+        renders blank-line paragraphs as ``<p><br></p>``. ``innerText`` then
+        emits *several* newlines per block boundary (measured: a 2-newline
+        input read back as 5), while ``textContent`` joins blocks with
+        *nothing* (0 newlines). Both fail canonical equality for any
+        multi-line prompt. The fix is a block-aware extractor: join each
+        top-level block child's text with a single ``\\n``, and treat an
+        empty block (the ``<br>``-only paragraph from a blank line) as one
+        newline. This reconstructs the typed text faithfully for both
+        single-line and multi-line input. Legacy ``<textarea>`` still reads
+        ``.value``, which is already exact.
+        """
+        # Imported lazily to avoid a module-load circular dependency.
+        from .cdp_driver import CDPJSError
+
+        d = self._driver
+        try:
+            actual = await d._js_strict(
+                "(function(){"
+                f"  var el = document.querySelector('{selector}');"
+                "  if (!el) return '';"
+                "  if (el.tagName === 'TEXTAREA') return el.value;"
+                # Block-aware read for contenteditable. Walk the immediate
+                # child nodes; each element block contributes its text plus
+                # one trailing newline, each text node contributes itself.
+                # An empty block (the <br>-only paragraph from a blank line)
+                # collapses to a single blank line, matching a typed "\n\n".
+                # This yields exactly the number of newlines the user typed.
+                "  var parts = [];"
+                "  function blockText(node) {"
+                "    return (node.textContent || '').replace(/\\u00a0/g, ' ');"
+                "  }"
+                "  for (var i = 0; i < el.childNodes.length; i++) {"
+                "    var child = el.childNodes[i];"
+                "    if (child.nodeType === 3) { parts.push(child.nodeValue || ''); }"
+                "    else if (child.nodeType === 1) {"
+                "      parts.push(blockText(child));"
+                "    }"
+                "  }"
+                "  var joined = parts.join('\\n');"
+                # ProseMirror may append a trailing empty <p>/<br> block that
+                # adds a stray trailing newline; strip at most one to mirror
+                # the single-trailing-newline tolerance below.
+                "  return joined.replace(/\\n$/, '');"
+                "})()"
+            )
+        except CDPJSError:
+            return False
+        if not actual:
+            return False
+        canon_actual = actual.replace("\r\n", "\n").replace("\r", "\n").replace("\u00a0", " ")
+        canon_expected = expected.replace("\r\n", "\n").replace("\r", "\n").replace("\u00a0", " ")
+        # ProseMirror wraps input in a <p> and may append a trailing block
+        # newline. Tolerate AT MOST ONE editor-added trailing newline — but
+        # never strip a user-intended trailing newline. So accept an exact
+        # match, OR actual == expected + one editor newline. (Stripping
+        # unconditionally would corrupt prompts that legitimately end in \n.)
+        return canon_actual == canon_expected or canon_actual == canon_expected + "\n"
+
+    async def click_send(self) -> None:
+        """Click the send button via JS MouseEvent sequence.
+
+        The new composer has no ``data-testid="send-button"``; its send
+        affordance is the submit ``<button aria-label="Send ...">`` inside
+        the composer form. We prefer that, falling back to the legacy
+        testid selector for older deployments. The stop button (which
+        appears during generation) is explicitly excluded — it also
+        carries an aria-label, but never "Send".
+        """
+        d = self._driver
+        # Wait for the send button to appear and be enabled. Try the new
+        # aria-label selector first, then the legacy testid fallback.
+        for _ in range(10):
+            has_btn = await d._js(
+                "(function() {"
+                f"  var btn = document.querySelector('{SEND_BUTTON_SELECTOR}')"
+                f"       || document.querySelector('{SEND_BUTTON_FALLBACK_SELECTOR}');"
+                "  return btn && !btn.disabled ? 'yes' : 'no';"
+                "})()"
+            )
+            if has_btn == "yes":
+                break
+            await asyncio.sleep(0.3)
+
+        result = await d._js(
+            "(function() {"
+            f"  var btn = document.querySelector('{SEND_BUTTON_SELECTOR}')"
+            f"       || document.querySelector('{SEND_BUTTON_FALLBACK_SELECTOR}');"
+            "  if (!btn) return 'no send button';"
+            "  if (btn.disabled) return 'button disabled';"
+            "  var evts = ['pointerdown','mousedown','pointerup','mouseup','click'];"
+            "  for (var i = 0; i < evts.length; i++) {"
+            "    btn.dispatchEvent(new MouseEvent(evts[i], {bubbles:true, cancelable:true, view:window}));"
+            "  }"
+            "  return 'sent';"
+            "})()"
+        )
+        if result != "sent":
+            await d._capture_selector_diagnostic("send-button (click_send)")
+            if d._breakers:
+                d._breakers.record_failure(BreakerKind.COMPOSER_SEND_READINESS)
+            from .cdp_driver import SendReadinessError
+
+            raise SendReadinessError(f"Send failed: {result}")
+        logger.info("Message sent")
+        # Success: clear composer failure history and recover a half-open
+        # breaker. Only after the message is confirmed sent — not after
+        # type_message alone, since a successful type can still fail to send.
+        if d._breakers:
+            d._breakers.record_success(BreakerKind.COMPOSER_SEND_READINESS)
+
+    # ── Rate-limit popup ──────────────────────────────────────
+
+    async def dismiss_rate_limit(self) -> bool:
+        """Dismiss ChatGPT's 'Too many requests' pop-up by clicking 'Got it'.
+
+        Targets the pop-up by its text ('Too many requests') rather than fragile
+        class names: find the ``[role=dialog]`` whose text matches, then click
+        the button inside it whose text is 'Got it'. After clicking, re-scan the
+        page to confirm the pop-up cleared.
+
+        Best-effort: never raises. Returns True if the pop-up is gone after the
+        attempt, False if it couldn't be dismissed (button missing, or the
+        limit persists), None if the status is unknown (scan error — the
+        click may have succeeded but we can't confirm). Callers should retry
+        on False but NOT on None, to avoid hammering an already-dismissed pop-up.
+        """
+        d = self._driver
+        click_js = (
+            "(function(){"
+            "  try {"
+            "    var dlgs = document.querySelectorAll('[role=dialog]');"
+            "    var target = null;"
+            "    for (var i = 0; i < dlgs.length; i++) {"
+            "      if (/too many requests/i.test(dlgs[i].innerText || '')) { target = dlgs[i]; break; }"
+            "    }"
+            "    if (!target) return JSON.stringify({clicked: false});"
+            "    var btns = target.querySelectorAll('button');"
+            "    var btn = null;"
+            "    for (var j = 0; j < btns.length; j++) {"
+            "      if ((btns[j].innerText || '').trim().toLowerCase() === 'got it') { btn = btns[j]; break; }"
+            "    }"
+            "    if (!btn) return JSON.stringify({clicked: false});"
+            "    btn.click();"
+            "    return JSON.stringify({clicked: true});"
+            "  } catch(e) { return JSON.stringify({clicked: false, error: e.message}); }"
+            "})()"
+        )
+        try:
+            click_raw = await d._js_strict(click_js, timeout=10)
+            clicked = json.loads(click_raw).get("clicked", False) if click_raw else False
+        except Exception:  # best-effort: never raise
+            logger.warning("dismiss_rate_limit: click failed", exc_info=True)
+            return None  # unknown — don't trigger retry storm
+        if not clicked:
+            return False
+
+        # Re-scan to confirm the pop-up cleared.
+        try:
+            scan = await d._js_strict(
+                "(function(){var t=(document.body&&document.body.innerText)||'';"
+                "return JSON.stringify({text:t.slice(0,4000)});})()",
+                timeout=10,
+            )
+            text = json.loads(scan).get("text", "") if scan else ""
+        except Exception:
+            # #19: If the re-scan errors, the status is unknown (not False).
+            # Returning False would trigger a retry storm against an already-
+            # dismissed pop-up; returning None lets callers skip the retry.
+            return None
+        from .cdp_driver import is_rate_limited_text
+
+        return not is_rate_limited_text(text)
+
+    # ── Diagnostics ───────────────────────────────────────────
+
+    async def _capture_selector_diagnostic(self, selector_name: str) -> None:
+        """#5: Capture DOM state when a selector fails to match.
+
+        Logs a diagnostic snapshot (URL, title, body text preview, button count)
+        so selector drift is diagnosable without W2A_DIAGNOSE=1. Called at the
+        point of selector failure (e.g. 'no send button', 'No textarea').
+        Best-effort — never raises.
+        """
+        d = self._driver
+        try:
+            snapshot = await d._js_strict(
+                "(function(){"
+                "  return JSON.stringify({"
+                "    url: location.href,"
+                "    title: document.title,"
+                "    body_preview: (document.body && document.body.innerText || '').slice(0, 300),"
+                "    button_count: document.querySelectorAll('button').length,"
+                "    textarea_count: document.querySelectorAll('textarea').length"
+                "  });"
+                "})()",
+                timeout=5,
+            )
+            logger.warning("Selector drift diagnostic (%s): %s", selector_name, snapshot)
+        except Exception:
+            logger.warning("Selector drift diagnostic (%s): capture failed", selector_name)

--- a/tests/test_chatgpt_dom.py
+++ b/tests/test_chatgpt_dom.py
@@ -1,0 +1,264 @@
+"""Wiring tests for ChatGPTDom (Phase 5 PR3 extraction).
+
+These verify the extraction moved the 9 composer-DOM methods + 4 selector
+constants onto ChatGPTDom and that the DOM layer reaches the driver's
+transport/breaker/navigation through the correct seam. They are NOT
+behavioral tests — the behavior of each method is already covered by
+test_composer_selectors / test_conversation_guard / test_resilience and the
+broad suite, which stub the driver's DOM methods and confirm the delegators
+preserve the surface. This file guards the wiring: no method is dropped, the
+DOM layer talks to the driver (not to itself) for transport/breaker, state
+stays on the driver, selectors stay importable from cdp_driver, and the
+driver wires _dom in __init__.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.chatgpt_dom import (
+    COMPOSER_FALLBACK_SELECTOR,
+    COMPOSER_SELECTOR,
+    SEND_BUTTON_FALLBACK_SELECTOR,
+    SEND_BUTTON_SELECTOR,
+    ChatGPTDom,
+)
+
+
+def _make_dom():
+    """A ChatGPTDom backed by a mock driver with the attributes/seam the DOM
+    layer reaches through. The driver's JS evaluators default to AsyncMocks so
+    individual tests override only what they assert on."""
+    driver = MagicMock()
+    driver._breakers = None
+    driver._current_conv_id = None
+    driver._js = AsyncMock(return_value="")
+    driver._js_strict = AsyncMock(return_value="")
+    driver._cdp = AsyncMock(return_value={})
+    driver.navigate_new_chat = AsyncMock()
+    driver._capture_selector_diagnostic = AsyncMock()
+    driver._has_composer = AsyncMock(return_value=True)
+    driver._wait_for_composer = AsyncMock(return_value=True)
+    driver._detect_select_all_modifier = AsyncMock(return_value=2)
+    driver._verify_composer_text = AsyncMock(return_value=True)
+    return ChatGPTDom(driver), driver
+
+
+# ── 1. Every moved method exists on ChatGPTDom ────────────────────────
+
+
+def test_dom_has_all_moved_methods():
+    """The extraction must not drop a method. Each of these is delegated by
+    CDPDriver and must live on ChatGPTDom."""
+    dom, _ = _make_dom()
+    expected = [
+        "_has_composer",
+        "_wait_for_composer",
+        "_ensure_send_ready",
+        "type_message",
+        "_detect_select_all_modifier",
+        "_verify_composer_text",
+        "click_send",
+        "dismiss_rate_limit",
+        "_capture_selector_diagnostic",
+    ]
+    missing = [name for name in expected if not callable(getattr(dom, name, None))]
+    assert missing == [], f"ChatGPTDom is missing moved methods: {missing}"
+
+
+# ── 2. Selectors moved canonically + re-exported from cdp_driver ──────
+
+
+def test_selectors_live_in_chatgpt_dom():
+    """The 4 selector constants must be defined in chatgpt_dom."""
+    assert "ProseMirror" in COMPOSER_SELECTOR
+    assert "prompt-textarea" in COMPOSER_FALLBACK_SELECTOR
+    assert "Send" in SEND_BUTTON_SELECTOR
+    assert "send-button" in SEND_BUTTON_FALLBACK_SELECTOR
+
+
+def test_selectors_reexported_from_cdp_driver():
+    """cdp_driver must re-export the selectors for back-compat (tests and the
+    navigation methods that stay there import them from cdp_driver)."""
+    from chatgpt_web2api import cdp_driver
+
+    assert cdp_driver.COMPOSER_SELECTOR is COMPOSER_SELECTOR
+    assert cdp_driver.COMPOSER_FALLBACK_SELECTOR is COMPOSER_FALLBACK_SELECTOR
+    assert cdp_driver.SEND_BUTTON_SELECTOR is SEND_BUTTON_SELECTOR
+    assert cdp_driver.SEND_BUTTON_FALLBACK_SELECTOR is SEND_BUTTON_FALLBACK_SELECTOR
+
+
+# ── 3. Transport seam: DOM reaches driver._js / _js_strict / _cdp ─────
+
+
+@pytest.mark.asyncio
+async def test_has_composer_reaches_driver_js():
+    """_has_composer must evaluate JS through the driver's soft evaluator."""
+    dom, driver = _make_dom()
+    driver._js = AsyncMock(return_value='{"ready": true}')
+    assert await dom._has_composer() is True
+    driver._js.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_capture_selector_diagnostic_reaches_driver_js_strict():
+    dom, driver = _make_dom()
+    driver._js_strict = AsyncMock(return_value='{"url":"https://chatgpt.com/"}')
+    await dom._capture_selector_diagnostic("test selector")
+    driver._js_strict.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_verify_composer_text_reaches_driver_js_strict():
+    """_verify_composer_text reads the composer via the driver's strict
+    evaluator and canonicalizes locally."""
+    dom, driver = _make_dom()
+    driver._js_strict = AsyncMock(return_value="hello")
+    assert await dom._verify_composer_text(COMPOSER_SELECTOR, "hello") is True
+    driver._js_strict.assert_awaited_once()
+
+
+# ── 4. DOM peer calls route through the driver seam ──────────────────
+#
+# type_message → driver._detect_select_all_modifier / driver._verify_composer_text;
+# _ensure_send_ready → driver.navigate_new_chat / driver._wait_for_composer /
+# driver._capture_selector_diagnostic. All through self._driver, NOT self, so
+# monkeypatches of those driver methods keep intercepting.
+
+
+@pytest.mark.asyncio
+async def test_type_message_routes_peer_calls_through_driver():
+    """type_message must call driver._detect_select_all_modifier and
+    driver._verify_composer_text (not the dom's own), so driver patches hold."""
+    dom, driver = _make_dom()
+    driver._js = AsyncMock(return_value="composer")  # focus result
+    await dom.type_message("hello")
+    driver._detect_select_all_modifier.assert_awaited_once()
+    driver._verify_composer_text.assert_awaited()
+    driver._cdp.assert_awaited()  # select-all + insertText via driver._cdp
+
+
+@pytest.mark.asyncio
+async def test_ensure_send_ready_routes_navigation_through_driver():
+    """When the composer is missing, _ensure_send_ready must navigate via
+    driver.navigate_new_chat (not a dom-local nav) and record the breaker
+    failure through driver._breakers."""
+    from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+    from chatgpt_web2api.cdp_driver import SendReadinessError
+
+    dom, driver = _make_dom()
+    reg = BreakerRegistry()
+    driver._breakers = reg
+    driver._wait_for_composer = AsyncMock(side_effect=[False, False])  # never ready
+    driver.navigate_new_chat = AsyncMock()
+
+    with pytest.raises(SendReadinessError):
+        await dom._ensure_send_ready()
+    driver.navigate_new_chat.assert_awaited_once()
+    driver._capture_selector_diagnostic.assert_awaited_once()
+    # record_failure reached through driver._breakers (threshold is 3, so one
+    # failure is recorded but the breaker is not yet tripped — assert the
+    # failure was recorded, not that it's open).
+    state = reg._states[BreakerKind.COMPOSER_SEND_READINESS]
+    assert len(state.recent_failures) == 1
+
+
+@pytest.mark.asyncio
+async def test_click_send_records_success_through_driver_breaker():
+    """A confirmed send must record_success via driver._breakers (half-open
+    recovery) — the registry stays on the driver, not the dom."""
+    from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+
+    dom, driver = _make_dom()
+    reg = BreakerRegistry()
+    driver._breakers = reg
+    driver._js = AsyncMock(return_value="sent")
+
+    await dom.click_send()
+    # Not open after a success record (record_success clears failures).
+    assert not reg.is_open(BreakerKind.COMPOSER_SEND_READINESS)
+
+
+# ── 5. dismiss_rate_limit tri-state via driver._js_strict ────────────
+
+
+@pytest.mark.asyncio
+async def test_dismiss_rate_limit_click_then_clear_returns_true():
+    dom, driver = _make_dom()
+    # First call: click succeeded; second call: re-scan shows no rate-limit text.
+    driver._js_strict = AsyncMock(side_effect=['{"clicked": true}', '{"text":"normal text"}'])
+    assert await dom.dismiss_rate_limit() is True
+
+
+@pytest.mark.asyncio
+async def test_dismiss_rate_limit_no_dialog_returns_false():
+    dom, driver = _make_dom()
+    driver._js_strict = AsyncMock(return_value='{"clicked": false}')
+    assert await dom.dismiss_rate_limit() is False
+
+
+@pytest.mark.asyncio
+async def test_dismiss_rate_limit_scan_error_returns_none():
+    dom, driver = _make_dom()
+    driver._js_strict = AsyncMock(side_effect=['{"clicked": true}', RuntimeError("scan failed")])
+    assert await dom.dismiss_rate_limit() is None
+
+
+# ── 6. State stays on the driver (not migrated into the dom) ──────────
+
+
+def test_dom_holds_no_driver_state():
+    """The dom must NOT own _breakers / _current_conv_id / _js / _cdp — those
+    stay on the driver so connect/reconnect/close and test stubs that poke
+    driver._breakers keep working."""
+    dom, _ = _make_dom()
+    for attr in ("_breakers", "_current_conv_id", "_js", "_js_strict", "_cdp"):
+        assert not hasattr(dom, attr), (
+            f"ChatGPTDom must not own driver state '{attr}' (Phase 5 PR3 contract)"
+        )
+
+
+# ── 7. Integration: CDPDriver wires ChatGPTDom in __init__ ───────────
+
+
+def test_driver_wires_chatgpt_dom():
+    """CDPDriver.__init__ constructs a ChatGPTDom and delegates through it."""
+    from chatgpt_web2api.cdp_driver import CDPDriver
+
+    d = CDPDriver(cdp_port=9222)
+    assert isinstance(d._dom, ChatGPTDom)
+    assert d._dom._driver is d
+
+
+def test_driver_delegators_preserve_signatures():
+    """All 9 moved methods remain callable on the driver (delegators), so
+    internal call sites and test stubs that patch driver.type_message /
+    driver.click_send etc. keep working unchanged."""
+    from chatgpt_web2api.cdp_driver import CDPDriver
+
+    d = CDPDriver(cdp_port=9222)
+    for name in (
+        "_has_composer",
+        "_wait_for_composer",
+        "_ensure_send_ready",
+        "type_message",
+        "_detect_select_all_modifier",
+        "_verify_composer_text",
+        "click_send",
+        "dismiss_rate_limit",
+        "_capture_selector_diagnostic",
+    ):
+        assert callable(getattr(d, name, None)), f"CDPDriver lost delegator {name}"
+
+
+# ── 8. Breaker stays on driver; dom only reaches through ─────────────
+
+
+def test_breaker_registry_stays_on_driver():
+    """The breaker registry must live on CDPDriver (default None, set via
+    ctor), never on ChatGPTDom."""
+    from chatgpt_web2api.cdp_driver import CDPDriver
+
+    d = CDPDriver(cdp_port=9222)
+    assert hasattr(d, "_breakers")
+    assert not hasattr(d._dom, "_breakers")

--- a/tests/test_dismiss.py
+++ b/tests/test_dismiss.py
@@ -9,7 +9,6 @@ live behavior is covered by an E2E test.
 """
 
 import json
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -17,12 +16,12 @@ from chatgpt_web2api.cdp_driver import CDPDriver
 
 
 def _driver_with_js_sequence(js_returns: list[str]):
-    """Build a mock driver whose _js_strict returns the given sequence.
+    """Build a CDPDriver whose _js_strict returns the given sequence.
 
     Each call to _js_strict pops the next canned return; once exhausted it
     returns 'OK'. This lets us script the click + the post-click re-scan.
     """
-    driver = MagicMock()
+    driver = CDPDriver(cdp_port=9222)
     seq = list(js_returns)
 
     async def fake_js(expr, timeout=15):
@@ -48,7 +47,7 @@ async def test_dismiss_returns_true_when_popup_clears():
         json.dumps({"text": "Normal page content, no popup"}),  # post-click scan
     ])
 
-    result = await CDPDriver.dismiss_rate_limit(driver)
+    result = await driver.dismiss_rate_limit()
 
     assert result is True
 
@@ -61,7 +60,7 @@ async def test_dismiss_returns_false_when_popup_persists():
         json.dumps({"text": "Too many requests. Please wait a few minutes."}),
     ])
 
-    result = await CDPDriver.dismiss_rate_limit(driver)
+    result = await driver.dismiss_rate_limit()
 
     assert result is False
 
@@ -74,7 +73,7 @@ async def test_dismiss_returns_false_when_no_got_it_button():
         json.dumps({"text": "Too many requests..."}),         # still limited
     ])
 
-    result = await CDPDriver.dismiss_rate_limit(driver)
+    result = await driver.dismiss_rate_limit()
 
     assert result is False
 
@@ -84,7 +83,7 @@ async def test_dismiss_never_raises_on_js_error():
     """A JS error during dismiss must not propagate — best-effort contract.
     Returns None (unknown status) per #19 tri-state: not False, to avoid
     triggering a retry storm against an already-dismissed pop-up."""
-    driver = MagicMock()
+    driver = CDPDriver(cdp_port=9222)
 
     async def failing_js(expr, timeout=15):
         raise RuntimeError("websocket closed")
@@ -92,5 +91,5 @@ async def test_dismiss_never_raises_on_js_error():
     driver._js_strict = failing_js
 
     # Should swallow and return None (not raise, not False).
-    result = await CDPDriver.dismiss_rate_limit(driver)
+    result = await driver.dismiss_rate_limit()
     assert result is None


### PR DESCRIPTION
Extracts the **ChatGPT-composer DOM interaction surface** from `CDPDriver` into a new `ChatGPTDom` collaborator, following the exact `backend_client.py` (PR1) / `cdp_transport.py` (PR2) convention: method bodies move, thin delegators stay on `CDPDriver`, all shared state stays on the driver.

## Moved to `ChatGPTDom` — 9 methods + 4 selector constants

**Selectors:** `COMPOSER_SELECTOR`, `COMPOSER_FALLBACK_SELECTOR`, `SEND_BUTTON_SELECTOR`, `SEND_BUTTON_FALLBACK_SELECTOR`

**Methods:**
| Method | Role |
|---|---|
| `_has_composer` | Composer-present probe |
| `_wait_for_composer` | Poll wrapper |
| `_ensure_send_ready` | Poll → `navigate_new_chat` → re-check |
| `type_message` | Focus + select-all + CDP insertText + canonical verify |
| `_detect_select_all_modifier` | Ctrl vs Cmd platform probe |
| `_verify_composer_text` | Block-aware canonical text check |
| `click_send` | JS MouseEvent send + breaker record_success |
| `dismiss_rate_limit` | Rate-limit popup dismiss (tri-state True/False/None) |
| `_capture_selector_diagnostic` | Selector-drift DOM snapshot |

## Stays in `cdp_driver.py`

`send_and_stream` orchestration, navigation (`navigate_new_chat`/`navigate_conversation`/`navigate_gpt`/`select_model`), conversation-id ownership (`ensure_current_conversation`/`_is_live_conversation_url`/`_is_url_at_conversation`), connection lifecycle, backend-client surface, CDP-transport surface, **breaker registry ownership**.

## Convention (identical to PR1/PR2)

- State stays on `CDPDriver`: `_breakers`, `_current_conv_id`. `ChatGPTDom` reaches through `self._driver`.
- **Breaker rule:** 3 methods record `COMPOSER_SEND_READINESS` failures/successes through `self._driver._breakers`. The registry STAYS on the driver; no breaker-policy code (`trip`/`threshold`/`cooldown`/`is_open` policy) moves — only `record_failure`/`record_success` calls reach through. `click_send` still does `record_success` on a confirmed send (half-open recovery).
- **Driver-facing seam preserved (the PR2 lesson):** every internal call routes through `self._driver` — `_js`/`_js_strict`/`_cdp` for transport; peer DOM calls (`_verify_composer_text`, `_detect_select_all_modifier`, `_has_composer`, `_capture_selector_diagnostic`) for monkeypatch interception; `navigate_new_chat` for the send-readiness path; `_breakers` for breaker records. `type_message` → `driver._verify_composer_text` (not `self._verify_composer_text`), so driver patches hold.
- `CDPDriver` keeps thin delegators for all 9 methods, byte-identical signatures; `self._dom = ChatGPTDom(self)` wired in `__init__`. The 4 selector constants are re-exported from `cdp_driver.py` (back-compat — tests and the navigation methods that stay there import them).

## Verification against acceptance bar

| Requirement | Status |
|---|---|
| add `chatgpt_dom.py` | ✅ |
| wire `self._dom = ChatGPTDom(self)` in `__init__` | ✅ |
| 9 `CDPDriver` delegators, same signatures | ✅ |
| 4 selector constants re-exported from `cdp_driver.py` | ✅ (`is` identity confirmed) |
| `_breakers`/`_current_conv_id` stay on `CDPDriver` | ✅ (grep audit: no dom-local state) |
| `send_and_stream` + `navigate_*` + `select_model` stay | ✅ (grep audit: 5 defs in driver, 0 in dom) |
| no `backend_client.py` / `cdp_transport.py` edits | ✅ (zero diff) |
| no breaker policy changes | ✅ (only `record_*` calls; no `trip`/`threshold`/`cooldown`) |
| DOM internal routing preserves driver seam | ✅ (all calls through `self._driver`) |

## Tests

- **`tests/test_chatgpt_dom.py`** (new, 16 tests): methods exist on `ChatGPTDom`; selectors moved + re-exported from `cdp_driver` (identity); DOM reaches `driver._js`/`_js_strict`/`_cdp` (not local); `type_message` routes peer calls (`_detect_select_all_modifier`/`_verify_composer_text`) through driver; `_ensure_send_ready` routes navigation through `driver.navigate_new_chat` + records breaker failure through driver registry; `click_send` records success through driver registry; `dismiss_rate_limit` tri-state; state stays on driver; driver wires `_dom`; breaker registry stays on driver.
- **`tests/test_dismiss.py`**: construct a real `CDPDriver` instead of a raw `MagicMock` so the `_dom` seam resolves (same construction-only fix as PR2s `test_js_injection.py`); the click/scan/None assertions are unchanged.
- Behavior covered by existing `test_composer_selectors.py`/`test_conversation_guard.py`/`test_resilience.py` — green, unchanged (exercised through the driver facade).

## Verification

- `ruff check` on all 4 changed files: **clean** (24 pre-existing errors elsewhere, identical on `master`).
- `pytest`: **462 passed** (was 446; +16 new).

## Changed files (4)
- `src/chatgpt_web2api/chatgpt_dom.py` — **new**, 9 method bodies + 4 selectors + lazy `CDPJSError`/`SendReadinessError` imports
- `src/chatgpt_web2api/cdp_driver.py` — bodies → delegators; `self._dom` wired in `__init__`; selectors re-exported
- `tests/test_chatgpt_dom.py` — **new**, 16 wiring tests
- `tests/test_dismiss.py` — construct real driver (seam fix), assertions unchanged

Follows ROADMAP Phase 5 PR3.