### PR TITLE
refactor: extract completion_detector.py (Phase 5 PR4, no behavior change)

### DIFF
--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -49,17 +49,14 @@ RATE_LIMIT_DEFAULT_RETRY_AFTER = 60
 # Canonical home is now backend_client.py.
 from .backend_client import TOKEN_TTL_SECONDS  # noqa: E402,F401
 
-# A generation is considered "stuck" (vs. merely slow) if no DOM progress
-# signal occurs within this window. Slow-but-progressing generations
-# (image rendering, deep-research thinking) legitimately exceed this and
-# are allowed the full timeout; a true stall fails fast here instead of
-# hanging silently to the deadline. Applied to both Phase 1 (node appear)
-# and Phase 2 (text streaming). 90s accommodates reasoning/thinking models,
-# whose ``result-thinking`` placeholder can hold the DOM static for a minute+
-# while the model reasons before the first answer token renders; the
-# is_thinking reset covers the labeled phase, but there is an unlabeled gap
-# between thinking-end and answer-start that also needs this headroom.
-PHASE_STALL_SECONDS = 90
+# Phase 5 PR4: generation-completion stall window + rate-limit pop-up text
+# matcher extracted into completion_detector.py; re-exported here for back-compat
+# (is_rate_limited_text is imported from cdp_driver by api_server, chatgpt_dom,
+# and tests). _RATE_LIMIT_PHRASES stays private to completion_detector.
+from .completion_detector import (  # noqa: E402,F401
+    PHASE_STALL_SECONDS,
+    is_rate_limited_text,
+)
 
 # How long to wait (seconds) for a freshly-created owned tab to settle on
 # chatgpt.com before refreshing the access token. ``_create_owned_tab`` only
@@ -186,24 +183,8 @@ class CDPReconnectError(RuntimeError):
     """
 
 
-# Phrases ChatGPT uses in its rate-limit pop-up. Matched case-insensitively
-# against scanned DOM text. Kept narrow to avoid false positives on normal
-# chat content (e.g. a user asking about "rate limits" in a message).
-_RATE_LIMIT_PHRASES = (
-    "too many requests",
-    "you're making requests too quickly",
-    "temporarily limited access to your conversations",
-    "you've reached the rate limit",
-)
-
-
-def is_rate_limited_text(text: str) -> bool:
-    """Return True if *text* looks like ChatGPT's rate-limit pop-up copy."""
-    if not text:
-        return False
-    lowered = text.lower()
-    return any(phrase in lowered for phrase in _RATE_LIMIT_PHRASES)
-
+# Phrases ChatGPT uses in its rate-limit pop-up + the ``is_rate_limited_text``
+# matcher moved to completion_detector.py (Phase 5 PR4); re-exported above.
 
 def parse_retry_after(text: str, default: int = RATE_LIMIT_DEFAULT_RETRY_AFTER) -> int:
     """Extract a retry-after duration in seconds from ChatGPT's pop-up text.
@@ -335,6 +316,16 @@ class CDPDriver:
         from .chatgpt_dom import ChatGPTDom
 
         self._dom = ChatGPTDom(self)
+        # Phase 5 PR4: streaming completion detection (Phase-1 appear loop +
+        # Phase-2 stream loop) extracted into CompletionDetector. Lazy import
+        # for the same reason; the detector reaches through this driver for
+        # _js_strict, _fetch_end_turn, _get_live_conversation_id_best_effort,
+        # and reads _current_conv_id (read-only — never assigned by the
+        # detector). It yields delta chunks only; the terminal stop chunk and
+        # the _current_conv_id mutation stay in send_and_stream.
+        from .completion_detector import CompletionDetector
+
+        self._completion = CompletionDetector(self)
 
     async def connect(self) -> None:
         """Connect to Chrome's CDP and authenticate.
@@ -1224,342 +1215,21 @@ class CDPDriver:
         await self.type_message(text)
         await self.click_send()
 
-        # Wait for a new assistant message. The full `timeout` governs (was
-        # capped at 60s, which killed slow-to-appear responses like image
-        # generation). A stall detector (PHASE_STALL_SECONDS) catches a true
-        # hang fast: if the assistant node count doesn't change at all — even
-        # 0→1 with empty text counts as progress — for longer than the stall
-        # window, we raise GenerationStuckError instead of waiting out the
-        # whole deadline. Slow-but-progressing generations (image render,
-        # deep-research thinking) keep resetting the stall clock and are
-        # allowed the full timeout.
-        deadline = time.monotonic() + timeout
-        last_node_count = initial_count
-        last_progress = time.monotonic()
-        while time.monotonic() < deadline:
-            # First check for ChatGPT's rate-limit pop-up — if present, fail
-            # fast with a clear error instead of waiting out the whole timeout.
-            # The pop-up blocks the assistant from responding, so the assistant
-            # count would never increase; without this check we'd hit a generic
-            # timeout that hides the real cause.
-            try:
-                dom_scan = await self._js_strict(
-                    "(function(){"
-                    "  var t = (document.body && document.body.innerText) || '';"
-                    "  return JSON.stringify({text: t.slice(0, 4000)});"
-                    "})()"
-                )
-                scanned_text = json.loads(dom_scan).get("text", "")
-            except (CDPJSError, json.JSONDecodeError, TypeError):
-                scanned_text = ""
-            if is_rate_limited_text(scanned_text):
-                # from_text parses any explicit wait from the pop-up copy.
-                raise RateLimitError.from_text(scanned_text)
+        # Phase 5 PR4: the Phase-1 (assistant-node appear) and Phase-2 (DOM
+        # streaming + completion-detection) loops were extracted verbatim into
+        # CompletionDetector.stream_until_complete — a delta-only async
+        # sub-generator. Re-yield its chunks with NO buffering / post-processing
+        # so the public yield sequence stays byte-equivalent to pre-extraction.
+        # The detector yields StreamChunk(delta=...) only; the terminal
+        # finish_reason="stop" chunk is emitted by the tail below. The detector
+        # raises RateLimitError / GenerationStuckError on the same conditions
+        # the inline loops did; those propagate out of the async-for unchanged.
+        async for chunk in self._completion.stream_until_complete(
+            initial_count=initial_count,
+            timeout=timeout,
+        ):
+            yield chunk
 
