### PR TITLE
docs: add documentation index (Phase 6 PR3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,8 +476,17 @@ for you to log in.
 
 ## Documentation
 
+**[📋 Full documentation index](docs/INDEX.md)** — start here if you're unsure which doc to read.
+
+Key docs:
+
+- [Deployment Guide](docs/deployment.md) — pip install, Docker, cookie injection, multi-instance, sharing
+- [OS Supervision Guide](docs/os-supervision.md) — systemd / launchd / Task Scheduler / NSSM for always-on deployments
+- [Production Runbook](docs/runbook.md) — health interpretation, failure modes, breaker states, auth recovery, safe restart
+- [API Reference](docs/api-reference.md) — OpenAI-compatible REST endpoints + MCP server surface
+- [Architecture](docs/architecture.md) — codebase structure and the CDPDriver hub-and-spoke module layout
 - [Protocol Reference](docs/protocol-reference.md) — captured ChatGPT web API endpoints
-- [Deployment Guide](docs/deployment.md) — Docker, cookie injection, multi-instance
+- [Roadmap](docs/ROADMAP.md) — phases 1–6, what landed, what's deferred
 - [Contributing](CONTRIBUTING.md) — how to contribute
 - [Changelog](CHANGELOG.md) — version history
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,91 @@
+# Documentation Index
+
+This is the navigation hub for `chatgpt-web2api` documentation. Every doc in
+`docs/` is listed here with a one-line purpose. If you don't know which one to
+read, start with the [routing table](#which-doc-should-i-read) below.
+
+---
+
+## Which doc should I read?
+
+| I want to… | Read this first |
+|------------|-----------------|
+| **try it locally for the first time** | [deployment.md](deployment.md) → Option 1 (pip install) |
+| **run it in Docker / headed Chrome in a container** | [deployment.md](deployment.md) → Docker section + [reverse-engineering-notes.md](reverse-engineering-notes.md) (anti-bot caveats) |
+| **share it with a non-technical user** | [deployment.md](deployment.md) → cookie-export / remote options |
+| **run it always-on under systemd / launchd / NSSM** | [os-supervision.md](os-supervision.md) |
+| **diagnose an incident or interpret `/health`** | [runbook.md](runbook.md) |
+| **recover from a `circuit_open` / auth expiry** | [runbook.md](runbook.md) → §4 (circuit_open) + §6 (auth recovery) |
+| **call the REST or MCP API from code** | [api-reference.md](api-reference.md) |
+| **understand how the codebase is structured** | [architecture.md](architecture.md) |
+| **understand why we drive Chrome via CDP** | [adr-0001-automation-backend.md](adr-0001-automation-backend.md) |
+| **see what's planned / what already landed** | [ROADMAP.md](ROADMAP.md) |
+| **reverse-engineer a new ChatGPT endpoint** | [protocol-reference.md](protocol-reference.md) + [reverse-engineering-notes.md](reverse-engineering-notes.md) |
+
+---
+
+## Operating guides (Phase 6)
+
+These four are the day-to-day operator surface — start here for running a
+deployment.
+
+| Doc | Purpose |
+|-----|---------|
+| [deployment.md](deployment.md) | **Installing & sharing.** pip / Docker / cookie-export / remote-deploy options, plus cross-links to supervision and the runbook. |
+| [os-supervision.md](os-supervision.md) | **Always-on supervision.** systemd (Linux), launchd (macOS), Task Scheduler + NSSM (Windows); `ensure`-on-a-timer and REST+MCP split-service styles. |
+| [runbook.md](runbook.md) | **Operating a running deployment.** Startup checklist, `/health` interpretation, failure modes, breaker states, auth recovery, safe restart, post-deploy validation, logs. Source-cited. |
+| [api-reference.md](api-reference.md) | **Calling the API.** OpenAI-compatible REST endpoints and the MCP server surface (tools, transports). |
+
+---
+
+## Architecture & decisions
+
+| Doc | Purpose |
+|-----|---------|
+| [architecture.md](architecture.md) | **Codebase structure.** Module layout, the `CDPDriver` orchestration/interception hub + extracted collaborators (`backend_client`, `cdp_transport`, `chatgpt_dom`, `completion_detector`), data flow. |
+| [adr-0001-automation-backend.md](adr-0001-automation-backend.md) | **Decision record.** Why the automation backend stays on CDP (drives a real Chrome) and defers a Chrome-extension approach. |
+| [ROADMAP.md](ROADMAP.md) | **Project plan & history.** Phases 1–6, what landed, follow-ups, and the explicit deferral of Group C lifecycle extraction. |
+
+---
+
+## Reverse-engineering & internals
+
+These capture ChatGPT's web internals **as observed at a point in time**.
+ChatGPT changes its DOM/API frequently — treat them as a starting map, not a
+contract. The `doctor` command (`chatgpt-web2api doctor`) is the live source of
+truth for current selector/endpoint health.
+
+| Doc | Purpose |
+|-----|---------|
+| [protocol-reference.md](protocol-reference.md) | **ChatGPT web API surface.** Autonomously captured backend-api endpoints, auth, request/response shapes. |
+| [reverse-engineering-notes.md](reverse-engineering-notes.md) | **DOM & API findings.** Composer selectors, completion signals, anti-bot notes from the Phase-2 / composer-redesign work. |
+| [comprehensive-discovery-plan.md](comprehensive-discovery-plan.md) | **Capture methodology.** Plan for a single structured capture of the full ChatGPT feature/model/project surface. |
+| [knowledge-gaps.md](knowledge-gaps.md) | **Open unknowns.** What has been captured vs. what still needs probing. |
+| [phase1-results.md](phase1-results.md) | **Historical capture.** Phase-1 protocol discovery results (Jun 2026). |
+
+---
+
+## ZCode-internal planning (not operator docs)
+
+Under `docs/superpowers/` are planning artifacts (specs, plans) from ZCode
+sessions. They are working notes, not user-facing documentation — not linked
+individually here.
+
+---
+
+## Quick reference
+
+```bash
+# Start / reconcile (the one command):
+chatgpt-web2api ensure --rest-port 8080 --mcp-sse-port 8090 --cdp-port 9222
+
+# Health:
+curl -s http://localhost:8080/health
+
+# Do NOT use (no __main__ block):
+#   python -m chatgpt_web2api.ensure
+```
+
+See [runbook.md](runbook.md) §1 (startup checklist) and §8 (post-deploy
+validation) for the full operational sequence, including the exact-output
+`"Reply with exactly: ok"` sanity send.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -447,6 +447,13 @@ collection, and post-deploy validation (incl. the exact-output `"Reply with
 exactly: ok"` sanity send). Linked from `docs/deployment.md` (Option 5). All
 field names/state values/thresholds verified against source.
 
+✅ **PR3 (#30) — Documentation index.** Added `docs/INDEX.md`: a "which doc
+should I read?" routing table plus grouped listings (operating guides,
+architecture/decisions, reverse-engineering/internals) with one-line purposes
+for every doc in `docs/`. Linked from `README.md` (Documentation section
+refreshed) and `docs/deployment.md` (top pointer). Makes the Phase 6 ops docs
+(os-supervision, runbook) discoverable without adding operational surface.
+
 Docs only — no code:
 
 ```text

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,8 @@
 # ChatGPT-Web2API — Deployment Guide
 
+> Looking for a different doc? See the **[documentation index](INDEX.md)** for a
+> "which doc should I read?" routing table.
+
 Three ways to share this with others, depending on the audience.
 
 ---


### PR DESCRIPTION
## Summary

Docs-only PR. Adds a documentation index so the Phase 6 ops docs (and the rest of `docs/`) are discoverable. **No code changes.**

## What it adds

**New: `docs/INDEX.md`** — a navigation hub:
- **"Which doc should I read?"** routing table mapping operator goals → starting doc (first-time local use, Docker, always-on supervision, incident response, API calls, architecture, reverse-engineering).
- **Grouped listings** with a one-line purpose for every doc in `docs/`:
  - Operating guides: deployment, os-supervision, runbook, api-reference
  - Architecture & decisions: architecture, adr-0001, ROADMAP
  - Reverse-engineering & internals: protocol-reference, reverse-engineering-notes, comprehensive-discovery-plan, knowledge-gaps, phase1-results
- Note that `docs/superpowers/` planning artifacts are ZCode-internal, not linked.
- Quick-reference command block (ensure / health / the `-m` caveat).

## Links in
- **`README.md`** — Documentation section refreshed to lead with the index and list the 8 key docs. The old list was stale (4 items, missing runbook / os-supervision / architecture / api-reference / roadmap).
- **`docs/deployment.md`** — top pointer to the index (deployment is the most-trafficked doc; readers landing there now find the hub).
- **`docs/ROADMAP.md`** — Phase 6 PR3 recorded.

## Why this PR
Makes the Phase 6 work (#28 os-supervision, #29 runbook) discoverable without adding operational surface area. The runbook and supervision guide are only useful if operators can find them.

## Verification
- [x] docs only — no `.py` changes
- [x] all 16 link targets verified to resolve (every `docs/*.md`, README, CONTRIBUTING, CHANGELOG)
- [x] one-line purposes match each doc's actual content (read from headers, not guessed)
- [x] conservative scope — no code, no new operational surface
- [ ] CI green on head

Per the review-gate note: docs-only PRs need CI green + mergeable; required-review gate does not apply.