### PR TITLE
docs: mark Phase 5 extraction complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The tool surface is now **16 tools** (was 15): added `delete_project` (DELETE `/backend-api/gizmos/{id}`, gated under `W2A_ENABLE_DESTRUCTIVE=1`). The "15 tools" invariant across unit/deep/gating/integration tests updated to 16.
 - `list_tools` now returns the gated surface via the new `build_tools()`; `_build_tools()` (all 16, unfiltered) is retained for tests.
+- **Phase 5 `cdp_driver.py` split — internal refactor, no behavior change.** The ~2986-line monolith was reduced to **1558 lines** by extracting four focused modules while keeping the public `CDPDriver` API byte-stable as an orchestration/interception hub:
+  - `backend_client.py` (#22) — token/session/conversation fetch + project/memory CRUD. Also landed follow-up A: bounded transient-404 retry in `_fetch_text` (#23).
+  - `cdp_transport.py` (#24) — CDP websocket/session/reconnect primitives.
+  - `chatgpt_dom.py` (#25) — composer selectors, send-readiness, typing/send, rate-limit dismiss.
+  - `completion_detector.py` (#26) — Phase-1 assistant-node-appear loop + Phase-2 stream/completion-detection loop (delta-only sub-generator re-yielded by the driver).
+  - `CDPDriver` retains thin delegators as the **monkeypatch interception seam** used by the extracted modules and the test suite — these are intentional, not cruft (a post-extraction audit found zero delete-safe). Lifecycle/tab-ownership/reconnect extraction (Group C) is deferred as a separate high-risk initiative. See `docs/ROADMAP.md` (Phase 5) for the full landing record and rationale.
 
 ## [0.2.0] - 2025-06-06
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -317,12 +317,12 @@ Discovered during Phase 4 runtime validation. Each is a separate, small PR — d
 not bundle them into the Phase 5 refactor.
 
 ```text
-A. _fetch_text transient 404 retry
+A. _fetch_text transient 404 retry   ✅ RESOLVED (#23)
    cdp_driver._fetch_text can hit a backend 404 immediately after send, before
-   the just-created conversation is persisted server-side. Treat this as a
-   bounded transient retry, NOT a breaker. Recommended sequence: extract
-   backend_client.py (Phase 5 PR1, no behavior change) FIRST, then fix the 404
-   in the new module so the retry patch is easy to review.
+   the just-created conversation is persisted server-side. Treated as a bounded
+   transient retry (NOT a breaker). Landed in backend_client.py (#22 extraction)
+   via #23 — the recommended sequence (extract first, then fix in the new module)
+   was followed exactly.
 
 B. requests_served semantics
    /health.requests_served currently counts requests accepted/handled, not
@@ -350,29 +350,75 @@ E. BreakerPolicy threshold config
 
 ---
 
-## Phase 5 — Split `cdp_driver.py`
+## Phase 5 — Split `cdp_driver.py`  ✅ COMPLETE 2026-06-27
 
-**Goal:** reduce bug density *after* behavior is stable. `cdp_driver.py` is
-~2800 lines mixing CDP transport, ChatGPT DOM logic, completion detection, token
-fetch, and tab registry.
+**Goal:** reduce bug density *after* behavior is stable. `cdp_driver.py` was
+~2986 lines mixing CDP transport, ChatGPT DOM logic, completion detection, and
+token/session/conversation fetch. **Reduced to 1558 lines** (nearly halved);
+the rest was extracted into focused, singly-responsible modules with **no
+behavior change**. Each extraction was verified by a full test pass, a green CI
+matrix, and a live `"ok"` send against a real ChatGPT account.
 
-### Suggested split
+### Landed PRs
 
 ```text
-cdp_transport.py        CDP websocket / session / reconnect
-chatgpt_dom.py          composer / selectors / send-readiness
-completion_detector.py  Phase-2 / action / end_turn / stall logic
-backend_client.py       token / session / conversation fetch
-tab_registry.py         (already split — validates the pattern)
-driver.py               orchestration facade (stable CDPDriver API)
+#22 backend_client.py   token / session / conversation fetch (+ project/memory CRUD)
+#23 _fetch_text 404 retry   bounded transient-404 retry (follow-up A, in backend_client)
+#24 cdp_transport.py     CDP websocket / session / reconnect primitives
+#25 chatgpt_dom.py       composer / selectors / send-readiness / rate-limit dismiss
+#26 completion_detector.py   Phase-1 appear loop + Phase-2 stream/completion loop
 ```
 
-### Rules
+### Final architecture — hub-and-spoke interception
+
+`CDPDriver` is now an **orchestration facade + interception hub** plus the
+lifecycle/tab-ownership core. The extracted modules (`backend_client`,
+`cdp_transport`, `chatgpt_dom`, `completion_detector`) hold a back-reference
+to the driver and route every transport/state/peer call through
+`self._driver.<method>` — *not* their own implementations. This is deliberate:
+`CDPDriver` remains the single monkeypatch seam, so test patches on
+`driver.X` propagate into the collaborators. This contract is asserted by
+`tests/test_chatgpt_dom.py` and `tests/test_completion_detector.py` and
+documented in each module's docstring.
+
+### Post-extraction audit — remaining delegators are load-bearing
+
+A full import-site audit (every method on `CDPDriver`, across `src/` and
+`tests/`) found **zero delete-safe facade methods**. The remaining
+driver-facing methods are the intentional compatibility/interception seams used
+by collaborator modules and the test suite — they are **not** technical debt in
+this architecture. Keeping them is what made #22–#26 safe. `cdp_driver.py` is
+at its natural floor for the hub-and-spoke design; further line reduction is
+not available without restructuring the interception contract.
+
+### Deferred — Group C lifecycle / tab-ownership (separate initiative)
+
+The only remaining extraction target is the **lifecycle core**: `connect` /
+`reconnect` / `close`, heartbeat (`_heartbeat_loop`, `_live_target_ids`), tab
+ownership (`_create_owned_tab`, `_find_owned_tab_ws`, `_adopt_existing_chatgpt_tab`,
+`_find_page_ws`, `_browser_cdp`), token refresh, and the breaker-policy touch
+points. This is **deferred as a separate high-risk initiative**, not a Phase 5
+continuation. It is the first extraction that simultaneously crosses lifecycle
+ownership, reconnect semantics, heartbeat, the target registry, browser-domain
+CDP, and breaker policy. It should not be started on the momentum of the
+facade-split work; it deserves a fresh "should we do this at all?" decision
+after Phase 5 is closed.
 
 ```text
-no behavior changes in the first split PR
-move tests with modules
-keep the public CDPDriver facade stable (no caller breakage)
+Phase 5 complete. The driver has been reduced to an orchestration/interception
+hub plus lifecycle/tab-ownership core. A post-extraction audit found no
+delete-safe facade methods: the remaining driver-facing methods are intentional
+compatibility and monkeypatch seams used by collaborator modules and tests.
+Further extraction would require moving lifecycle/tab ownership and reconnect
+policy, which is deferred as a separate high-risk initiative.
+```
+
+### Rules (honored)
+
+```text
+no behavior changes in any split PR             ✅
+tests moved/added with modules                  ✅
+public CDPDriver facade kept stable (no caller breakage)  ✅
 ```
 
 ---
@@ -408,7 +454,7 @@ always-on / server users → use OS supervision (this phase)
 2. SSE recommended transport (docs + integration tests)  ✅
 3. ensure command + ZCode hook docs                        ✅
 4. non-rate-limit breaker policy                           ✅ (PR1 #18 / PR2 #19 / PR3 #20)
-5. split cdp_driver.py                                     (next architectural phase)
+5. split cdp_driver.py                                     ✅ (#22–#26; complete 2026-06-27)
 6. optional OS-supervision docs                            (last, docs-only)
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,14 +35,34 @@ src/chatgpt_web2api/
 │   ├── Monitor process health
 │   └── Restart on crash
 │
-├── cdp_driver.py      CDP primitives (24 methods)
-│   ├── Browser control: navigate, wait_for_selector, evaluate_js
-│   ├── Input: type_text, click_send, upload_file
-│   ├── Streaming: send_and_stream (DOM poll + API hybrid)
-│   ├── Data: get_conversations, get_conversation_detail
-│   ├── Projects: create_project, get_project_detail
-│   ├── Memory: get_memories, delete_memory
-│   └── Auth: ensure_token, get_access_token
+├── cdp_driver.py      CDPDriver — orchestration facade + interception hub (1558 lines)
+│   ├── Lifecycle/tab ownership: connect, reconnect, close, heartbeat,
+│   │   owned-tab discovery/adoption, token refresh  (Group C — not extracted)
+│   ├── Navigation: select_model, navigate_new_chat/conversation/gpt,
+│   │   ensure_current_conversation
+│   ├── send_and_stream: the high-level send + stream orchestration shell
+│   │   (delegates completion-detection loops to completion_detector.py)
+│   └── Thin delegators: the monkeypatch interception seam — every transport/
+│       DOM/backend call routes back through self._driver.<method> so test
+│       patches on the driver propagate into the collaborators. These are
+│       intentional (see Phase 5 audit in docs/ROADMAP.md), not removable.
+│
+├── backend_client.py      Token / session / conversation fetch + project/memory CRUD
+│   └── Extracted Phase 5 (#22). Holds a driver back-reference; routes CDP via
+│       self._driver._js* and token refresh via self._driver.ensure_token.
+│
+├── cdp_transport.py       CDP websocket / session / reconnect primitives
+│   └── Extracted Phase 5 (#24). Owns _ws/_msg_id/_pending; calls back into
+│       reconnect() on socket death.
+│
+├── chatgpt_dom.py         Composer / selectors / send-readiness / rate-limit dismiss
+│   └── Extracted Phase 5 (#25). Routes transport/breakers/navigation through
+│       self._driver; owns no long-lived state.
+│
+├── completion_detector.py Phase-1 appear loop + Phase-2 stream/completion loop
+│   └── Extracted Phase 5 (#26). Delta-only async sub-generator; the driver
+│       re-yields its chunks. Yields deltas only — never finish_reason, never
+│       writes _current_conv_id.
 │
 ├── api_server.py      OpenAI-compatible HTTP server
 │   ├── POST /v1/chat/completions (streaming + non-streaming)


### PR DESCRIPTION
## Summary

Docs-only PR recording that Phase 5 (`cdp_driver.py` split) is complete. **No code changes.**

The post-extraction audit (PR #26 follow-up) found **zero delete-safe facade methods** — the remaining `CDPDriver` delegators are the intentional monkeypatch interception seam, not removable glue. This PR records that decision and closes Phase 5.

## Phase 5 landed (#22–#26)
`cdp_driver.py` reduced **2986 → 1558 lines** (nearly halved), no behavior change, each extraction verified by full test pass + green CI + live `"ok"` send:

| PR | Module | Concern |
|----|--------|---------|
| #22 | `backend_client.py` | token/session/conversation fetch + project/memory CRUD |
| #23 | (in backend_client) | bounded transient-404 retry (follow-up A) |
| #24 | `cdp_transport.py` | CDP websocket/session/reconnect primitives |
| #25 | `chatgpt_dom.py` | composer/selectors/send-readiness/rate-limit dismiss |
| #26 | `completion_detector.py` | Phase-1 appear + Phase-2 stream/completion loops |

## Key decision recorded
`CDPDriver` is now an **orchestration facade + interception hub** plus the lifecycle/tab-ownership core. The extracted modules route every transport/state/peer call back through `self._driver.<method>` — *not* their own implementations — so the driver remains the single monkeypatch seam and test patches propagate. This contract is asserted by `test_chatgpt_dom.py` / `test_completion_detector.py` and documented in each module's docstring. The remaining delegators are **load-bearing seams, not technical debt**.

## Deferred — Group C
The lifecycle core (`connect`/`reconnect`/`close`, heartbeat, tab ownership, token refresh, breaker-policy touch points) is the only remaining extraction target. It is **deferred as a separate high-risk initiative** — the first extraction that simultaneously crosses lifecycle ownership, reconnect semantics, heartbeat, target registry, browser-domain CDP, and breaker policy. It should not start on Phase 5's momentum; it deserves a fresh "should we do this at all?" decision.

## Files changed
- `docs/ROADMAP.md` — Phase 5 section rewritten from future-tense "suggested split" to a complete landing record; follow-up A marked resolved (#23); final-sequencing block updated; Group C deferral + hub-and-spoke rationale recorded.
- `CHANGELOG.md` — Phase 5 entry under `[Unreleased]` `Changed`.
- `docs/architecture.md` — stale "CDP primitives (24 methods)" monolith description replaced with the hub-and-spoke module layout.

## Verification
- [x] docs only — no `.py` changes
- [x] marks Phase 5 complete
- [x] preserves the hub-and-spoke rationale
- [x] states remaining delegators are intentionally retained
- [x] defers Group C explicitly
- [x] avoids promising a near-term lifecycle extraction
- [ ] CI green on head