-            try:
-                raw = await self._js_strict(
-                    "document.querySelectorAll('[data-message-author-role=\"assistant\"]').length"
-                )
-                current_count = int(raw or 0)
-            except CDPJSError:
-                current_count = last_node_count  # no progress signal
-            if current_count != last_node_count:
-                # Any node-count change is progress (incl. 0→1 with empty text,
-                # the slow-render case). Reset the stall clock.
-                last_node_count = current_count
-                last_progress = time.monotonic()
-            if current_count > initial_count:
-                break
-            if time.monotonic() - last_progress > PHASE_STALL_SECONDS:
-                raise GenerationStuckError("phase_1_appear", time.monotonic() - last_progress)
-            await asyncio.sleep(0.5)
-        else:
-            raise GenerationStuckError("phase_1_appear", timeout)
-
-        logger.info("Assistant message appeared, waiting for completion...")
-
-        # Poll until generation is done (Stop button gone). A stall detector
-        # (PHASE_STALL_SECONDS) catches a stuck generation: if NO DOM progress
-        # occurs for longer than the stall window, we raise GenerationStuckError.
-        #
-        # Progress is tracked on THREE signals, not just text, so non-text
-        # responses (images, tool-use, code interpreter) don't falsely stall:
-        #   - text:       .markdown textContent (streamed as deltas for text)
-        #   - html_len:   assistant message innerHTML length (grows when img/
-        #                 canvas/tool-use elements are added)
-        #   - child_count: direct children count (grows when new blocks render)
-        # Any of these changing resets the stall clock.
-        #
-        # Done detection: Stop button gone AND there's meaningful content
-        # (either .markdown text OR non-trivial HTML footprint). The threshold
-        # (> 50 chars) prevents false 'done' from an empty/partial node.
-        last_dom_text = ""
-        last_html_len = 0
-        last_child_count = 0
-        had_non_text_content = False
-        # saw_thinking: has the model shown a reasoning phase this turn? Used
-        # to unlock the R4 backend fallback DURING thinking (when last_dom_text
-        # is empty) — without this, a long reasoning response (>90s think time
-        # with no DOM text change) stalls before the answer ever streams.
-        saw_thinking = False
-        # Completion detection for Phase-2. The history here matters — three
-        # earlier signals each failed in live testing, all producing an
-        # off-by-one where request N returned request N-1's text:
-        #   1. ``done = !stopBtn && hasContent`` — broke on the FIRST poll.
-        #      Right after send the Stop button hasn't appeared yet (generation
-        #      not begun) but html_len > 50 (the message wrapper), so this was
-        #      True immediately, leaving last_dom_text empty.
-        #   2. ``generation_started && not is_generating`` — the Stop button
-        #      FLICKERS off between token batches, breaking mid-generation with
-        #      truncated text.
-        #   3. Text-stability alone — ``.markdown`` textContent is empty during
-        #      streaming (text renders elsewhere until the turn settles), so
-        #      "stable empty" never completes and the stall detector fires.
-        #
-        # The robust signal is the per-turn ACTION BUTTON. ChatGPT renders a
-        # copy/feedback action row (data-testid containing "copy" or
-        # "response-turn") on an assistant message ONLY once it has finished
-        # generating — it is absent while the message is streaming or thinking.
-        # Polling for that button on the NEW message is immune to the Stop
-        # flicker and to the empty-.markdown-during-streaming quirk. Text is
-        # captured from the message's innerText (which IS populated during
-        # streaming) rather than .markdown textContent (which lags).
-        last_change_time = time.monotonic()
-        deadline = time.monotonic() + timeout
-        # Backend end_turn fallback throttle (R4): if the DOM action-button
-        # selector drifts again, the conversation API's end_turn flag is a
-        # secondary completion signal. Throttled to once per 3s to respect the
-        # shared account rate budget, and only fires when has_action is false
-        # (so it never races the primary DOM signal). Never the sole signal.
-        last_backend_check = 0.0
-        conv_id_for_check = self._current_conv_id or ""
-        # Mid-loop conv_id probe throttle. On a NEW chat (REST /health path or
-        # the SSE/MCP path) _current_conv_id is None here and conv_id_for_check
-        # is "" — which silently disables the backend end_turn fallback below
-        # (its guard is ``conv_id_for_check and ...``). That fallback is the
-        # stable completion signal when the DOM action-button selector drifts.
-        # ChatGPT navigates to /c/{id} within ~1s of send, so we probe the live
-        # URL (cheap) until a conv_id is available, then the existing backend
-        # check can fire. See _get_live_conversation_id_best_effort.
-        last_conv_id_probe = 0.0
-        while time.monotonic() < deadline:
-            try:
-                result = await self._js_strict(
-                    "(function() {"
-                    "  var msgs = document.querySelectorAll('[data-message-author-role=\"assistant\"]');"
-                    "  if (!msgs.length) return JSON.stringify({text:'', md_text:'', html_len:0, child_count:0, has_action:false, is_thinking:false});"
-                    "  var last = msgs[msgs.length - 1];"
-                    # Text: the clean answer lives in ``.markdown`` textContent.
-                    # It's empty during streaming and populates as the turn
-                    # settles — so we ALSO capture ``innerText`` (populated
-                    # during streaming) as a fallback. innerText includes the
-                    # reasoning UI label ("Thinking.../Thought for N seconds"),
-                    # so md_text is captured SEPARATELY and Python prefers it;
-                    # the innerText fallback is trimmed of the leading label.
-                    "  var md = last.querySelector('.markdown');"
-                    "  var mdText = md ? (md.textContent || '') : '';"
-                    "  var rawText = (last.innerText || '').trim();"
-                    # Strip a leading "Thinking..." / "Thought for …" reasoning
-                    # label so the innerText fallback can't leak it as a delta.
-                    "  var text = mdText || rawText.replace(/^Think(ing|\\s+for)[^\\n]*\\n?/i, '');"
-                    "  var html_len = last.innerHTML.length;"
-                    "  var child_count = last.children.length;"
-                    # has_action: the per-turn copy/feedback action row appears
-                    # only on a COMPLETED message. ChatGPT's DOM layout puts these
-                    # buttons in a SIBLING/UNCLE container, NOT as descendants of
-                    # the assistant message node — so a plain
-                    # ``last.querySelector(...)`` finds nothing and completion is
-                    # never detected (every send stalled at the 90s ceiling). The
-                    # fix: walk up ancestors, querying down at each scope, and
-                    # require the button to be GEOMETRICALLY NEAR the message so
-                    # an older turn's action row can't falsely complete a brand-new
-                    # answer. New testid scheme is ``*-turn-action-button``
-                    # (copy/good-response/bad-response); the legacy
-                    # ``response-turn`` selector is retained for older deployments
-                    # but no longer matches anything on current ChatGPT.
-                    #
-                    # Depth was 4; raised to 8 after issue #12 found the action
-                    # row at ancestor depth 6. The geometry window is widened to
-                    # accept buttons rendered ABOVE the message (top - 180) —
-                    # short answers place the action row in the spacing above the
-                    # message node, which the old top-8 gate rejected. This is a
-                    # FALLBACK signal now (backend end_turn is primary); kept as an
-                    # escape hatch for when conv_id is unavailable or backend fails.
-                    '  var ACT = \'[data-testid="copy-turn-action-button"],'
-                    '            [data-testid="good-response-turn-action-button"],'
-                    '            [data-testid="bad-response-turn-action-button"],'
-                    '            [data-testid*="turn-action-button"],'
-                    '            [data-testid*="copy"],'
-                    '            [data-testid*="response-turn"]\';'
-                    "  var has_action = (function() {"
-                    "    var lastRect = last.getBoundingClientRect();"
-                    "    var scope = last;"
-                    "    for (var d = 0; scope && d <= 8; d++, scope = scope.parentElement) {"
-                    "      var btns = Array.prototype.filter.call("
-                    "        scope.querySelectorAll(ACT),"
-                    "        function(el){ return el.offsetParent !== null || el.getClientRects().length > 0; }"
-                    "      );"
-                    "      if (!btns.length) continue;"
-                    "      for (var i = 0; i < btns.length; i++) {"
-                    "        var r = btns[i].getBoundingClientRect();"
-                    "        if (r.top >= lastRect.top - 180 && r.top <= lastRect.bottom + 240) {"
-                    "          return true;"
-                    "        }"
-                    "      }"
-                    "    }"
-                    "    return false;"
-                    "  })();"
-                    # is_thinking: the active-reasoning indicator. Narrowed to
-                    # ``.result-thinking`` AND ``!has_action`` — the action
-                    # button marks a finished turn, and ``.result-thinking``
-                    # lingers in the DOM after completion as a collapsed
-                    # "Thought process" section. WITHOUT the has_action gate
-                    # this stayed true forever, and the old ``/thinking/i``
-                    # word-match on innerText matched the persistent
-                    # "Thought for N seconds" summary label — together they
-                    # pinned is_thinking=true on every thinking-model turn
-                    # and on any answer that mentioned the word "thinking",
-                    # which suppressed all delta emission (see the elif below)
-                    # and produced empty responses when _fetch_text lagged.
-                    # Also recognize a plain "Thinking..." innerText placeholder
-                    # (some layouts show reasoning text without .result-thinking)
-                    # so the stall clock treats it as active generation, not a stall.
-                    "  var hasThinkingEl = !!last.querySelector('.result-thinking');"
-                    "  var visibleThinking = /^(thinking|reasoning)\\b/i.test(rawText.trim());"
-                    "  var is_thinking = !has_action && (hasThinkingEl || (visibleThinking && !mdText));"
-                    "  return JSON.stringify({text: text, md_text: mdText, html_len: html_len, child_count: child_count, has_action: has_action, is_thinking: is_thinking});"
-                    "})()",
-                )
-                data = json.loads(result)
-            except (CDPJSError, json.JSONDecodeError, TypeError):
-                await asyncio.sleep(0.5)
-                continue
-
-            current = data.get("text", "")
-            md_text = data.get("md_text", "")
-            html_len = data.get("html_len", 0)
-            child_count = data.get("child_count", 0)
-            has_action = data.get("has_action", False)
-            is_thinking = data.get("is_thinking", False)
-
-            # Streaming source: prefer the clean .markdown answer container
-            # over the innerText fallback (which carries the reasoning label).
-            # When md_text is empty (early streaming, before .markdown fills),
-            # the innerText fallback (with its leading label already stripped
-            # in JS) is what carries the streamed answer.
-            current = md_text or current
-
-            # is_thinking means the model is actively reasoning — the DOM is
-            # legitimately static for tens of seconds, which is NOT a stall.
-            # It MUST reset the stall clock so a genuine reasoning phase isn't
-            # killed early. But a STALE thinking state (.result-thinking lingers
-            # as a collapsed section after the answer finishes) must not freeze
-            # the stall detector forever — that's how a drift in the DOM
-            # action-button selector produced the 120s completion hang (issue
-            # #10): is_thinking pinned last_change_time every poll so the 90s
-            # stall guard never fired. Compromise: let thinking reset the stall
-            # clock ONLY while we have no stable backend completion signal
-            # available. Once conv_id_for_check is resolved, the backend
-            # end_turn fallback can detect completion even under stale thinking,
-            # so we stop granting the indefinite thinking stall reset — the
-            # normal stall clock applies and bounds the worst case. (Resetting
-            # saw_thinking is independent of this and always happens.)
-            if is_thinking:
-                saw_thinking = True
-                if not conv_id_for_check:
-                    last_change_time = time.monotonic()
-            if current != last_dom_text:
-                last_change_time = time.monotonic()
-                if len(current) > len(last_dom_text):
-                    delta = current[len(last_dom_text) :]
-                    yield StreamChunk(delta=delta)
-                last_dom_text = current
-
-            # Non-text progress signals (images, tool-use, etc.)
-            if html_len != last_html_len or child_count != last_child_count:
-                last_change_time = time.monotonic()
-                if html_len > 50:
-                    had_non_text_content = True
-            last_html_len = html_len
-            last_child_count = child_count
-
-            # ── Completion detection ─────────────────────────────────────
-            # Two signals, ordered by stability. Backend end_turn is PRIMARY
-            # (issue #12): it survived three DOM action-button drifts where the
-            # DOM selector failed. The DOM has_action is a FALLBACK for the
-            # window where conv_id is unavailable (before the URL resolves, ~1s
-            # into a new chat) or when the backend fetch fails transiently.
-            #
-            # Resolve conv_id first (needed for the primary signal on new chats).
-            if not conv_id_for_check:
-                now = time.monotonic()
-                if now - last_conv_id_probe >= 1.0:
-                    last_conv_id_probe = now
-                    try:
-                        conv_id_for_check = await self._get_live_conversation_id_best_effort()
-                        if conv_id_for_check:
-                            logger.info(
-                                "Resolved conversation id mid-loop: %s",
-                                conv_id_for_check,
-                            )
-                    except Exception as e:
-                        logger.debug("conv_id probe failed (ignored): %s", e)
-
-            # PRIMARY: backend end_turn. Throttled to one fetch per 3s to respect
-            # the shared account rate budget. Eligible when we have streamed text
-            # OR have seen a thinking phase — a long reasoning response has empty
-            # last_dom_text during thinking, but the backend reports end_turn once
-            # the model finishes. Completion stays strict (end_turn AND usable
-            # content) so this can't complete an empty answer. Fetch failures set
-            # backend_fetch_failed so the DOM fallback below is unlocked this poll.
-            backend_fetch_failed = False
-            if (
-                conv_id_for_check
-                and (last_dom_text or saw_thinking or is_thinking or had_non_text_content)
-                and time.monotonic() - last_backend_check > 3.0
-            ):
-                last_backend_check = time.monotonic()
-                try:
-                    if await self._fetch_end_turn(conv_id_for_check):
-                        # STRICT: end_turn AND usable content. The saw_thinking
-                        # unlock lets us CONSULT the backend during thinking, but
-                        # we must not finish on a bare end_turn with no answer.
-                        if last_dom_text or had_non_text_content:
-                            logger.info(
-                                "Backend end_turn=true (primary completion) for %s",
-                                conv_id_for_check,
-                            )
-                            break
-                        logger.debug(
-                            "Backend end_turn=true but no content yet for %s — "
-                            "not completing (strict content guard)",
-                            conv_id_for_check,
-                        )
-                except Exception as e:
-                    backend_fetch_failed = True
-                    logger.debug("end_turn fetch failed (ignored): %s", e)
-
-            # FALLBACK: DOM action button (has_action). Used ONLY when the primary
-            # backend signal can't run: conv_id is unavailable (before the URL
-            # resolves) OR the backend fetch just failed this poll. When the
-            # backend IS available it is authoritative — a widened has_action
-            # match (depth 8, top-180) can hit a PRIOR turn's action row, so DOM
-            # must not override a live backend that says "not done yet" or that
-            # hasn't been consulted yet due to throttle. Also requires usable
-            # content (same strict guard as the primary) so it can't complete an
-            # empty answer off a stale button.
-            if (
-                has_action
-                and (not conv_id_for_check or backend_fetch_failed)
-                and (last_dom_text or had_non_text_content)
-            ):
-                logger.info("DOM has_action (fallback completion) — no backend signal")
-                break
-
-            if time.monotonic() - last_change_time > PHASE_STALL_SECONDS:
-                raise GenerationStuckError("phase_2_stream", time.monotonic() - last_change_time)
-
-            await asyncio.sleep(0.5)
 
         # Wait for URL to become /c/{id}
         conv_id = ""
