### PR TITLE
fix: accept ISO update_time and null gizmo_id in MCP list_conversations

### DIFF
--- a/src/chatgpt_web2api/mcp_server.py
+++ b/src/chatgpt_web2api/mcp_server.py
@@ -408,9 +408,18 @@ CONVERSATION_ITEM = {
     "properties": {
         "id": {"type": "string", "description": "Conversation UUID"},
         "title": {"type": "string"},
-        "update_time": {"type": "number", "description": "Unix timestamp"},
+        # ChatGPT's /backend-api/conversations emits update_time as an ISO-8601
+        # string (e.g. "2026-06-26T15:38:05.162163Z"); some fixtures/older
+        # payloads use epoch seconds. Accept both plus null/missing so MCP
+        # structured-output validation does not reject real backend data.
+        "update_time": {
+            "type": ["number", "string", "null"],
+            "description": "Backend update timestamp; may be epoch seconds or ISO-8601 string",
+        },
         "gizmo_id": {
-            "type": "string",
+            # Handler emits None for conversations with no project; accept null
+            # alongside the string id so MCP output validation matches reality.
+            "type": ["string", "null"],
             "description": "Project ID if conversation belongs to a project, null otherwise",
         },
     },

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -135,6 +135,36 @@ async def test_list_conversations(mock_driver):
     assert result["conversations"][0]["id"] == "conv-1"
 
 
+def test_list_conversations_output_schema_accepts_iso_update_time():
+    """list_conversations outputSchema must accept ISO-8601 update_time.
+
+    Regression guard: ChatGPT's /backend-api/conversations emits update_time
+    as an ISO-8601 string (e.g. "2026-06-26T15:38:05.162163Z"), but the schema
+    previously declared it as "number", so every real call failed MCP
+    structured-output validation. The schema must accept number, string, and
+    null so neither real backend data nor fixtures break validation.
+    """
+    import jsonschema
+
+    from chatgpt_web2api.mcp_server import LIST_CONVERSATIONS_OUTPUT
+
+    base = {
+        "conversations": [
+            {"id": "conv-1", "title": "Test Chat", "gizmo_id": None},
+        ]
+    }
+    # Each of these update_time shapes must validate against the schema.
+    for update_time in (
+        "2026-06-26T15:38:05.162163Z",  # ISO-8601 (real ChatGPT data)
+        1700000000,                       # epoch seconds (legacy/fixture)
+        None,                             # missing/null
+    ):
+        payload = json.loads(json.dumps(base))
+        payload["conversations"][0]["update_time"] = update_time
+        # Must not raise — this is the exact validation MCP runs on tool output.
+        jsonschema.validate(payload, LIST_CONVERSATIONS_OUTPUT)
+
+
 # ── do_get_conversation ──────────────────────────────────────
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes two MCP output-schema mismatches in the `list_conversations` tool that caused structured-output validation to fail on **real ChatGPT backend data**. Found via live agent testing (the tool hard-failed with `'2026-06-26T15:38:05.162163Z' is not of type 'number'`).

## Root cause
The `CONVERSATION_ITEM` outputSchema in `mcp_server.py` declared two fields with types that don't match what the handler actually emits against real ChatGPT data:

| Field | Schema said | Handler emits (real data) | Result |
|-------|-------------|---------------------------|--------|
| `update_time` | `number` | ISO-8601 **string** (e.g. `"2026-06-26T15:38:05.162163Z"`) | ❌ validation fails |
| `gizmo_id` | `string` | `null` for non-project conversations (the common case) | ❌ validation fails |

The handler (`do_list_conversations`, `mcp_server.py:854-855`) passes both through verbatim from `/backend-api/conversations`. The bug was masked because the existing test fixture (`test_business.py:46`) mocked `update_time` as a number — real data was never exercised.

## Fix — widen the schema, not the data
`list_conversations` is a discovery/listing tool. Preserving the backend shape is lower risk than coercing time formats (timezone/parsing edge cases) and keeps the existing numeric-timestamp fixture valid:

```python
"update_time": {"type": ["number", "string", "null"], ...}   # was: number
"gizmo_id":    {"type": ["string", "null"], ...}              # was: string
```

No handler/data-path change.

## Tests
New regression test `test_list_conversations_output_schema_accepts_iso_update_time` validates ISO string, epoch number, and null `update_time` shapes against `LIST_CONVERSATIONS_OUTPUT` via `jsonschema` (the exact validation MCP runs on tool output). Also exercises null `gizmo_id`. 472 passed (was 471).

## Verification
- [x] `ruff check src tests` — clean
- [x] `pytest -q` — 472 passed
- [x] regression test reproduces the original failure on the old schema, passes on the new
- [ ] CI green on head
- [ ] post-merge live check: `list_conversations` returns data instead of a validation error

## Out of scope
- `list_memories created_at=""` — lower priority (empty string is schema-compatible, no validation failure). Track as follow-up if memory timestamps are needed.
- `chat_with_gpt` — legitimately untestable without an account-owned Custom GPT; not a bug.

## Note on the second field
The agent report flagged only `update_time`. My regression test surfaced `gizmo_id` as a second latent failure of the same class (string schema vs null emission) — fixing both in one PR since they're the same root cause and the test exercises both. Scope is still 2 schema lines + 1 test.

This is a **code-touching PR** → per the standing rule, it needs a GitHub approving review before merge (the required-review gate applies), and I'll hold for explicit re-review after any post-review push.