@@ -1577,6 +1247,12 @@ class CDPDriver:
         if conv_id:
             logger.info("Conversation: %s", conv_id)
             self._current_conv_id = conv_id
+            # last_dom_text is the streamed-text baseline accumulated by the
+            # Phase-2 loop in CompletionDetector; had_non_text_content flags an
+            # image/tool-use turn. Both are surfaced as per-call results on the
+            # detector (read here; the loop owned them pre-extraction).
+            last_dom_text = self._completion.last_dom_text
+            had_non_text_content = self._completion.had_non_text_content
             # Fetch final text from API (more reliable than DOM for thinking models)
             for _ in range(60):
                 api_text = await self._fetch_text(conv_id)

--- a/src/chatgpt_web2api/completion_detector.py
+++ b/src/chatgpt_web2api/completion_detector.py
@@ -1,0 +1,497 @@
+"""Streaming completion detection — Phase-1 appear loop + Phase-2 stream loop.
+
+Phase 5 PR4 extraction (no behavior change). Owns the generation-completion
+detection surface that was previously inlined in ``CDPDriver.send_and_stream``:
+
+  - stall window constant (``PHASE_STALL_SECONDS``)
+  - rate-limit pop-up phrase matchers (``_RATE_LIMIT_PHRASES``,
+    ``is_rate_limited_text``)
+  - Phase-1 appear loop: wait for a new assistant node, fail fast on a
+    rate-limit pop-up, raise ``GenerationStuckError`` on a true stall
+  - Phase-2 stream loop: poll the DOM for streamed text, yield deltas as
+    ``StreamChunk``s, detect completion via the backend ``end_turn`` primary
+    signal with the per-turn action button as a DOM fallback, raise
+    ``GenerationStuckError`` on a three-signal stall
+
+The driver-reference collaborator seam: ``CompletionDetector`` holds a
+reference to its owning ``CDPDriver`` and reaches through it for the CDP
+transport (``_js_strict``), the backend completion signals
+(``_fetch_end_turn`` / ``_get_live_conversation_id_best_effort``), and the
+in-flight conversation id (``_current_conv_id``, read-only). No state migrates
+into this module — it stays on the driver, and the detector is stateless
+beyond ``_driver``.
+
+Boundary: this module is the generation-completion detection layer.
+``send_and_stream`` orchestration (pre-count, type/send, the post-loop
+conversation-id resolve + ``_current_conv_id`` mutation, the ``_fetch_text``
+final reconcile, and the terminal ``finish_reason="stop"`` chunk) stays in
+``cdp_driver.py``. The detector yields **deltas only** — it never emits a
+``finish_reason`` and never writes ``_current_conv_id``.
+
+Per-call result surfacing: the driver's post-loop tail consumes two values the
+Phase-2 loop accumulates as locals — ``last_dom_text`` (the streamed-text
+baseline used to emit the ``_fetch_text`` suffix delta) and
+``had_non_text_content`` (drives the non-text placeholder). They cannot be
+re-derived without re-running the poll, so after the generator exhausts the
+driver reads ``self._completion.last_dom_text`` /
+``self._completion.had_non_text_content``. These are transient per-call results
+(reset at the start of each call), not long-lived configuration; the detector
+holds no state across calls beyond ``_driver``.
+
+Call-rule inside CompletionDetector method bodies — every internal call routes
+through ``self._driver`` (NOT ``self``) to preserve monkeypatch interception on
+the driver-facing seam (the PR2 lesson):
+
+  transport:       self._driver._js_strict(...)
+  backend signals: self._driver._fetch_end_turn(...)
+                   self._driver._get_live_conversation_id_best_effort(...)
+  conv-id read:    self._driver._current_conv_id   (read once into a local;
+                   NEVER assigned here)
+
+Circular-import rule (mandatory): ``cdp_driver`` top-level re-exports
+``PHASE_STALL_SECONDS`` and ``is_rate_limited_text`` from this module, so this
+module must NOT import anything from ``cdp_driver`` at module load. The error
+classes (``RateLimitError`` / ``GenerationStuckError``) and the ``StreamChunk``
+yield type are imported **lazily inside ``stream_until_complete``**, after
+``cdp_driver`` is fully initialized — mirroring the ``chatgpt_dom`` convention
+(``chatgpt_dom.py`` lazy-imports ``CDPJSError``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from .cdp_driver import StreamChunk
+
+logger = logging.getLogger(__name__)
+
+
+# A generation is considered "stuck" (vs. merely slow) if no DOM progress
+# signal occurs within this window. Slow-but-progressing generations
+# (image rendering, deep-research thinking) legitimately exceed this and
+# are allowed the full timeout; a true stall fails fast here instead of
+# hanging silently to the deadline. Applied to both Phase 1 (node appear)
+# and Phase 2 (text streaming). 90s accommodates reasoning/thinking models,
+# whose ``result-thinking`` placeholder can hold the DOM static for a minute+
+# while the model reasons before the first answer token renders; the
+# is_thinking reset covers the labeled phase, but there is an unlabeled gap
+# between thinking-end and answer-start that also needs this headroom.
+PHASE_STALL_SECONDS = 90
+
+# Phrases ChatGPT uses in its rate-limit pop-up. Matched case-insensitively
+# against scanned DOM text. Kept narrow to avoid false positives on normal
+# chat content (e.g. a user asking about "rate limits" in a message).
+_RATE_LIMIT_PHRASES = (
+    "too many requests",
+    "you're making requests too quickly",
+    "temporarily limited access to your conversations",
+    "you've reached the rate limit",
+)
+
+
+def is_rate_limited_text(text: str) -> bool:
+    """Return True if *text* looks like ChatGPT's rate-limit pop-up copy."""
+    if not text:
+        return False
+    lowered = text.lower()
+    return any(phrase in lowered for phrase in _RATE_LIMIT_PHRASES)
+
+
+class CompletionDetector:
+    """Generation-completion detection, composed by ``CDPDriver``.
+
+    Constructed once in ``CDPDriver.__init__`` and stored as
+    ``self._completion``. Exposes a single delta-only async sub-generator;
+    the driver re-yields its chunks verbatim (no buffering / post-processing)
+    so the public ``send_and_stream`` yield sequence is byte-equivalent to
+    pre-extraction.
+
+    Stateless beyond ``_driver`` across calls — every loop variable is a method
+    local. Two per-call results (``last_dom_text`` /
+    ``had_non_text_content``) are exposed as instance attributes for the
+    driver's post-loop tail to read; they are reset at the start of each call
+    and carry no state between calls.
+    """
+
+    def __init__(self, driver) -> None:
+        self._driver = driver
+        # Per-call results surfaced for the driver tail; reset each call.
+        self.last_dom_text: str = ""
+        self.had_non_text_content: bool = False
+
+    async def stream_until_complete(
+        self,
+        *,
+        initial_count: int,
+        timeout: float,
+    ) -> AsyncIterator[StreamChunk]:
+        """Run Phase-1 (appear) + Phase-2 (stream) and yield delta chunks.
+
+        Yields ``StreamChunk(delta=...)`` as new streamed text arrives. Does
+        NOT emit a terminal ``finish_reason`` chunk — that is the driver
+        shell's responsibility after this generator returns. Returns (stops
+        iterating) once generation is detected complete (backend ``end_turn``
+        primary, action-button fallback, or a stall raises
+        ``GenerationStuckError``).
+        """
+        # Imported lazily to avoid a module-load circular dependency: cdp_driver
+        # top-level re-exports PHASE_STALL_SECONDS / is_rate_limited_text from
+        # this module, so this module must not import cdp_driver at load time.
+        from .cdp_driver import CDPJSError, GenerationStuckError, RateLimitError, StreamChunk
+
+        d = self._driver
+
+        # Reset per-call results surfaced to the driver tail.
+        self.last_dom_text = ""
+        self.had_non_text_content = False
+
+        # Wait for a new assistant message. The full `timeout` governs (was
+        # capped at 60s, which killed slow-to-appear responses like image
+        # generation). A stall detector (PHASE_STALL_SECONDS) catches a true
+        # hang fast: if the assistant node count doesn't change at all — even
+        # 0→1 with empty text counts as progress — for longer than the stall
+        # window, we raise GenerationStuckError instead of waiting out the
+        # whole deadline. Slow-but-progressing generations (image render,
+        # deep-research thinking) keep resetting the stall clock and are
+        # allowed the full timeout.
+        deadline = time.monotonic() + timeout
+        last_node_count = initial_count
+        last_progress = time.monotonic()
+        while time.monotonic() < deadline:
+            # First check for ChatGPT's rate-limit pop-up — if present, fail
+            # fast with a clear error instead of waiting out the whole timeout.
+            # The pop-up blocks the assistant from responding, so the assistant
+            # count would never increase; without this check we'd hit a generic
+            # timeout that hides the real cause.
+            try:
+                dom_scan = await d._js_strict(
+                    "(function(){"
+                    "  var t = (document.body && document.body.innerText) || '';"
+                    "  return JSON.stringify({text: t.slice(0, 4000)});"
+                    "})()"
+                )
+                scanned_text = json.loads(dom_scan).get("text", "")
+            except (CDPJSError, json.JSONDecodeError, TypeError):
+                scanned_text = ""
+            if is_rate_limited_text(scanned_text):
+                # from_text parses any explicit wait from the pop-up copy.
+                raise RateLimitError.from_text(scanned_text)
+
+            try:
+                raw = await d._js_strict(
+                    "document.querySelectorAll('[data-message-author-role=\"assistant\"]').length"
+                )
+                current_count = int(raw or 0)
+            except CDPJSError:
+                current_count = last_node_count  # no progress signal
+            if current_count != last_node_count:
+                # Any node-count change is progress (incl. 0→1 with empty text,
+                # the slow-render case). Reset the stall clock.
+                last_node_count = current_count
+                last_progress = time.monotonic()
+            if current_count > initial_count:
+                break
+            if time.monotonic() - last_progress > PHASE_STALL_SECONDS:
+                raise GenerationStuckError("phase_1_appear", time.monotonic() - last_progress)
+            await asyncio.sleep(0.5)
+        else:
+            raise GenerationStuckError("phase_1_appear", timeout)
+
+        logger.info("Assistant message appeared, waiting for completion...")
+
+        # Poll until generation is done (Stop button gone). A stall detector
+        # (PHASE_STALL_SECONDS) catches a stuck generation: if NO DOM progress
+        # occurs for longer than the stall window, we raise GenerationStuckError.
+        #
+        # Progress is tracked on THREE signals, not just text, so non-text
+        # responses (images, tool-use, code interpreter) don't falsely stall:
+        #   - text:       .markdown textContent (streamed as deltas for text)
+        #   - html_len:   assistant message innerHTML length (grows when img/
+        #                 canvas/tool-use elements are added)
+        #   - child_count: direct children count (grows when new blocks render)
+        # Any of these changing resets the stall clock.
+        #
+        # Done detection: Stop button gone AND there's meaningful content
+        # (either .markdown text OR non-trivial HTML footprint). The threshold
+        # (> 50 chars) prevents false 'done' from an empty/partial node.
+        last_dom_text = ""
+        last_html_len = 0
+        last_child_count = 0
+        had_non_text_content = False
+        # saw_thinking: has the model shown a reasoning phase this turn? Used
+        # to unlock the R4 backend fallback DURING thinking (when last_dom_text
+        # is empty) — without this, a long reasoning response (>90s think time
+        # with no DOM text change) stalls before the answer ever streams.
+        saw_thinking = False
+        # Completion detection for Phase-2. The history here matters — three
+        # earlier signals each failed in live testing, all producing an
+        # off-by-one where request N returned request N-1's text:
+        #   1. ``done = !stopBtn && hasContent`` — broke on the FIRST poll.
+        #      Right after send the Stop button hasn't appeared yet (generation
+        #      not begun) but html_len > 50 (the message wrapper), so this was
+        #      True immediately, leaving last_dom_text empty.
+        #   2. ``generation_started && not is_generating`` — the Stop button
+        #      FLICKERS off between token batches, breaking mid-generation with
+        #      truncated text.
+        #   3. Text-stability alone — ``.markdown`` textContent is empty during
+        #      streaming (text renders elsewhere until the turn settles), so
+        #      "stable empty" never completes and the stall detector fires.
+        #
+        # The robust signal is the per-turn ACTION BUTTON. ChatGPT renders a
+        # copy/feedback action row (data-testid containing "copy" or
+        # "response-turn") on an assistant message ONLY once it has finished
+        # generating — it is absent while the message is streaming or thinking.
+        # Polling for that button on the NEW message is immune to the Stop
+        # flicker and to the empty-.markdown-during-streaming quirk. Text is
+        # captured from the message's innerText (which IS populated during
+        # streaming) rather than .markdown textContent (which lags).
+        last_change_time = time.monotonic()
+        deadline = time.monotonic() + timeout
+        # Backend end_turn fallback throttle (R4): if the DOM action-button
+        # selector drifts again, the conversation API's end_turn flag is a
+        # secondary completion signal. Throttled to once per 3s to respect the
+        # shared account rate budget, and only fires when has_action is false
+        # (so it never races the primary DOM signal). Never the sole signal.
+        last_backend_check = 0.0
+        conv_id_for_check = d._current_conv_id or ""
+        # Mid-loop conv_id probe throttle. On a NEW chat (REST /health path or
+        # the SSE/MCP path) _current_conv_id is None here and conv_id_for_check
+        # is "" — which silently disables the backend end_turn fallback below
+        # (its guard is ``conv_id_for_check and ...``). That fallback is the
+        # stable completion signal when the DOM action-button selector drifts.
+        # ChatGPT navigates to /c/{id} within ~1s of send, so we probe the live
+        # URL (cheap) until a conv_id is available, then the existing backend
+        # check can fire. See _get_live_conversation_id_best_effort.
+        last_conv_id_probe = 0.0
+        while time.monotonic() < deadline:
+            try:
+                result = await d._js_strict(
+                    "(function() {"
+                    "  var msgs = document.querySelectorAll('[data-message-author-role=\"assistant\"]');"
+                    "  if (!msgs.length) return JSON.stringify({text:'', md_text:'', html_len:0, child_count:0, has_action:false, is_thinking:false});"
+                    "  var last = msgs[msgs.length - 1];"
+                    # Text: the clean answer lives in ``.markdown`` textContent.
+                    # It's empty during streaming and populates as the turn
+                    # settles — so we ALSO capture ``innerText`` (populated
+                    # during streaming) as a fallback. innerText includes the
+                    # reasoning UI label ("Thinking.../Thought for N seconds"),
+                    # so md_text is captured SEPARATELY and Python prefers it;
+                    # the innerText fallback is trimmed of the leading label.
+                    "  var md = last.querySelector('.markdown');"
+                    "  var mdText = md ? (md.textContent || '') : '';"
+                    "  var rawText = (last.innerText || '').trim();"
+                    # Strip a leading "Thinking..." / "Thought for …" reasoning
+                    # label so the innerText fallback can't leak it as a delta.
+                    "  var text = mdText || rawText.replace(/^Think(ing|\\s+for)[^\\n]*\\n?/i, '');"
+                    "  var html_len = last.innerHTML.length;"
+                    "  var child_count = last.children.length;"
+                    # has_action: the per-turn copy/feedback action row appears
+                    # only on a COMPLETED message. ChatGPT's DOM layout puts these
+                    # buttons in a SIBLING/UNCLE container, NOT as descendants of
+                    # the assistant message node — so a plain
+                    # ``last.querySelector(...)`` finds nothing and completion is
+                    # never detected (every send stalled at the 90s ceiling). The
+                    # fix: walk up ancestors, querying down at each scope, and
+                    # require the button to be GEOMETRICALLY NEAR the message so
+                    # an older turn's action row can't falsely complete a brand-new
+                    # answer. New testid scheme is ``*-turn-action-button``
+                    # (copy/good-response/bad-response); the legacy
+                    # ``response-turn`` selector is retained for older deployments
+                    # but no longer matches anything on current ChatGPT.
+                    #
+                    # Depth was 4; raised to 8 after issue #12 found the action
+                    # row at ancestor depth 6. The geometry window is widened to
+                    # accept buttons rendered ABOVE the message (top - 180) —
+                    # short answers place the action row in the spacing above the
+                    # message node, which the old top-8 gate rejected. This is a
+                    # FALLBACK signal now (backend end_turn is primary); kept as an
+                    # escape hatch for when conv_id is unavailable or backend fails.
+                    '  var ACT = \'[data-testid="copy-turn-action-button"],'
+                    '            [data-testid="good-response-turn-action-button"],'
+                    '            [data-testid="bad-response-turn-action-button"],'
+                    '            [data-testid*="turn-action-button"],'
+                    '            [data-testid*="copy"],'
+                    '            [data-testid*="response-turn"]\';'
+                    "  var has_action = (function() {"
+                    "    var lastRect = last.getBoundingClientRect();"
+                    "    var scope = last;"
+                    "    for (var d = 0; scope && d <= 8; d++, scope = scope.parentElement) {"
+                    "      var btns = Array.prototype.filter.call("
+                    "        scope.querySelectorAll(ACT),"
+                    "        function(el){ return el.offsetParent !== null || el.getClientRects().length > 0; }"
+                    "      );"
+                    "      if (!btns.length) continue;"
+                    "      for (var i = 0; i < btns.length; i++) {"
+                    "        var r = btns[i].getBoundingClientRect();"
+                    "        if (r.top >= lastRect.top - 180 && r.top <= lastRect.bottom + 240) {"
+                    "          return true;"
+                    "        }"
+                    "      }"
+                    "    }"
+                    "    return false;"
+                    "  })();"
+                    # is_thinking: the active-reasoning indicator. Narrowed to
+                    # ``.result-thinking`` AND ``!has_action`` — the action
+                    # button marks a finished turn, and ``.result-thinking``
+                    # lingers in the DOM after completion as a collapsed
+                    # "Thought process" section. WITHOUT the has_action gate
+                    # this stayed true forever, and the old ``/thinking/i``
+                    # word-match on innerText matched the persistent
+                    # "Thought for N seconds" summary label — together they
+                    # pinned is_thinking=true on every thinking-model turn
+                    # and on any answer that mentioned the word "thinking",
+                    # which suppressed all delta emission (see the elif below)
+                    # and produced empty responses when _fetch_text lagged.
+                    # Also recognize a plain "Thinking..." innerText placeholder
+                    # (some layouts show reasoning text without .result-thinking)
+                    # so the stall clock treats it as active generation, not a stall.
+                    "  var hasThinkingEl = !!last.querySelector('.result-thinking');"
+                    "  var visibleThinking = /^(thinking|reasoning)\\b/i.test(rawText.trim());"
+                    "  var is_thinking = !has_action && (hasThinkingEl || (visibleThinking && !mdText));"
+                    "  return JSON.stringify({text: text, md_text: mdText, html_len: html_len, child_count: child_count, has_action: has_action, is_thinking: is_thinking});"
+                    "})()",
+                )
+                data = json.loads(result)
+            except (CDPJSError, json.JSONDecodeError, TypeError):
+                await asyncio.sleep(0.5)
+                continue
+
+            current = data.get("text", "")
+            md_text = data.get("md_text", "")
+            html_len = data.get("html_len", 0)
+            child_count = data.get("child_count", 0)
+            has_action = data.get("has_action", False)
+            is_thinking = data.get("is_thinking", False)
+
+            # Streaming source: prefer the clean .markdown answer container
+            # over the innerText fallback (which carries the reasoning label).
+            # When md_text is empty (early streaming, before .markdown fills),
+            # the innerText fallback (with its leading label already stripped
+            # in JS) is what carries the streamed answer.
+            current = md_text or current
+
+            # is_thinking means the model is actively reasoning — the DOM is
+            # legitimately static for tens of seconds, which is NOT a stall.
+            # It MUST reset the stall clock so a genuine reasoning phase isn't
+            # killed early. But a STALE thinking state (.result-thinking lingers
+            # as a collapsed section after the answer finishes) must not freeze
+            # the stall detector forever — that's how a drift in the DOM
+            # action-button selector produced the 120s completion hang (issue
+            # #10): is_thinking pinned last_change_time every poll so the 90s
+            # stall guard never fired. Compromise: let thinking reset the stall
+            # clock ONLY while we have no stable backend completion signal
+            # available. Once conv_id_for_check is resolved, the backend
+            # end_turn fallback can detect completion even under stale thinking,
+            # so we stop granting the indefinite thinking stall reset — the
+            # normal stall clock applies and bounds the worst case. (Resetting
+            # saw_thinking is independent of this and always happens.)
+            if is_thinking:
+                saw_thinking = True
+                if not conv_id_for_check:
+                    last_change_time = time.monotonic()
+            if current != last_dom_text:
+                last_change_time = time.monotonic()
+                if len(current) > len(last_dom_text):
+                    delta = current[len(last_dom_text) :]
+                    yield StreamChunk(delta=delta)
+                last_dom_text = current
+                self.last_dom_text = last_dom_text
+
+            # Non-text progress signals (images, tool-use, etc.)
+            if html_len != last_html_len or child_count != last_child_count:
+                last_change_time = time.monotonic()
+                if html_len > 50:
+                    had_non_text_content = True
+                    self.had_non_text_content = True
+            last_html_len = html_len
+            last_child_count = child_count
+
+            # ── Completion detection ─────────────────────────────────────
+            # Two signals, ordered by stability. Backend end_turn is PRIMARY
+            # (issue #12): it survived three DOM action-button drifts where the
+            # DOM selector failed. The DOM has_action is a FALLBACK for the
+            # window where conv_id is unavailable (before the URL resolves, ~1s
+            # into a new chat) or when the backend fetch fails transiently.
+            #
+            # Resolve conv_id first (needed for the primary signal on new chats).
+            if not conv_id_for_check:
+                now = time.monotonic()
+                if now - last_conv_id_probe >= 1.0:
+                    last_conv_id_probe = now
+                    try:
+                        conv_id_for_check = await d._get_live_conversation_id_best_effort()
+                        if conv_id_for_check:
+                            logger.info(
+                                "Resolved conversation id mid-loop: %s",
+                                conv_id_for_check,
+                            )
+                    except Exception as e:
+                        logger.debug("conv_id probe failed (ignored): %s", e)
+
+            # PRIMARY: backend end_turn. Throttled to one fetch per 3s to respect
+            # the shared account rate budget. Eligible when we have streamed text
+            # OR have seen a thinking phase — a long reasoning response has empty
+            # last_dom_text during thinking, but the backend reports end_turn once
+            # the model finishes. Completion stays strict (end_turn AND usable
+            # content) so this can't complete an empty answer. Fetch failures set
+            # backend_fetch_failed so the DOM fallback below is unlocked this poll.
+            backend_fetch_failed = False
+            if (
+                conv_id_for_check
+                and (last_dom_text or saw_thinking or is_thinking or had_non_text_content)
+                and time.monotonic() - last_backend_check > 3.0
+            ):
+                last_backend_check = time.monotonic()
+                try:
+                    if await d._fetch_end_turn(conv_id_for_check):
+                        # STRICT: end_turn AND usable content. The saw_thinking
+                        # unlock lets us CONSULT the backend during thinking, but
+                        # we must not finish on a bare end_turn with no answer.
+                        if last_dom_text or had_non_text_content:
+                            logger.info(
+                                "Backend end_turn=true (primary completion) for %s",
+                                conv_id_for_check,
+                            )
+                            break
+                        logger.debug(
+                            "Backend end_turn=true but no content yet for %s — "
+                            "not completing (strict content guard)",
+                            conv_id_for_check,
+                        )
+                except Exception as e:
+                    backend_fetch_failed = True
+                    logger.debug("end_turn fetch failed (ignored): %s", e)
+
+            # FALLBACK: DOM action button (has_action). Used ONLY when the primary
+            # backend signal can't run: conv_id is unavailable (before the URL
+            # resolves) OR the backend fetch just failed this poll. When the
+            # backend IS available it is authoritative — a widened has_action
+            # match (depth 8, top-180) can hit a PRIOR turn's action row, so DOM
+            # must not override a live backend that says "not done yet" or that
+            # hasn't been consulted yet due to throttle. Also requires usable
+            # content (same strict guard as the primary) so it can't complete an
+            # empty answer off a stale button.
+            if (
+                has_action
+                and (not conv_id_for_check or backend_fetch_failed)
+                and (last_dom_text or had_non_text_content)
+            ):
+                logger.info("DOM has_action (fallback completion) — no backend signal")
+                break
+
+            if time.monotonic() - last_change_time > PHASE_STALL_SECONDS:
+                raise GenerationStuckError("phase_2_stream", time.monotonic() - last_change_time)
+
+            await asyncio.sleep(0.5)
+
+        # Per-call results (last_dom_text / had_non_text_content) are already
+        # mirrored to self.* as they changed during the loop; the driver tail
+        # reads them to emit the _fetch_text suffix delta / non-text placeholder.
+        return

--- a/tests/test_completion_detector.py
+++ b/tests/test_completion_detector.py
@@ -1,0 +1,232 @@
+"""Wiring tests for CompletionDetector (Phase 5 PR4 extraction).
+
+These verify the extraction moved the Phase-1 (assistant-node appear) and
+Phase-2 (DOM stream + completion-detection) loop bodies onto
+CompletionDetector.stream_until_complete, and that the detector reaches the
+driver's transport / backend / conversation-id through the correct seam. They
+are NOT behavioral tests — completion behavior is already covered by
+test_end_turn_primary / test_reliability / test_rate_limit and the broad suite,
+which stub the driver and confirm the driver-facing surface is preserved. This
+file guards the wiring:
+
+  - CompletionDetector exists and exposes stream_until_complete (delta-only
+    async sub-generator).
+  - CDPDriver wires self._completion = CompletionDetector(self) in __init__.
+  - The detector holds no long-lived config beyond _driver (the two per-call
+    result attrs are transient, reset each call).
+  - The detector routes transport/backend/conv-id through self._driver, NOT
+    local copies — so driver-side monkeypatches still intercept.
+  - is_rate_limited_text / PHASE_STALL_SECONDS stay importable from cdp_driver
+    (back-compat for api_server / chatgpt_dom / tests).
+  - No cdp_driver import at completion_detector module load (circular-import
+    rule); error classes / StreamChunk are imported lazily inside the method.
+"""
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.completion_detector import (
+    PHASE_STALL_SECONDS,
+    CompletionDetector,
+)
+
+
+def _make_detector():
+    """A CompletionDetector backed by a mock driver with the seam it reaches
+    through. JS/backend defaults to AsyncMocks so individual tests override
+    only what they assert on."""
+    driver = MagicMock()
+    driver._current_conv_id = None
+    driver._js_strict = AsyncMock(return_value="")
+    driver._fetch_end_turn = AsyncMock(return_value=False)
+    driver._get_live_conversation_id_best_effort = AsyncMock(return_value="")
+    return CompletionDetector(driver), driver
+
+
+# ── 1. CompletionDetector exposes the sub-generator ───────────────────
+
+
+def test_detector_has_stream_until_complete():
+    """The single extracted method exists and is an async generator function
+    (it yields delta chunks)."""
+    detector, _ = _make_detector()
+    assert callable(getattr(detector, "stream_until_complete", None)), (
+        "CompletionDetector must expose stream_until_complete"
+    )
+    assert inspect.isasyncgenfunction(detector.stream_until_complete), (
+        "stream_until_complete must be an async generator (it yields StreamChunks)"
+    )
+
+
+def test_stream_until_complete_is_keyword_only():
+    """The driver shell calls it with initial_count= / timeout= by keyword."""
+    sig = inspect.signature(CompletionDetector.stream_until_complete)
+    for name in ("initial_count", "timeout"):
+        assert sig.parameters[name].kind == inspect.Parameter.KEYWORD_ONLY, (
+            f"{name} must be keyword-only"
+        )
+
+
+# ── 2. CDPDriver wires _completion ────────────────────────────────────
+
+
+def test_driver_wires_completion():
+    """CDPDriver.__init__ must construct the detector with itself."""
+    from chatgpt_web2api.cdp_driver import CDPDriver
+
+    d = CDPDriver(cdp_port=9222)
+    assert isinstance(d._completion, CompletionDetector), (
+        "CDPDriver must wire self._completion = CompletionDetector(self)"
+    )
+    assert d._completion._driver is d, "detector's _driver must be the owner"
+
+
+# ── 3. Per-call results, no long-lived config across calls ────────────
+
+
+def test_detector_has_only_driver_and_transient_results():
+    """The detector holds _driver plus two transient per-call result attrs
+    (last_dom_text / had_non_text_content). No long-lived config migrates in."""
+    detector, _ = _make_detector()
+    own = vars(detector)
+    assert set(own) == {"_driver", "last_dom_text", "had_non_text_content"}, (
+        f"unexpected instance state on CompletionDetector: {set(own)}"
+    )
+
+
+def test_per_call_results_reset_on_each_call():
+    """last_dom_text / had_non_text_content are reset at the start of each
+    stream_until_complete call (no state leaks between calls)."""
+    detector, driver = _make_detector()
+    # Pollute them; the first thing the method does is reset both to defaults.
+    detector.last_dom_text = "stale"
+    detector.had_non_text_content = True
+
+    # The detector calls _js_strict with several distinct JS expressions:
+    #   - the rate-limit body scan  -> JSON {"text": ...}
+    #   - the assistant node count  -> integer-as-string
+    #   - the Phase-2 poll           -> JSON {text, md_text, html_len, ...}
+    # Discriminate by expression so each returns the right shape. The poll
+    # carries text so the backend end_turn completion guard (which requires
+    # last_dom_text OR had_non_text_content) can fire and end the loop fast.
+    scan = '{"text": ""}'
+    poll = '{"text":"hi","md_text":"hi","html_len":60,"child_count":1,"has_action":false,"is_thinking":false}'
+
+    async def fake_js(expr):
+        if "getBoundingClientRect" in expr:  # Phase-2 completion poll
+            return poll
+        if "innerText" in expr:  # Phase-1 rate-limit body scan
+            return scan
+        return "1"  # assistant-node count poll
+
+    driver._js_strict = fake_js
+    driver._fetch_end_turn = AsyncMock(return_value=True)
+    # Provide a conv_id so the backend end_turn primary signal is eligible
+    # (guard requires conv_id_for_check); without it the loop has no
+    # completion path and would run to the timeout.
+    driver._get_live_conversation_id_best_effort = AsyncMock(return_value="conv-1")
+
+    import asyncio
+
+    async def drain():
+        async for _ in detector.stream_until_complete(initial_count=0, timeout=5):
+            pass
+
+    asyncio.run(drain())
+    # Reset happened: the "stale" value did not survive the call boundary. With
+    # the poll carrying text="hi", last_dom_text reflects THIS call ("hi").
+    assert detector.last_dom_text == "hi"
+    assert detector.last_dom_text != "stale"
+
+
+# ── 4. Back-compat re-exports from cdp_driver ─────────────────────────
+
+
+def test_is_rate_limited_text_reexported_identity():
+    """is_rate_limited_text must remain importable from cdp_driver, and it must
+    be the SAME object (identity) as the one in completion_detector."""
+    from chatgpt_web2api.cdp_driver import is_rate_limited_text as drv_fn
+    from chatgpt_web2api.completion_detector import is_rate_limited_text as det_fn
+
+    assert drv_fn is det_fn, "is_rate_limited_text must be re-exported by identity"
+    assert drv_fn("Too many requests") is True
+    assert drv_fn("normal chat answer") is False
+
+
+def test_phase_stall_seconds_reexported_equal():
+    """PHASE_STALL_SECONDS must remain importable from cdp_driver with the same
+    value (equality, not identity — ints are not guaranteed interned)."""
+    from chatgpt_web2api.cdp_driver import PHASE_STALL_SECONDS as drv_val
+
+    assert drv_val == PHASE_STALL_SECONDS == 90
+
+
+# ── 5. Detector routes through self._driver (the seam) ───────────────
+
+
+@pytest.mark.asyncio
+async def test_detector_routes_js_through_driver():
+    """The detector must call self._driver._js_strict, NOT a local copy — so
+    driver-side monkeypatches (used across the test suite) still intercept."""
+    detector, driver = _make_detector()
+    driver._fetch_end_turn = AsyncMock(return_value=True)
+    # Discriminate by JS expression: body scan -> JSON, count -> "1" (exceeds
+    # initial_count=0 so Phase-1 breaks), poll -> completed payload WITH text so
+    # the backend end_turn strict-content guard can fire and end the loop.
+    scan = '{"text": ""}'
+    poll = '{"text":"hi","md_text":"hi","html_len":60,"child_count":1,"has_action":false,"is_thinking":false}'
+    js_calls = {"n": 0}
+
+    async def fake_js(expr):
+        js_calls["n"] += 1  # proof the detector reached transport via the driver
+        if "getBoundingClientRect" in expr:  # Phase-2 poll (also contains innerText)
+            return poll
+        if "innerText" in expr:  # Phase-1 body scan
+            return scan
+        return "1"
+
+    driver._js_strict = fake_js
+    driver._fetch_end_turn = AsyncMock(return_value=True)
+    # Provide conv_id so the backend end_turn primary signal is eligible and
+    # the loop completes (otherwise no completion path → runs to timeout).
+    driver._get_live_conversation_id_best_effort = AsyncMock(return_value="conv-1")
+    seen = []
+    async for chunk in detector.stream_until_complete(initial_count=0, timeout=10000):
+        seen.append(chunk)
+    assert js_calls["n"] >= 1, "detector must reach transport via _driver._js_strict"
+    assert driver._fetch_end_turn.await_count >= 1, (
+        "detector must reach backend via _driver._fetch_end_turn"
+    )
+
+
+# ── 6. No cdp_driver import at completion_detector module load ────────
+
+
+def test_no_cdp_driver_import_at_module_load():
+    """Circular-import rule: completion_detector must NOT import anything from
+    cdp_driver at module top level (cdp_driver top-level re-exports symbols FROM
+    completion_detector). Error classes / StreamChunk are imported lazily inside
+    the method body. Verify by inspecting the module's source for a top-level
+    cdp_driver import."""
+    src = inspect.getsource(importlib_import_module("chatgpt_web2api.completion_detector"))
+    # A `from .cdp_driver import` at column 0 (module level, not inside a def)
+    # would be a circular-import violation. The lazy import is indented inside
+    # stream_until_complete, so it does not start at column 0.
+    for line in src.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("from .cdp_driver import") or stripped.startswith(
+            "from chatgpt_web2api.cdp_driver import"
+        ):
+            assert line.startswith(" "), (
+                f"cdp_driver import must be lazy (indented inside a method), "
+                f"not top-level: {line!r}"
+            )
+
+
+# importlib shim imported lazily so the test file's own imports stay clean
+def importlib_import_module(name):
+    import importlib
+
+    return importlib.import_module(name)

--- a/tests/test_end_turn_primary.py
+++ b/tests/test_end_turn_primary.py
@@ -187,12 +187,16 @@ def test_has_action_js_walks_depth_8():
     """The JS has_action selector must walk up to depth 8 (was 4) so it
     reaches the action row at ancestor depth 6. This is a structural check
     on the JS source — the depth limit is what the #12 investigation found
-    was too shallow."""
+    was too shallow.
+
+    Phase 5 PR4: the Phase-2 completion-detection JS moved from
+    CDPDriver.send_and_stream into CompletionDetector.stream_until_complete;
+    inspect the detector (the JS's new canonical home)."""
     import inspect
 
-    from chatgpt_web2api.cdp_driver import CDPDriver
+    from chatgpt_web2api.completion_detector import CompletionDetector
 
-    src = inspect.getsource(CDPDriver.send_and_stream)
+    src = inspect.getsource(CompletionDetector.stream_until_complete)
     # The walk loop bound must be 8, not the old 4
     assert "d <= 8" in src, "has_action JS must walk d <= 8 ancestors (was 4)"
     assert "d <= 4" not in src, "old d <= 4 depth limit must be gone"
@@ -204,12 +208,14 @@ def test_has_action_js_walks_depth_8():
 def test_has_action_js_geometry_accepts_above_message():
     """Short answers place the action button ABOVE the message node. The
     geometry gate must accept top >= lastRect.top - 180 (was -8). Structural
-    check on the JS source."""
+    check on the JS source.
+
+    Phase 5 PR4: JS moved to CompletionDetector.stream_until_complete."""
     import inspect
 
-    from chatgpt_web2api.cdp_driver import CDPDriver
+    from chatgpt_web2api.completion_detector import CompletionDetector
 
-    src = inspect.getsource(CDPDriver.send_and_stream)
+    src = inspect.getsource(CompletionDetector.stream_until_complete)
     # The geometry window must be widened to top-180 (the #12 short-answer case)
     assert "lastRect.top - 180" in src, (
         "geometry gate must accept buttons 180px above message (was top - 8)"


### PR DESCRIPTION
## Summary

Phase 5 PR4 — slices the generation-completion detection concern (Phase-1 appear loop + Phase-2 stream loop) out of `CDPDriver.send_and_stream` into a new `completion_detector.py`. **No behavior change.**

Unlike PRs #22–#25 (which moved already-factored `def`s), this PR cuts **inline loop bodies** out of one monolithic method into a delta-only async sub-generator, which the driver re-yields verbatim.

## What moved → `completion_detector.py`
- `PHASE_STALL_SECONDS`, `_RATE_LIMIT_PHRASES` (private), `is_rate_limited_text`
- Phase-1 appear loop (node-appear + rate-limit pop-up scan + stall guard)
- Phase-2 stream loop (DOM poll + delta emit + 3-signal stall + action-button fallback + backend `end_turn` primary + mid-loop `conv_id` resolve)

## What stays in `cdp_driver.py` (`send_and_stream`)
- Signature, pre-count, `type_message`/`click_send`, `async for ... yield` re-yield
- Post-loop URL conv-id resolve + `self._current_conv_id` mutation
- `_fetch_text` final reconcile + non-text placeholder
- Terminal `StreamChunk(delta="", finish_reason="stop")`
- `StreamChunk`, `RateLimitError`, `GenerationStuckError`, `RATE_LIMIT_DEFAULT_RETRY_AFTER`, `parse_retry_after`

## Key design decisions
1. **Delta-only sub-generator.** The detector yields `StreamChunk(delta=...)` only; the terminal `finish_reason="stop"` stays in the driver tail. `finish_reason` remains literally `"stop"` (no `length`/`tool_calls` path invented).
2. **Byte-equivalent yield ordering.** The driver does `async for chunk in self._completion.stream_until_complete(...): yield chunk` — no buffering / list accumulation / post-processing.
3. **Mandatory circular-import rule.** `cdp_driver` top-level re-exports `PHASE_STALL_SECONDS` + `is_rate_limited_text` from `completion_detector`; therefore `completion_detector` imports `StreamChunk`/`RateLimitError`/`GenerationStuckError`/`CDPJSError` **lazily inside the method body** (mirrors the proven `chatgpt_dom` convention). No `cdp_driver` import at module load.
4. **Detector seam.** Every call routes through `self._driver` (not `self`): `_js_strict`, `_fetch_end_turn`, `_get_live_conversation_id_best_effort`. Reads `_current_conv_id` once into a local; **never writes it**. Never touches the breaker registry.
5. **Per-call results.** The driver tail needs `last_dom_text` (for the `_fetch_text` suffix delta) and `had_non_text_content` (placeholder gate) — these were locals inside the extracted loop. They're surfaced as transient instance attrs on the detector, reset at the start of each call (no state across calls beyond `_driver`).

## Back-compat
- `is_rate_limited_text` and `PHASE_STALL_SECONDS` remain importable from `cdp_driver` (consumers: `api_server.py`, `chatgpt_dom.py`, `test_rate_limit.py`, `test_e2e_rate_limit.py`). Identity / value equality verified by tests.

## Tests
- **New** `tests/test_completion_detector.py` — 9 wiring tests (method presence, keyword-only signature, `_completion` wiring, instance-state boundary, per-call reset, identity/value re-exports, driver-seam routing, no-module-load-circular-import).
- **Retargeted** `tests/test_end_turn_primary.py` — the 2 structural JS-source assertions (`d <= 8` depth, `lastRect.top - 180` geometry) now inspect `CompletionDetector.stream_until_complete` (the JS's new canonical home) instead of `send_and_stream`. Assertions unchanged.
- **471 passed** (462 prior + 9 new). No `backend_client.py` / `cdp_transport.py` / `chatgpt_dom.py` edits.

## Verification
- [x] `ruff check src tests` — clean
- [x] `pytest -q` — 471 passed
- [x] grep audit — no completion-loop JS remains inline in `send_and_stream`; no top-level `cdp_driver` import in `completion_detector`
- [ ] CI green on head
- [ ] Post-merge live check (deploy notes): `chatgpt-web2api ensure --rest-port 8080 --mcp-sse-port 8090` → `GET :8080/health` → non-stream `"ok"` POST

## Blockers (review checklist)
- [ ] `completion_detector.py` does NOT import `cdp_driver` at module load
- [ ] detector does NOT emit `finish_reason="stop"`
- [ ] detector does NOT write `_current_conv_id`
- [ ] `send_and_stream` tail (conv-id resolve / mutation / `_fetch_text` reconcile / terminal chunk) is unchanged
- [ ] `finish_reason` and rate-limit error semantics unchanged
- [ ] breaker behavior unchanged
- [ ] `backend_client.py` / `cdp_transport.py` / `chatgpt_dom.py` untouched
- [ ] detector chunks not buffered/post-processed at the re-yield seam