### PR TITLE
feat: parallel multi-tab on one Chrome (parallel_tabs, default-off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,12 @@
 # W2A_HOST       - API server host (default: 127.0.0.1)
 # W2A_HEADLESS   - Run Chrome headless: true/false (default: false)
 # W2A_LOG_LEVEL  - Logging level: DEBUG, INFO, WARNING, ERROR (default: INFO)
+# W2A_TAB_MODE   - Tab isolation: "owned" (default, dedicated tab per process)
+#                  or "adopt" (reuse an existing chatgpt.com tab)
+# W2A_PARALLEL_TABS - Parallel multi-tab mode: true/false (default: false).
+#                  When true, requires tab_mode=owned; each bridge process
+#                  drives its own tab with per-target locking. See
+#                  docs/deployment.md "Parallel mode (one Chrome, many tabs)".
 #
 # MCP tool access gates (see README "MCP Tool Access Control"):
 # W2A_ENABLE_WRITE      - Expose mutating tools (create_project, update_project_instructions,

--- a/README.md
+++ b/README.md
@@ -377,6 +377,8 @@ chat_with_gpt(gpt_id="g-hkJGhxxx", message="Analyze this data")
   "headless": false,
   "default_model": "auto",
   "default_project_id": null,
+  "tab_mode": "owned",
+  "parallel_tabs": false,
   "api_keys": [],
   "request_timeout": 120
 }
@@ -495,7 +497,7 @@ Key docs:
 - **Single browser session** — one Chrome profile = one ChatGPT account (scale with nginx round-robin)
 - **No headless** — headless Chrome triggers ChatGPT's bot detection; use VNC on servers
 - **Cookie expiry** — auth cookies expire ~2 weeks; re-login needed
-- **Serial requests** — one chat at a time through the browser (concurrent reads are fine)
+- **Serial requests** — one chat at a time through the browser *by default* (concurrent reads are fine). For per-tab parallelism on one shared Chrome, set `parallel_tabs: true` (requires `tab_mode: "owned"`); see [docs/deployment.md](docs/deployment.md) → "Parallel mode (one Chrome, many tabs)".
 - **Memory writes** — ChatGPT's `/backend-api/memories` is read-only; creating memories works via chat interface
 - **No image input** — text only (CDP file upload not yet implemented)
 
@@ -503,7 +505,7 @@ Key docs:
 
 - [ ] Image/file upload to conversations via CDP drag-and-drop
 - [ ] Headless mode with anti-detection patches
-- [ ] Concurrent chat pooling across multiple Chrome instances
+- [ ] Concurrent chat pooling across multiple Chrome instances (per-tab parallelism on one Chrome landed via `parallel_tabs`; the cross-instance pool/router is still future work)
 - [ ] Web search mode (trigger ChatGPT's built-in search)
 - [ ] DALL-E image generation via ChatGPT
 - [ ] Canvas/code execution support

--- a/config.example.json
+++ b/config.example.json
@@ -7,6 +7,8 @@
   "headless": false,
   "default_model": "auto",
   "default_project_id": null,
+  "tab_mode": "owned",
+  "parallel_tabs": false,
   "api_keys": [],
   "request_timeout": 120,
   "log_level": "INFO",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,7 +31,7 @@ deployment.
 
 | Doc | Purpose |
 |-----|---------|
-| [deployment.md](deployment.md) | **Installing & sharing.** pip / Docker / cookie-export / remote-deploy options, plus cross-links to supervision and the runbook. |
+| [deployment.md](deployment.md) | **Installing & sharing.** pip / Docker / cookie-export / remote-deploy options, multiple-instance scaling, `parallel_tabs` (one Chrome, many tabs), plus cross-links to supervision and the runbook. |
 | [os-supervision.md](os-supervision.md) | **Always-on supervision.** systemd (Linux), launchd (macOS), Task Scheduler + NSSM (Windows); `ensure`-on-a-timer and REST+MCP split-service styles. |
 | [runbook.md](runbook.md) | **Operating a running deployment.** Startup checklist, `/health` interpretation, failure modes, breaker states, auth recovery, safe restart, post-deploy validation, logs. Source-cited. |
 | [api-reference.md](api-reference.md) | **Calling the API.** OpenAI-compatible REST endpoints and the MCP server surface (tools, transports). |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -482,7 +482,16 @@ always-on / server users → use OS supervision (this phase)
 4. non-rate-limit breaker policy                           ✅ (PR1 #18 / PR2 #19 / PR3 #20)
 5. split cdp_driver.py                                     ✅ (#22–#26; complete 2026-06-27)
 6. optional OS-supervision docs                            (last, docs-only)
+7. parallel multi-tab on one Chrome                        ✅ (PR1–5; per-target locks +
+   _owns_chrome lifecycle + MutationLock/resolver + parallel_tabs bundle + docs)
 ```
+
+The parallel-tabs phase (7) shipped as five stacked PRs: `CrossProcessLock`
+`lock_key` generalization → `_owns_chrome` lifecycle ownership → `MutationLock`
++ resolver (inert) → `parallel_tabs` config + enforcement + wiring → docs. The
+safety invariant — the `parallel_tabs` bundle becomes usable in the same PR
+where fail-closed owned-tab enforcement lands — held across the sequence. The
+cross-instance pool/router (single endpoint) remains future work.
 
 Known follow-ups (A–E, listed under Phase 4) slot in around Phase 5 as small
 standalone PRs — do not bundle them into the refactor. The recommended

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -142,7 +142,7 @@ resp = client.chat.completions.create(
 )
 ```
 
-**Important**: Only one request at a time. The browser is single-threaded. For team use, queue requests or run multiple instances on different ports.
+**Important**: One mutating request at a time *per tab* by default. The browser is single-threaded per page. For team use, queue requests, run multiple instances on different ports, or enable `parallel_tabs` (see [Parallel mode](#parallel-mode-one-chrome-many-tabs) below) for per-tab concurrency on one shared Chrome.
 
 ---
 
@@ -244,6 +244,51 @@ server {
     }
 }
 ```
+
+### Parallel mode (one Chrome, many tabs)
+
+`parallel_tabs: true` (or `W2A_PARALLEL_TABS=1`) lets several bridge processes
+share **one** Chrome instance, each driving its own owned tab in parallel — no
+proxy, no second browser profile. Per-target locking serializes same-tab
+mutations while different tabs run concurrently. Requires `tab_mode: "owned"`
+(enforced at load; the default).
+
+```bash
+# Process A — its own REST port, own tab on the shared Chrome (cdp 9222)
+W2A_PARALLEL_TABS=1 chatgpt-web2api --port 8081 --cdp-port 9222
+
+# Process B — different REST port, different tab on the SAME Chrome
+W2A_PARALLEL_TABS=1 chatgpt-web2api --port 8082 --cdp-port 9222
+```
+
+**Requirements and caveats:**
+- `parallel_tabs: true` requires `tab_mode: "owned"` (enforced at load). Each
+  process drives exactly one owned tab; mutating operations serialize per owned
+  target, not globally per CDP port. This is **not** an in-process tab pool or
+  request router — that remains future work.
+- Each process still needs its **own local REST/MCP port** (`--port`). There is
+  no single-endpoint router yet.
+- **One ChatGPT account is shared** across all tabs (one Chrome profile).
+  Parallel mode increases browser-tab parallelism, **not** account quota — all
+  workers share one session and may hit account-level rate limits; rate-limit
+  handling stays reactive (backoff/retry).
+- **Unique instance identity per process.** REST derives it from `rest:{port}`
+  automatically. MCP derives it from `mcp:sse:{host}:{port}` (SSE) or
+  `mcp:stdio:{pid}` (stdio) when `parallel_tabs=true`. The stdio PID identity
+  is unique per run but **not stable across restart** (a new PID can't reclaim
+  the prior tab); set `W2A_INSTANCE_ID` to a stable, unique-per-worker value if
+  you need restart-reclaim. **Do not reuse the same `W2A_INSTANCE_ID` across
+  live workers** on the same Chrome — that makes them collide on one tab.
+- **Fail-closed, not fallback.** If a process can't obtain (or loses mid-flight)
+  an owned tab, the operation fails retryably (REST 503 `code=owned_tab_required`
+  / MCP `isError`) rather than silently sharing a tab. Mixing per-target and
+  port-wide locks would reintroduce split-brain. Other retryable 503/`isError`
+  codes (`lock_timeout`, `circuit_open`) keep their existing semantics.
+
+> **Rollout warning:** do not mix old (port-lock-only) workers and new
+> (`parallel_tabs=true`) workers on the **same CDP port** during a rolling
+> upgrade — their lock files don't exclude each other. Finish the rollout on a
+> port before enabling parallel mode on it.
 
 ---
 

--- a/src/chatgpt_web2api/api_server.py
+++ b/src/chatgpt_web2api/api_server.py
@@ -26,7 +26,8 @@ from .cdp_driver import (
     is_rate_limited_text,
 )
 from .config import Config
-from .cross_process_lock import CrossProcessLock, LockAcquisitionError
+from .cross_process_lock import LockAcquisitionError
+from .lock_resolver import MutationLock, OwnedTabRequiredError, resolve_mutation_lock
 from .resilience import retry_on_rate_limit
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ class APIServer:
         self._config = config
         self._driver = driver
         self._cdp_port = config.chrome.cdp_port
+        self._parallel_tabs = config.chatgpt.parallel_tabs
         self._request_count = 0
         # Health telemetry (event-derived, not polled). These are the only
         # fields that make sense to cache: they mark WHEN something happened,
@@ -326,7 +328,28 @@ class APIServer:
             # (the user may have logged back in).
             await self._check_circuit_or_recover()
 
-            async with CrossProcessLock(cdp_port=self._cdp_port):
+            # PR4/5: per-target lock in parallel mode (port-wide otherwise).
+            # Resolver raises OwnedTabRequiredError (→ 503) if parallel mode
+            # has no owned target rather than silently degrading to the port
+            # lock (split-brain guard). When parallel mode is OFF, skip the
+            # resolver entirely and use the cached port — preserves the exact
+            # legacy path (the resolver would read driver.port, which is the
+            # same value but needlessly couples the legacy path to the driver).
+            if self._parallel_tabs:
+                _port, _key = resolve_mutation_lock(self._driver, True)
+            else:
+                _port, _key = self._cdp_port, None
+            async with MutationLock(_port, _key):
+                # Drift guard (parallel mode only): if the owned target changed
+                # while we waited for the lock, the key we hold no longer names
+                # the active tab. Fail retryably instead of mutating under a
+                # stale key.
+                if self._parallel_tabs:
+                    _, _current_key = resolve_mutation_lock(self._driver, True)
+                    if _current_key != _key:
+                        raise OwnedTabRequiredError(
+                            "owned target changed while waiting for mutation lock"
+                        )
                 # Second circuit-open check, now that we hold the lock. A
                 # concurrent request may have tripped a breaker while we were
                 # waiting. Without this, we'd drive Chrome despite the process
@@ -474,6 +497,18 @@ class APIServer:
                         "type": "server_error",
                         "param": None,
                         "code": "circuit_open",
+                    }
+                },
+                status=503,
+            )
+        if isinstance(exc, OwnedTabRequiredError):
+            return web.json_response(
+                {
+                    "error": {
+                        "message": f"{exc}. Retry later.",
+                        "type": "server_error",
+                        "param": None,
+                        "code": "owned_tab_required",
                     }
                 },
                 status=503,

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 
 from .breakers import BreakerKind, BreakerRegistry
 from .diagnostics import diagnose
+from .lock_resolver import OwnedTabRequiredError
 
 try:
     import websockets
@@ -250,8 +251,14 @@ class CDPDriver:
         tab_mode: str = "owned",
         instance_id: str | None = None,
         breakers: BreakerRegistry | None = None,
+        *,
+        parallel_tabs: bool = False,
     ) -> None:
         self.port = cdp_port
+        # PR4/5: when True, owned-tab creation is mandatory (no shared-tab
+        # fallback) and the resolver grants per-target locks. Config validates
+        # tab_mode=owned when this is True; here we just store the flag.
+        self._parallel_tabs = parallel_tabs
         # Tab isolation strategy: "owned" creates a dedicated chatgpt.com tab
         # per driver (multi-session safe — two drivers get two DOMs). "adopt"
         # reuses an existing chatgpt.com tab (single-process compat). The
@@ -409,7 +416,19 @@ class CDPDriver:
                         self._tab_registry.record(self._target_id)
                     except Exception as e:
                         logger.debug("Tab registry record failed: %s", e)
+            except OwnedTabRequiredError:
+                # Never swallow the parallel-mode fail-closed signal — it must
+                # propagate as REST 503 / MCP isError, not become a login wait.
+                raise
             except Exception as e:
+                if self._parallel_tabs:
+                    # Parallel mode: refuse the shared-tab fallback. A fallback
+                    # tab cannot be per-target locked, so silently adopting one
+                    # would reintroduce the split-brain the bundle eliminates.
+                    raise OwnedTabRequiredError(
+                        f"Owned-tab creation failed in parallel mode; refusing "
+                        f"shared-tab fallback: {e}"
+                    ) from e
                 logger.warning("Tab isolation failed (%s) — falling back to shared tab", e)
                 self._target_id = None
                 self._owns_target = False
@@ -552,6 +571,9 @@ class CDPDriver:
             self._ws = None
         # Clear stale state (#18) — the page we reconnect to may be different
         self._current_conv_id = None
+        # PR4: capture the pre-reconnect target so we can detect a target change
+        # (drift) after a successful reconnect in parallel mode.
+        _pre_reconnect_target_id = self._target_id
         self._current_model = None
         self._pending.clear()
 
@@ -570,8 +592,26 @@ class CDPDriver:
                     ws_url = self._adopt_existing_chatgpt_tab()
                 if not ws_url:
                     logger.info("No reusable tab — creating new one")
-                    ws_url = await self._create_owned_tab()
+                    try:
+                        ws_url = await self._create_owned_tab()
+                    except Exception as create_err:
+                        if self._parallel_tabs:
+                            # Ownership-invariant violation: parallel mode
+                            # cannot fall back to a shared tab. Raise inside
+                            # the try so the OwnedTabRequiredError escape
+                            # (not the broad retry) handles it.
+                            raise OwnedTabRequiredError(
+                                f"Reconnect owned-tab creation failed in "
+                                f"parallel mode; refusing fallback: {create_err}"
+                            ) from create_err
+                        raise
                 if not ws_url:
+                    if self._parallel_tabs:
+                        # Parallel mode: no shared-tab fallback (split-brain guard).
+                        raise OwnedTabRequiredError(
+                            "Reconnect could not obtain an owned tab; refusing "
+                            "shared-tab fallback in parallel mode"
+                        )
                     ws_url = await self._find_page_ws()
                 self._ws = await websockets.connect(
                     ws_url,
@@ -590,8 +630,19 @@ class CDPDriver:
                 # reopens the socket but can't auth isn't a clean recovery.
                 if self._breakers:
                     self._breakers.record_success(BreakerKind.CDP_RECONNECT)
+                # PR4 drift guard: raise if the owned target changed during
+                # reconnect (parallel mode only). See _assert_reconnect_target_stable.
+                self._assert_reconnect_target_stable(_pre_reconnect_target_id)
                 return
+            except OwnedTabRequiredError:
+                # Never let the parallel-mode fail-closed signal be swallowed by
+                # the reconnect retry loop / CDPReconnectError wrapping below.
+                raise
             except Exception as e:
+                # Transient WS/auth/CDP errors still retry (parallel mode does
+                # NOT change retry policy for same-target reconnect failures —
+                # only ownership-invariant violations raise OwnedTabRequiredError
+                # inside the try, above).
                 logger.warning("Reconnect attempt %d failed: %s", attempt, e)
                 if attempt < 3:
                     await asyncio.sleep(delay)
@@ -1201,6 +1252,11 @@ class CDPDriver:
         5. Poll DOM for streaming text
         6. Fetch final text from conversation API
         """
+        # PR4 belt-and-suspenders: refuse to mutate the DOM in parallel mode if
+        # the driver lost its owned tab. The primary gate is the resolver/drift
+        # guard at the REST/MCP lock site; this catches any driver-level path
+        # that reaches send_and_stream without going through the lock.
+        self._assert_owned_tab_required()
         # Count existing assistants BEFORE sending
         try:
             initial_raw = await self._js_strict(
@@ -1580,3 +1636,40 @@ class CDPDriver:
         non-empty ``_target_id``.
         """
         return self.tab_mode == "owned" and self._owns_target and bool(self._target_id)
+
+    def _assert_owned_tab_required(self) -> None:
+        """Fail-closed owned-tab enforcement for parallel mode.
+
+        Raises ``OwnedTabRequiredError`` if ``parallel_tabs`` is on but the
+        driver has no owned target. Called at the top of ``send_and_stream``
+        as belt-and-suspenders (the resolver/drift guard at the lock site is
+        the primary gate). Surfaces as REST 503 / MCP isError=True.
+        """
+        if self._parallel_tabs and not self.has_owned_target:
+            raise OwnedTabRequiredError(
+                "parallel_tabs=true requires an owned tab target, but the "
+                f"driver has none (tab_mode={self.tab_mode!r}, "
+                f"owns_target={self._owns_target}, "
+                f"target_id={self._target_id!r})"
+            )
+
+    def _assert_reconnect_target_stable(self, pre_target_id: str | None) -> None:
+        """Reconnect drift guard (PR4): raise if the owned target changed.
+
+        Called after a successful reconnect. In parallel mode, a reconnect that
+        ends on a DIFFERENT target than it started means any in-flight mutation
+        holding the old target's lock no longer names the active tab. Fail
+        retryably so the caller re-resolves and re-locks. Factored as a method
+        so the guard is unit-testable without driving the full WS chain.
+        """
+        if (
+            self._parallel_tabs
+            and pre_target_id is not None
+            and self._target_id is not None
+            and self._target_id != pre_target_id
+        ):
+            raise OwnedTabRequiredError(
+                f"Owned target changed during reconnect "
+                f"({pre_target_id} -> {self._target_id}); retry the mutation "
+                f"so it re-resolves the lock key"
+            )

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -1556,3 +1556,27 @@ class CDPDriver:
     @property
     def is_connected(self) -> bool:
         return self._ws is not None and self._ws.state.name == "OPEN"
+
+    # PR3/5: read-only owned-target state for the lock resolver + observability.
+    # Backs ``has_owned_target``, which the resolver uses to decide per-target
+    # vs port-wide locking in parallel mode. Mirrors the close() guard at
+    # :1535 — "a driver that adopted a tab never closes a tab it didn't open."
+    @property
+    def target_id(self) -> str | None:
+        """The owned tab's CDP targetId, or None if none owned/adopted."""
+        return self._target_id
+
+    @property
+    def owns_target(self) -> bool:
+        """True iff this driver created its target (owned mode), not adopted."""
+        return self._owns_target
+
+    @property
+    def has_owned_target(self) -> bool:
+        """True iff the driver holds a dedicated owned tab target.
+
+        The condition the parallel-tabs lock resolver checks before granting a
+        per-target lock: ``tab_mode == "owned"`` AND ``_owns_target`` AND a
+        non-empty ``_target_id``.
+        """
+        return self.tab_mode == "owned" and self._owns_target and bool(self._target_id)

--- a/src/chatgpt_web2api/chrome.py
+++ b/src/chatgpt_web2api/chrome.py
@@ -21,8 +21,13 @@ from pathlib import Path
 
 from .breakers import BreakerKind, BreakerRegistry
 from .config import Config
+from .cross_process_lock import CrossProcessLock, chrome_launch_lock_key
 
 logger = logging.getLogger(__name__)
+
+# Health-monitor tick interval (seconds). Module-level so tests/operators can
+# shorten it; the monitor reads this attribute each iteration.
+MONITOR_INTERVAL_S = 30
 
 
 class ChromeProcess:
@@ -41,47 +46,150 @@ class ChromeProcess:
         # restart would defeat the 3-in-300s policy; recovery is cooldown/half-
         # open only.
         self._breakers = breakers
+        # PR2/5: lifecycle ownership. True only for the process that launched
+        # Chrome. Mirrors the driver's ``_owns_target`` pattern (cdp_driver.py):
+        # a process that did not create the resource never restarts/kills it.
+        self._owns_chrome: bool = False
 
     # ── Public API ────────────────────────────────────────────
+    #
+    # Locking invariant (PR2/5):
+    #   - The chrome-launch election lock is acquired ONLY by ensure_running()
+    #     and restart().
+    #   - Mutation locks (target / port) are acquired ONLY by the REST/MCP
+    #     send/mutation paths.
+    #   - No code path may hold both. If that ever becomes necessary, the
+    #     lifecycle/send lock ordering must be redesigned first — nesting them
+    #     here is a deadlock flag, not a fix.
 
     async def ensure_running(self) -> None:
         """Make sure Chrome is running with CDP enabled.
 
-        1. Check if CDP port is already listening (existing Chrome)
-        2. If not, launch Chrome with our config
-        3. Wait for CDP to be ready
+        Determines lifecycle ownership (``_owns_chrome``):
+          - A live owned process + CDP alive → stay owner (re-call guard).
+          - A dead owned process → clear stale handle, fall through.
+          - CDP alive with no live local process → attach as non-owner.
+          - CDP down → win a cold-start election (hold the chrome-launch lock
+            through launch + readiness) and become owner.
+
+        On launch/readiness failure, ownership is dropped and the exception
+        re-raised (a fresh process may later elect).
         """
+        # Live local Chrome process: this object owns its lifecycle regardless
+        # of CDP state. Must be handled BEFORE the dead-process clear and the
+        # foreign-attach branches, otherwise a live process + CDP-down would
+        # fall through to the cold-start election and launch a competing Chrome
+        # (orphaning the live one) or demote ownership against a foreign Chrome.
+        if self._process is not None and self._process.poll() is None:
+            self._owns_chrome = True
+            if await self._cdp_alive():
+                self._healthy = True
+                return
+            # Process live but CDP wedged — restart it (takes the election
+            # lock, kills, records the crash-loop failure, relaunches, waits).
+            logger.warning(
+                "Owned Chrome process running but CDP not responding; restarting"
+            )
+            await self.restart()
+            return
+
+        # Clear a stale owned-process handle before deciding attach vs launch.
+        # Without this, a dead _process + foreign Chrome on the port would let
+        # us falsely claim ownership of someone else's Chrome.
+        if self._process is not None and self._process.poll() is not None:
+            logger.warning(
+                "Owned Chrome process exited with code %s", self._process.returncode
+            )
+            self._process = None
+            self._owns_chrome = False
+            self._healthy = False
+
+        # Attacher: another process's Chrome is already up.
         if await self._cdp_alive():
             logger.info("Found existing Chrome on CDP port %d", self._cfg.cdp_port)
+            self._owns_chrome = False
             self._healthy = True
             return
 
-        await self._launch()
-        await self._wait_for_cdp(timeout=30)
+        # Cold-start election: serialize the check→launch→ready transition.
+        # Holding the lock through _wait_for_cdp prevents a second starter from
+        # seeing a not-yet-ready Chrome as dead and double-launching.
+        async with CrossProcessLock(
+            cdp_port=self._cfg.cdp_port, lock_key=chrome_launch_lock_key()
+        ):
+            if await self._cdp_alive():
+                # Lost the election — another process launched while we waited.
+                self._owns_chrome = False
+                self._healthy = True
+                return
+            self._owns_chrome = True
+            try:
+                await self._launch()
+                await self._wait_for_cdp(timeout=30)
+            except Exception:
+                # Drop ownership so a fresh process can elect; clean up the
+                # half-started Chrome so the next starter isn't competing.
+                await self._kill()
+                self._owns_chrome = False
+                self._healthy = False
+                raise
 
     async def restart(self) -> None:
-        """Kill and relaunch Chrome."""
-        logger.warning("Restarting Chrome (restart #%d)", self._restart_count + 1)
-        await self._kill()
-        self._restart_count += 1
-        if self._breakers:
-            self._breakers.record_failure(BreakerKind.CHROME_CRASH_LOOP)
-        await self._launch()
-        await self._wait_for_cdp(timeout=30)
+        """Kill and relaunch Chrome. Owner-only; no-op for attachers.
+
+        Records a CHROME_CRASH_LOOP failure on every attempt (including ones
+        that fail during _wait_for_cdp), so the crash-loop breaker sees every
+        retry. On failure, cleans up the half-launched Chrome but KEEPS
+        ownership — the owner retries on the next monitor tick, and no other
+        running process can recover an orphaned Chrome at runtime.
+        """
+        if not self._owns_chrome:
+            logger.warning("Refusing Chrome restart: this process does not own it")
+            return
+        async with CrossProcessLock(
+            cdp_port=self._cfg.cdp_port, lock_key=chrome_launch_lock_key()
+        ):
+            logger.warning("Restarting Chrome (restart #%d)", self._restart_count + 1)
+            await self._kill()
+            self._restart_count += 1
+            if self._breakers:
+                self._breakers.record_failure(BreakerKind.CHROME_CRASH_LOOP)
+            try:
+                await self._launch()
+                await self._wait_for_cdp(timeout=30)
+            except Exception:
+                # _launch may have partially succeeded and set _process; the
+                # cleanup _kill reclaims it. Keep _owns_chrome=True so the
+                # owner (not a fresh elector) retries on the next tick.
+                await self._kill()
+                self._healthy = False
+                raise
 
     async def stop(self) -> None:
-        """Stop Chrome cleanly."""
+        """Stop Chrome cleanly. Non-owners cancel their monitor but do not kill
+        Chrome (they never owned it). Owners kill and relinquish ownership."""
         if self._monitor_task:
             self._monitor_task.cancel()
             try:
                 await self._monitor_task
             except asyncio.CancelledError:
                 pass
+            self._monitor_task = None
+        if not self._owns_chrome:
+            logger.debug("Chrome stop skipped: this process does not own it")
+            return
         await self._kill()
+        self._owns_chrome = False
 
     @property
     def healthy(self) -> bool:
         return self._healthy
+
+    @property
+    def owns_chrome(self) -> bool:
+        """True if this process launched (and therefore owns the lifecycle of)
+        the Chrome subprocess. Attachers are False."""
+        return self._owns_chrome
 
     @property
     def restart_count(self) -> int:
@@ -192,31 +300,51 @@ class ChromeProcess:
         raise TimeoutError(f"Chrome CDP did not respond within {timeout}s")
 
     async def start_monitor(self) -> None:
-        """Start background health monitor."""
+        """Start the background health monitor. Runs in ALL processes —
+        attachers observe health (so /health stays accurate); only the owner
+        ever restarts. See _monitor_loop for the ownership/breaker gating."""
+        if self._monitor_task and not self._monitor_task.done():
+            return
         self._monitor_task = asyncio.create_task(self._monitor_loop())
 
     async def _monitor_loop(self) -> None:
-        """Periodically check Chrome health."""
+        """Periodically observe Chrome health (all processes) and restart
+        (owner-only). Health is updated first in every branch so /health stays
+        truthful even when restart is intentionally suppressed."""
         while True:
             try:
-                await asyncio.sleep(30)
+                await asyncio.sleep(MONITOR_INTERVAL_S)
                 alive = await self._cdp_alive()
+                # Update _healthy FIRST — truthful health beats restart logic.
+                was_healthy = self._healthy
                 if alive != self._healthy:
                     self._healthy = alive
-                    if not alive:
-                        if self._cfg.restart_on_crash:
-                            logger.warning(
-                                "Chrome died — restarting (attempt #%d)...", self._restart_count + 1
-                            )
-                            try:
-                                await self.restart()
-                                logger.info("Chrome restarted successfully")
-                            except Exception as e:
-                                logger.error("Chrome restart failed: %s", e)
-                        else:
-                            logger.error("Chrome CDP stopped responding")
-                    else:
+                if alive:
+                    if not was_healthy:
                         logger.info("Chrome CDP recovered")
+                    continue
+                # CDP is down.
+                if not self._owns_chrome:
+                    logger.error("Chrome CDP stopped; not owner, not restarting")
+                    continue
+                if not self._cfg.restart_on_crash:
+                    logger.error("Chrome CDP stopped; restart_on_crash=false")
+                    continue
+                if self._breakers and self._breakers.is_open(
+                    BreakerKind.CHROME_CRASH_LOOP
+                ):
+                    logger.error(
+                        "Chrome crash-loop breaker open; suppressing restart"
+                    )
+                    continue
+                logger.warning(
+                    "Chrome died — restarting (attempt #%d)...", self._restart_count + 1
+                )
+                try:
+                    await self.restart()
+                    logger.info("Chrome restarted successfully")
+                except Exception as e:
+                    logger.error("Chrome restart failed: %s", e)
             except asyncio.CancelledError:
                 return
             except Exception as e:

--- a/src/chatgpt_web2api/config.py
+++ b/src/chatgpt_web2api/config.py
@@ -77,6 +77,11 @@ class ChatGPTConfig:
     # compatibility. Owned tabs are the safe default because adoption lets one
     # session navigate another's tab out from under it.
     tab_mode: str = "owned"
+    # Parallel multi-tab mode (PR4/5). When True, the bundle is enforced:
+    # tab_mode=owned (validated at load), per-target MutationLocks, and
+    # fail-closed owned-tab requirement (no shared-tab fallback). Default False
+    # reproduces the exact legacy single-tab-serialized behavior.
+    parallel_tabs: bool = False
 
 
 @dataclass
@@ -94,6 +99,21 @@ class EnsureConfig:
     degraded_poll_interval_s: float = 2.0
     degraded_poll_budget_s: float = 20.0
     breaker_cooldown_grace_s: float = 5.0
+
+
+def _as_bool(v: object) -> bool:
+    """Parse a config/env value as bool, robust to JSON bools and strings.
+
+    ``bool("false")`` is ``True`` in Python (non-empty string), so a naive
+    ``bool(c)`` misparses string config values. Accept JSON booleans directly
+    and the usual truthy strings (``true``/``1``/``yes``); everything else
+    (incl. ``"false"``, ``"0"``, ``"no"``) is False.
+    """
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return v.lower() in ("true", "1", "yes")
+    return bool(v)
 
 
 @dataclass
@@ -136,6 +156,16 @@ class Config:
             else:
                 log.debug("No default config at %s; using built-in defaults", default_path)
         cfg._apply_env()
+        # Validate AFTER both file + env overlays are applied — env can fix or
+        # break what the file set. This is the first real validation in config;
+        # keep it as a single explicit bundle check for the parallel-tabs safety
+        # invariant.
+        if cfg.chatgpt.parallel_tabs and cfg.chatgpt.tab_mode != "owned":
+            raise ValueError(
+                "parallel_tabs=true requires tab_mode=owned (got "
+                f"{cfg.chatgpt.tab_mode!r}); parallel mode needs per-target "
+                "owned tabs for correct locking"
+            )
         return cfg
 
     def _apply_dict(self, data: dict) -> None:
@@ -150,7 +180,7 @@ class Config:
             self.chrome.cdp_port = int(c)
         c = data.get("headless")
         if c is not None:
-            self.chrome.headless = bool(c)
+            self.chrome.headless = _as_bool(c)
         c = data.get("port")
         if c is not None:
             self.server.port = int(c)
@@ -169,6 +199,9 @@ class Config:
         c = data.get("tab_mode")
         if c in ("owned", "adopt"):
             self.chatgpt.tab_mode = c
+        c = data.get("parallel_tabs")
+        if c is not None:
+            self.chatgpt.parallel_tabs = _as_bool(c)
         c = data.get("request_timeout")
         if c is not None:
             self.server.request_timeout = int(c)
@@ -207,6 +240,8 @@ class Config:
         if v := _env("W2A_TAB_MODE"):
             if v in ("owned", "adopt"):
                 self.chatgpt.tab_mode = v
+        if v := _env("W2A_PARALLEL_TABS"):
+            self.chatgpt.parallel_tabs = v.lower() in ("true", "1", "yes")
         if v := _env("W2A_HEADLESS"):
             self.chrome.headless = v.lower() in ("true", "1", "yes")
         if v := _env("W2A_LOG_LEVEL"):
@@ -230,6 +265,7 @@ class Config:
             "default_model": self.chatgpt.default_model,
             "default_project_id": self.chatgpt.default_project_id,
             "tab_mode": self.chatgpt.tab_mode,
+            "parallel_tabs": self.chatgpt.parallel_tabs,
             "request_timeout": self.server.request_timeout,
             "log_level": self.log.level,
             "ensure_degraded_poll_interval_s": self.ensure.degraded_poll_interval_s,

--- a/src/chatgpt_web2api/cross_process_lock.py
+++ b/src/chatgpt_web2api/cross_process_lock.py
@@ -10,24 +10,40 @@ This module provides an async context manager wrapping ``portalocker`` (a
 cross-platform file-lock library) so all processes that share a Chrome
 instance serialize their mutating operations (sends, creates, deletes).
 
-The lock is keyed on the CDP port (``~/.chatgpt-web2api/cdp-{port}.lock``)
-so multiple Chrome instances on different ports get independent locks.
+The lock is keyed on the CDP port plus an optional ``lock_key`` suffix
+(``~/.chatgpt-web2api/cdp-{port}[-{key}].lock``) so multiple Chrome instances
+on different ports get independent locks, and so different lock *purposes*
+within one Chrome get independent locks too. The two purposes today:
+
+  - mutation locks: ``lock_key=None`` (legacy port-wide) or
+    ``lock_key="target-{targetId}"`` (per-tab, parallel mode)
+  - lifecycle election: ``lock_key="chrome-launch"`` (cold-start launch race)
 
 Usage::
 
     async with CrossProcessLock(cdp_port=9222):
-        # exclusive across all processes on this port
+        # exclusive across all processes on this port (legacy behavior)
         await driver.send_and_stream(...)
 
+    async with CrossProcessLock(cdp_port=9222, lock_key=target_lock_key(tid)):
+        # exclusive per-tab — other tabs on the same Chrome run in parallel
+
 Design notes:
-  - Acquire/release are offloaded to ``asyncio.to_thread`` so the event loop
-    is never blocked by the OS-level file lock.
+  - Acquire uses a **non-blocking poll loop** (``LOCK_EX | LOCK_NB`` +
+    ``await asyncio.sleep``), never a blocking ``to_thread`` call. The
+    previous implementation wrapped a blocking ``portalocker.lock(LOCK_EX)``
+    in ``asyncio.to_thread`` + ``asyncio.wait_for``; on timeout the worker
+    thread was not killed and could acquire the OS lock *after* the coroutine
+    had given up. The poll loop has deterministic cancellation semantics —
+    no leaked background thread can grab the lock post-abandonment.
   - A timeout on acquire (default 120s, matching the typical send timeout)
     prevents indefinite hangs when a prior holder crashed. On timeout, raises
     ``LockAcquisitionError`` which surfaces as a clean MCP/REST error.
   - ``portalocker.LOCK_SHARED`` is NOT used — this is an exclusive lock.
     Read-only operations run lock-free by design (concurrent reads are safe;
     only DOM-mutating operations need serialization).
+  - ``lock_key`` is validated against a safe charset to prevent path
+    traversal / separator injection in the lock filename.
 """
 
 from __future__ import annotations
@@ -35,6 +51,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 from pathlib import Path
 
 import portalocker
@@ -46,6 +63,18 @@ logger = logging.getLogger(__name__)
 # the operation itself would take.
 _DEFAULT_TIMEOUT = 120
 
+# Poll interval for the non-blocking acquire loop. Small enough that an
+# uncontended-after-contention lock is picked up quickly, large enough that
+# we don't busy-spin. Pure ``asyncio.sleep`` — yields the event loop, no
+# thread created.
+_POLL_INTERVAL = 0.1
+
+# Safe charset for a lock_key suffix. Chrome target IDs are hex-ish strings
+# and our own keys ("chrome-launch", "target-{id}") are ASCII; this rejects
+# path separators, whitespace, traversal sequences, and anything else that
+# could corrupt the lock filename.
+_SAFE_LOCK_KEY = re.compile(r"^[A-Za-z0-9_.=-]+$")
+
 
 class LockAcquisitionError(RuntimeError):
     """Raised when the cross-process lock can't be acquired within the timeout.
@@ -55,20 +84,64 @@ class LockAcquisitionError(RuntimeError):
     """
 
 
+def _validate_lock_key(lock_key: str | None) -> None:
+    """Reject a lock_key that could corrupt the lock filename.
+
+    ``None`` means "no suffix" (legacy port-wide lock) and is always valid.
+    Any non-None value must match the safe charset — no path separators,
+    whitespace, or ``..`` traversal.
+    """
+    if lock_key is None:
+        return
+    if not _SAFE_LOCK_KEY.fullmatch(lock_key):
+        raise ValueError(
+            f"Unsafe lock_key {lock_key!r}: must match {_SAFE_LOCK_KEY.pattern}"
+        )
+
+
+def target_lock_key(target_id: str) -> str:
+    """Build the ``lock_key`` suffix for a per-tab mutation lock.
+
+    Combined with the port in ``CrossProcessLock``, this yields a distinct
+    lockfile per owned tab (``cdp-{port}-target-{targetId}.lock``) so two
+    processes on different tabs of the same Chrome run in parallel while two
+    processes on the *same* tab still serialize.
+    """
+    return f"target-{target_id}"
+
+
+def chrome_launch_lock_key() -> str:
+    """Build the ``lock_key`` suffix for the cold-start launch-election lock.
+
+    A fixed key (``cdp-{port}-chrome-launch.lock``) distinct from every
+    mutation lock, so lifecycle transitions never contend with sends. Held
+    only around the ``check → launch → wait-for-cdp`` transition in
+    ``ensure_running``/``restart``.
+    """
+    return "chrome-launch"
+
+
 class CrossProcessLock:
     """Async context manager providing cross-process mutual exclusion.
 
-    Wraps ``portalocker`` with ``asyncio.to_thread`` so the event loop is
-    never blocked by the file-lock acquire/release.
+    Wraps ``portalocker`` with a non-blocking poll loop so the event loop is
+    never blocked by, and never leaks a thread for, the OS-level file lock.
+
+    ``lock_key`` optionally appends a suffix to the lock filename. ``None``
+    reproduces the legacy port-wide lock (``cdp-{port}.lock``) exactly; a
+    non-None value produces ``cdp-{port}-{key}.lock``.
     """
 
     def __init__(
         self,
         cdp_port: int = 9222,
         timeout: float = _DEFAULT_TIMEOUT,
+        lock_key: str | None = None,
     ) -> None:
+        _validate_lock_key(lock_key)
+        suffix = f"-{lock_key}" if lock_key else ""
         self._lockfile_path = str(
-            Path.home() / ".chatgpt-web2api" / f"cdp-{cdp_port}.lock"
+            Path.home() / ".chatgpt-web2api" / f"cdp-{cdp_port}{suffix}.lock"
         )
         self._timeout = timeout
         self._fh = None  # file handle, held while locked
@@ -77,55 +150,42 @@ class CrossProcessLock:
         # Ensure the directory exists
         os.makedirs(os.path.dirname(self._lockfile_path), exist_ok=True)
 
-        def _acquire():
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + self._timeout
+
+        # Non-blocking poll loop. Each attempt is a LOCK_EX | LOCK_NB try —
+        # instant return, no thread, no cancellation leak. On contention we
+        # sleep on the event loop and retry until the deadline.
+        while True:
             fh = open(self._lockfile_path, "a")
             try:
                 portalocker.lock(fh, portalocker.LOCK_EX | portalocker.LOCK_NB)
-                return fh
+                self._fh = fh  # acquired
+                return self
             except portalocker.LockException:
                 fh.close()
-                return None
 
-        # Try non-blocking first (fast path — uncontended lock)
-        self._fh = await asyncio.to_thread(_acquire)
-        if self._fh is not None:
-            return self
-
-        # Contended — poll with blocking acquire in a thread
-        deadline = asyncio.get_event_loop().time() + self._timeout
-
-        def _acquire_blocking():
-            fh = open(self._lockfile_path, "a")
-            portalocker.lock(fh, portalocker.LOCK_EX)
-            return fh
-
-        while self._fh is None:
-            remaining = deadline - asyncio.get_event_loop().time()
+            remaining = deadline - loop.time()
             if remaining <= 0:
                 raise LockAcquisitionError(
                     f"Could not acquire cross-process lock at "
                     f"{self._lockfile_path} within {self._timeout}s — "
                     f"another process is holding it."
                 )
-            try:
-                self._fh = await asyncio.wait_for(
-                    asyncio.to_thread(_acquire_blocking),
-                    timeout=remaining,
-                )
-            except (TimeoutError, portalocker.LockException):
-                continue
-
-        return self
+            await asyncio.sleep(min(_POLL_INTERVAL, remaining))
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         if self._fh is not None:
+            fh, self._fh = self._fh, None
+            # Release off-thread only if it could block; portalocker.unlock +
+            # close are fast on all platforms, but keep the off-thread shape
+            # to guarantee the event loop is never wedged by a slow release.
             def _release():
                 try:
-                    portalocker.unlock(self._fh)
+                    portalocker.unlock(fh)
                 except Exception:
                     pass
                 finally:
-                    self._fh.close()
+                    fh.close()
 
             await asyncio.to_thread(_release)
-            self._fh = None

--- a/src/chatgpt_web2api/lock_resolver.py
+++ b/src/chatgpt_web2api/lock_resolver.py
@@ -1,0 +1,155 @@
+"""Per-target mutation locking + lock-scope resolution (PR3/5).
+
+This module provides the machinery for parallel multi-tab traffic on one Chrome
+instance. It is **inert until PR4 wires it**: nothing here is called from the
+REST/MCP send paths yet. PR3 lands the pieces so PR4 can flip the switch in a
+single, reviewable change.
+
+Two concerns live here:
+
+1. **`MutationLock`** — composes a *process-local* ``asyncio.Lock`` with the
+   *cross-process* ``CrossProcessLock``. Acquire order is process-local first,
+   file lock second; release is the reverse. The process-local lock is required
+   (not YAGNI) because OS file locks do not serialize reentrant acquisition by
+   two coroutines in the *same* process, and the REST server can have multiple
+   concurrent coroutines on the same driver/target.
+
+2. **`resolve_mutation_lock`** — picks ``(cdp_port, lock_key)`` for a mutating
+   operation based on ``parallel_tabs`` mode and the driver's owned-target
+   state. In parallel mode it RAISES rather than falls back to the port lock,
+   because a port lock and a target lock are different files that do not
+   exclude each other — falling back would reintroduce the split-brain regime
+   the ``parallel_tabs`` bundle was designed to eliminate.
+
+Lock-nesting invariant (asserted by the design, enforced by call-site
+discipline in PR4): a ``MutationLock`` and a ``chrome-launch`` election lock
+are never held simultaneously. Lifecycle never sends; sends never touch
+lifecycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import TYPE_CHECKING
+
+from .cross_process_lock import CrossProcessLock, target_lock_key
+
+if TYPE_CHECKING:
+    from .cdp_driver import CDPDriver
+
+
+class OwnedTabRequiredError(RuntimeError):
+    """Raised when parallel mode requires an owned tab and none is available.
+
+    Parallel mode (``parallel_tabs=true``) requires each bridge process to
+    drive a dedicated, owned tab target so per-target locking can serialize
+    DOM mutation correctly. If the driver has no owned target (adopt/fallback
+    path, or owned-tab creation failed), this is raised rather than silently
+    degrading to the port-wide lock — a port lock and a target lock are
+    independent files that do not exclude each other, so mixing them would
+    reintroduce the split-brain the parallel bundle eliminates. Surfaces to
+    MCP as a CallToolResult(isError=True) and to REST as a 503 — the caller
+    should retry, not treat it as permanent.
+    """
+
+
+# ── Process-local lock registry ──────────────────────────────────────────
+#
+# Keyed by (cdp_port, lock_key) — the same identity the cross-process file
+# lock uses. Two coroutines in the SAME process on the same target serialize
+# here regardless of OS file-lock reentrance; two coroutines on DIFFERENT
+# targets get distinct asyncio.Lock objects and run in parallel. The guard is
+# a threading.Lock only to make registry initialization safe if multiple
+# threads ever construct locks concurrently; under the single-event-loop
+# runtime it is effectively uncontended.
+_PROC_LOCKS: dict[tuple[int, str | None], asyncio.Lock] = {}
+_PROC_LOCKS_GUARD = threading.Lock()
+
+
+def _proc_lock_for(cdp_port: int, lock_key: str | None) -> asyncio.Lock:
+    """Return the process-local asyncio.Lock for a given (port, key).
+
+    Lazily creates and caches. Binds to the running event loop on first
+    ``acquire()`` (Python 3.10+ ``asyncio.Lock`` binds lazily), which is safe
+    under the project's single-loop runtime. If a future change runs locks
+    across multiple event loops in one process, key by
+    ``(id(asyncio.get_running_loop()), cdp_port, lock_key)`` instead.
+    """
+    ident = (cdp_port, lock_key)
+    with _PROC_LOCKS_GUARD:
+        lock = _PROC_LOCKS.get(ident)
+        if lock is None:
+            lock = asyncio.Lock()
+            _PROC_LOCKS[ident] = lock
+        return lock
+
+
+class MutationLock:
+    """Async CM: process-local asyncio.Lock (first) + CrossProcessLock (second).
+
+    Contract::
+
+        same process + same target  → serialized by the asyncio.Lock
+        different process + same target → serialized by the file lock
+        different target → parallel (distinct asyncio.Lock + distinct file)
+
+    Acquire order is process-local first, file lock second. Release order is
+    the reverse (file first, process-local second). Never acquire in the
+    opposite order elsewhere — the chrome-launch election lock and a
+    MutationLock must never be held at the same time.
+    """
+
+    def __init__(self, cdp_port: int, lock_key: str | None = None) -> None:
+        self._proc_lock = _proc_lock_for(cdp_port, lock_key)
+        self._file_lock = CrossProcessLock(cdp_port=cdp_port, lock_key=lock_key)
+
+    async def __aenter__(self) -> MutationLock:
+        await self._proc_lock.acquire()
+        try:
+            await self._file_lock.__aenter__()
+        except BaseException:
+            # File-lock acquire failed OR the coroutine was cancelled while
+            # waiting (asyncio.CancelledError is a BaseException, not an
+            # Exception, since 3.8 — `except Exception` would miss it). Release
+            # the proc lock so another coroutine on this target isn't blocked.
+            self._proc_lock.release()
+            raise
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        # Release file first, then process-local — strict reverse of acquire.
+        try:
+            await self._file_lock.__aexit__(exc_type, exc, tb)
+        finally:
+            self._proc_lock.release()
+
+
+def resolve_mutation_lock(
+    driver: CDPDriver, parallel_tabs: bool
+) -> tuple[int, str | None]:
+    """Return ``(cdp_port, lock_key)`` for a DOM-mutating operation.
+
+    - ``parallel_tabs=False`` (default): always the legacy port-wide lock
+      (``lock_key=None`` → ``cdp-{port}.lock``). No behavior change.
+    - ``parallel_tabs=True`` + owned target: per-target lock
+      (``target-{targetId}`` → ``cdp-{port}-target-{id}.lock``).
+    - ``parallel_tabs=True`` + no owned target: **raise**, do NOT fall back to
+      the port lock. See ``OwnedTabRequiredError`` docstring for why.
+    """
+    port = driver.port
+    if not parallel_tabs:
+        return port, None
+
+    target_id = driver.target_id
+    if driver.has_owned_target and target_id is not None:
+        # target_lock_key builds the validated "target-{id}" suffix.
+        return port, target_lock_key(target_id)
+
+    raise OwnedTabRequiredError(
+        "parallel_tabs=true requires an owned tab target, but the driver has "
+        f"none (tab_mode={driver.tab_mode!r}, owns_target={driver.owns_target}). "
+        "Refusing to fall back to the port-wide lock — that would mix lock "
+        "files and reintroduce split-brain. Ensure tab_mode=owned and the tab "
+        "was created successfully."
+    )

--- a/src/chatgpt_web2api/mcp_server.py
+++ b/src/chatgpt_web2api/mcp_server.py
@@ -50,7 +50,12 @@ from .cdp_driver import (
     RateLimitError,
 )
 from .config import Config
-from .cross_process_lock import CrossProcessLock, LockAcquisitionError
+from .cross_process_lock import LockAcquisitionError
+from .lock_resolver import (
+    MutationLock,
+    OwnedTabRequiredError,
+    resolve_mutation_lock,
+)
 from .resilience import retry_on_rate_limit
 from .tab_registry import TabRegistry
 
@@ -676,6 +681,8 @@ _breakers: BreakerRegistry | None = None
 # section, keyed on the CDP port so all processes sharing a Chrome instance
 # serialize. None until run_mcp() sets it. Read-only tools run lock-free.
 _lock_cdp_port: int | None = None
+# PR4/5: parallel-tabs flag (mirrors _lock_cdp_port's lifecycle — set in run_mcp).
+_parallel_tabs: bool = False
 
 # Tools that mutate browser state — must hold the lock
 _MUTATING_TOOLS = frozenset(
@@ -1544,10 +1551,37 @@ def create_server() -> Server:
         # Serialize mutating tools through the cross-process lock
         try:
             if name in _MUTATING_TOOLS and _lock_cdp_port is not None:
-                async with CrossProcessLock(cdp_port=_lock_cdp_port):
+                # PR4/5: per-target MutationLock in parallel mode (port-wide
+                # otherwise). Resolver raises OwnedTabRequiredError (→ isError)
+                # if parallel mode has no owned target. When parallel mode is
+                # OFF, use the cached port directly (legacy path).
+                if _parallel_tabs:
+                    _port, _key = resolve_mutation_lock(_driver, True)
+                else:
+                    _port, _key = _lock_cdp_port, None
+                async with MutationLock(_port, _key):
+                    # Drift guard (parallel mode only).
+                    if _parallel_tabs:
+                        _, _current_key = resolve_mutation_lock(_driver, True)
+                        if _current_key != _key:
+                            raise OwnedTabRequiredError(
+                                "owned target changed while waiting for mutation lock"
+                            )
                     result = await _run()
             else:
                 result = await _run()
+        except OwnedTabRequiredError as e:
+            # Parallel-mode fail-closed: surface as retryable isError with a
+            # machine-readable marker, mirroring the rate-limit/circuit style.
+            return mcp_types.CallToolResult(
+                content=[
+                    mcp_types.TextContent(
+                        type="text",
+                        text=f"{e}. Retry later. (owned_tab_required)",
+                    )
+                ],
+                isError=True,
+            )
         except RateLimitError as e:
             # Persistent limit (transparent retries exhausted). Signal it as an
             # error result with a recognizable marker the agent can parse to
@@ -1887,12 +1921,38 @@ def create_server() -> Server:
 # ═══════════════════════════════════════════════════════════════
 
 
+def _mcp_server_identity(config: Config, transport: str, port: int) -> str:
+    """Derive the tab-registry ``server_identity`` for MCP (PR4/5).
+
+    Outside parallel mode this is the fixed ``"mcp"`` (legacy behavior). In
+    parallel mode it must be unique per concurrent MCP process so two processes
+    on the same CDP port don't collide on a tab-registry entry:
+
+      - SSE: ``mcp:sse:{host}:{port}`` — unique AND stable across restart
+        (host:port survives restart, so reclaim works). Mirrors REST's
+        ``rest:{port}`` model.
+      - stdio: ``mcp:stdio:{pid}`` — unique (one PID per process) but NOT stable
+        across restart, so restart-reclaim is sacrificed. For the typical
+        one-MCP-per-agent-session case, isolation beats reclaim; a leaked tab
+        on restart is preferable to two sessions corrupting a shared lease.
+
+    The result feeds ``TabRegistry.derive_instance_id``, which still honors
+    ``W2A_INSTANCE_ID`` as the highest-priority override.
+    """
+    if not config.chatgpt.parallel_tabs:
+        return "mcp"
+    if transport == "sse":
+        return f"mcp:sse:{config.server.host or '127.0.0.1'}:{port}"
+    return f"mcp:stdio:{os.getpid()}"
+
+
 async def run_mcp(config: Config, transport: str = "stdio", port: int = 8090) -> None:
     """Connect to Chrome and run the MCP server."""
-    global _driver, _config, _lock_cdp_port, _breakers
+    global _driver, _config, _lock_cdp_port, _breakers, _parallel_tabs
 
     _config = config
     _lock_cdp_port = config.chrome.cdp_port
+    _parallel_tabs = config.chatgpt.parallel_tabs
 
     # Phase 4 PR2: one MCP-local registry. Injected into MCP's own driver;
     # auth/composer/CDP failures record here. CHROME_CRASH_LOOP is never
@@ -1904,9 +1964,10 @@ async def run_mcp(config: Config, transport: str = "stdio", port: int = 8090) ->
         tab_mode=config.chatgpt.tab_mode,
         instance_id=TabRegistry.derive_instance_id(
             cdp_port=config.chrome.cdp_port,
-            server_identity="mcp",
+            server_identity=_mcp_server_identity(config, transport, port),
         ),
         breakers=_breakers,
+        parallel_tabs=config.chatgpt.parallel_tabs,
     )
     try:
         await _driver.connect()

--- a/src/chatgpt_web2api/service.py
+++ b/src/chatgpt_web2api/service.py
@@ -21,6 +21,7 @@ from .breakers import BreakerRegistry
 from .cdp_driver import CDPDriver
 from .chrome import ChromeProcess
 from .config import Config
+from .lock_resolver import OwnedTabRequiredError
 from .tab_registry import TabRegistry
 
 logger = logging.getLogger(__name__)
@@ -69,10 +70,14 @@ class Service:
                 server_identity=f"rest:{cfg.server.port}",
             ),
             breakers=self._breakers,
+            parallel_tabs=cfg.chatgpt.parallel_tabs,
         )
 
         try:
             await self._driver.connect()
+        except OwnedTabRequiredError:
+            # Parallel-mode fail-closed must propagate, not become a login wait.
+            raise
         except Exception as e:
             logger.info("Auth failed: %s — waiting for login", e)
             # Not logged in — wait for user to complete login

--- a/tests/test_breaker_failfast.py
+++ b/tests/test_breaker_failfast.py
@@ -185,6 +185,7 @@ async def test_rest_post_lock_check_catches_race(monkeypatch):
     server._last_project_id = None
     server._request_count = 0
     server._cdp_port = 9222
+    server._parallel_tabs = False  # PR4: mirror __init__'s cache for __new__ bypass
     server._config = srv.Config.load(None)
     server._last_error = None
     reg = BreakerRegistry()
@@ -229,7 +230,7 @@ async def test_rest_post_lock_check_catches_race(monkeypatch):
 
     import chatgpt_web2api.api_server as mod
 
-    monkeypatch.setattr(mod, "CrossProcessLock", _RacingLock)
+    monkeypatch.setattr(mod, "MutationLock", _RacingLock)
 
     request = MagicMock()
     request.json = AsyncMock(
@@ -266,6 +267,7 @@ async def test_rest_auth_recovery_probes_then_proceeds(monkeypatch):
     server._last_project_id = None
     server._request_count = 0
     server._cdp_port = 9222
+    server._parallel_tabs = False  # PR4: mirror __init__'s cache for __new__ bypass
     server._config = srv.Config.load(None)
     server._last_error = None
     server._last_successful_send_at = None
@@ -316,7 +318,7 @@ async def test_rest_auth_recovery_probes_then_proceeds(monkeypatch):
 
     import chatgpt_web2api.api_server as mod
 
-    monkeypatch.setattr(mod, "CrossProcessLock", _NullLock)
+    monkeypatch.setattr(mod, "MutationLock", _NullLock)
 
     request = MagicMock()
     request.json = AsyncMock(
@@ -347,6 +349,7 @@ async def test_rest_auth_recovery_fails_still_fail_fasts():
     server._last_project_id = None
     server._request_count = 0
     server._cdp_port = 9222
+    server._parallel_tabs = False  # PR4: mirror __init__'s cache for __new__ bypass
     server._config = srv.Config.load(None)
     server._last_error = None
     reg = BreakerRegistry()

--- a/tests/test_chrome_lifecycle.py
+++ b/tests/test_chrome_lifecycle.py
@@ -1,0 +1,473 @@
+"""Tests for PR2/5 Chrome lifecycle ownership (``_owns_chrome``).
+
+These are the first tests for ``ChromeProcess`` — the restart path and monitor
+loop were previously untested. We construct instances via the ``__new__`` bypass
+(matching ``test_cross_process_lock.py`` / ``test_breaker_failfast.py``) so no
+real Chrome is launched, and monkeypatch the private I/O methods
+(``_cdp_alive``/``_launch``/``_kill``/``_wait_for_cdp``) on the instance.
+
+The election lock (``CrossProcessLock`` with ``lock_key=chrome_launch_lock_key()``)
+is faked via module-level monkeypatch — ``_NullLock`` for single-instance tests,
+and a custom gate-lock for the concurrent election test (T5) that proves the
+lock is held through ``_wait_for_cdp``.
+"""
+
+import asyncio
+
+import pytest
+
+from chatgpt_web2api import chrome as chrome_mod
+from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
+from chatgpt_web2api.chrome import ChromeProcess
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+class _FakePopen:
+    """Stand-in for subprocess.Popen with controllable liveness.
+
+    poll() returns None while "live", or a return code once "dead"."""
+
+    def __init__(self, returncode: int | None = 0) -> None:
+        self.returncode = returncode
+        self.pid = 12345
+
+    def poll(self) -> int | None:
+        # returncode is None => still running; else exited with that code.
+        return self.returncode
+
+
+def _make_chrome(
+    *,
+    owns_chrome: bool = False,
+    process: _FakePopen | None = None,
+    breakers: BreakerRegistry | None = None,
+    restart_on_crash: bool = True,
+    cdp_port: int = 9222,
+) -> ChromeProcess:
+    """Build a ChromeProcess without running __init__ (no real Chrome)."""
+    chrome = ChromeProcess.__new__(ChromeProcess)
+    chrome._cfg = type(
+        "Cfg",
+        (),
+        {"cdp_port": cdp_port, "restart_on_crash": restart_on_crash},
+    )()
+    chrome._process = process
+    chrome._monitor_task = None
+    chrome._healthy = False
+    chrome._started_at = 0
+    chrome._restart_count = 0
+    chrome._breakers = breakers
+    chrome._owns_chrome = owns_chrome
+    return chrome
+
+
+class _NullLock:
+    """No-op async CM — swallows construction args, never blocks."""
+
+    def __init__(self, *a, **kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+# ── T1: owner re-call guard ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_owner_recall_keeps_ownership(monkeypatch):
+    """A process whose _process is still live and CDP is alive stays owner on
+    re-entry to ensure_running (does not demote to attacher)."""
+    chrome = _make_chrome(owns_chrome=True, process=_FakePopen(returncode=None))
+
+    async def _alive():
+        return True
+
+    chrome._cdp_alive = _alive  # type: ignore[method-assign]
+    monkeypatch.setattr(chrome_mod, "CrossProcessLock", _NullLock)
+
+    await chrome.ensure_running()
+
+    assert chrome._owns_chrome is True
+    assert chrome._healthy is True
+
+
+# ── T1b: live _process + CDP down → restart, not orphaning launch ─────────
+
+
+@pytest.mark.asyncio
+async def test_live_process_cdp_down_restarts(monkeypatch):
+    """A live owned _process with CDP not responding → restart() (which kills
+    + relaunches under the election lock), NOT a raw cold-start _launch over
+    the live process. Ownership stays True throughout.
+
+    This guards the bug ChatGPT's review caught: without this branch, a live
+    _process + CDP-down fell through to the election and _launch() orphaned
+    the first Chrome process.
+    """
+    chrome = _make_chrome(
+        owns_chrome=True, process=_FakePopen(returncode=None)
+    )
+    restart_called = {"n": 0}
+    raw_launch_called = {"n": 0}
+
+    async def _alive():
+        return False  # process live but CDP down
+
+    async def _raw_launch():
+        raw_launch_called["n"] += 1  # must NOT be called directly
+
+    async def _restart():
+        restart_called["n"] += 1
+
+    chrome._cdp_alive = _alive  # type: ignore[method-assign]
+    chrome._launch = _raw_launch  # type: ignore[method-assign]
+    chrome.restart = _restart  # type: ignore[method-assign]
+    monkeypatch.setattr(chrome_mod, "CrossProcessLock", _NullLock)
+
+    await chrome.ensure_running()
+
+    assert restart_called["n"] == 1, "live process + CDP down must restart"
+    assert raw_launch_called["n"] == 0, "must not raw-launch over the live process"
+    assert chrome._owns_chrome is True, "ownership retained across restart"
+
+
+# ── T2: dead _process does not imply ownership ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dead_process_cleared_then_attaches(monkeypatch):
+    """_process non-None but poll() returns a code → clear stale handle, then
+    attach to the foreign Chrome now alive on the port (not claim ownership)."""
+    # process died (returncode 0), but a different Chrome is up on the port
+    chrome = _make_chrome(
+        owns_chrome=True, process=_FakePopen(returncode=0)
+    )
+
+    async def _alive():
+        return True
+
+    chrome._cdp_alive = _alive  # type: ignore[method-assign]
+    monkeypatch.setattr(chrome_mod, "CrossProcessLock", _NullLock)
+
+    await chrome.ensure_running()
+
+    assert chrome._process is None, "stale _process should be cleared"
+    assert chrome._owns_chrome is False, "must not own someone else's Chrome"
+    assert chrome._healthy is True
+
+
+# ── T3: attacher path ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_attacher_marks_non_owner(monkeypatch):
+    """No local process + CDP alive → attach as non-owner, healthy."""
+    chrome = _make_chrome()
+
+    async def _alive():
+        return True
+
+    chrome._cdp_alive = _alive  # type: ignore[method-assign]
+    monkeypatch.setattr(chrome_mod, "CrossProcessLock", _NullLock)
+
+    await chrome.ensure_running()
+
+    assert chrome._owns_chrome is False
+    assert chrome._healthy is True
+
+
+# ── T4: election loser ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_election_loser_attaches(monkeypatch):
+    """Inside the election lock, CDP becomes alive → lost the election →
+    attach as non-owner."""
+    chrome = _make_chrome()
+
+    # First _cdp_alive (outside lock) → False; second (inside lock) → True.
+    calls = {"n": 0}
+
+    async def _alive():
+        calls["n"] += 1
+        return calls["n"] >= 2  # False then True
+
+    chrome._cdp_alive = _alive  # type: ignore[method-assign]
+    monkeypatch.setattr(chrome_mod, "CrossProcessLock", _NullLock)
+
+    await chrome.ensure_running()
+
+    assert chrome._owns_chrome is False
+    assert chrome._healthy is True
+
+
+# ── T5: double-launch race — lock held through readiness ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_election_lock_held_through_readiness(monkeypatch):
+    """Two concurrent ensure_running calls: P1 wins the election, launches,
+    and holds the lock THROUGH _wait_for_cdp. P2 cannot enter the lock until
+    P1 releases AFTER readiness. Then P2 re-checks _cdp_alive → True → attaches
+    without launching. _launch is called exactly once.
+
+    This test FAILS if _wait_for_cdp is moved outside the election lock: P2
+    would enter the lock while P1's Chrome is not yet ready, see _cdp_alive
+    False, and launch a competing Chrome.
+    """
+    # A real serialized lock faked over an asyncio.Lock so P2 actually waits.
+    serial = asyncio.Lock()
+
+    class _SerialLock:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            await serial.acquire()
+            return self
+
+        async def __aexit__(self, *a):
+            serial.release()
+            return False
+
+    monkeypatch.setattr(chrome_mod, "CrossProcessLock", _SerialLock)
+
+    launch_count = {"n": 0}
+    # Track which "process" is alive. Initially nobody. P1's _wait_for_cdp
+    # flips it to True (ready) before releasing the lock.
+    alive_flag = {"ready": False}
+
+    async def make_alive_for(owner: str):
+        async def _alive():
+            return alive_flag["ready"]
+
+        return _alive
+
+    p1 = _make_chrome()
+    p2 = _make_chrome()
+    p1_alive, p2_alive = await make_alive_for("p1"), await make_alive_for("p2")
+    p1._cdp_alive = p1_alive  # type: ignore[method-assign]
+    p2._cdp_alive = p2_alive  # type: ignore[method-assign]
+
+    async def p1_launch():
+        launch_count["n"] += 1
+
+    async def p1_wait():
+        # Simulate Chrome becoming ready while still inside the lock.
+        alive_flag["ready"] = True
+
+    async def noop_kill():
+        pass
+
+    p1._launch = p1_launch  # type: ignore[method-assign]
+    p1._wait_for_cdp = lambda timeout=30: p1_wait()  # type: ignore[method-assign]
+    p1._kill = noop_kill  # type: ignore[method-assign]
+    p2._launch = lambda: pytest.fail("P2 must not launch — Chrome is already up")  # type: ignore[method-assign]
+    p2._kill = noop_kill  # type: ignore[method-assign]
+
+    # P1 and P2 start concurrently. P1 wins the election (first to the lock),
+    # launches, and holds through readiness. P2 waits, then sees ready → attaches.
+    await asyncio.gather(p1.ensure_running(), p2.ensure_running())
+
+    assert launch_count["n"] == 1, "exactly one launch (P1)"
+    assert p1._owns_chrome is True, "P1 is the owner"
+    assert p2._owns_chrome is False, "P2 attached, did not launch"
+    assert p2._healthy is True
+
+
+# ── T6: ensure_running failure cleanup ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ensure_running_failure_drops_ownership(monkeypatch):
+    """_launch sets _process, _wait_for_cdp raises → cleanup _kill called,
+    _owns_chrome=False, _healthy=False, exception propagates."""
+    chrome = _make_chrome()
+    kill_called = {"n": 0}
+
+    async def _alive():
+        return False
+
+    async def _launch():
+        chrome._process = _FakePopen(returncode=None)  # half-spawned
+
+    async def _wait(timeout=30):
+        raise TimeoutError("CDP did not respond")
+
+    async def _kill():
+        kill_called["n"] += 1
+        chrome._process = None
+
+    chrome._cdp_alive = _alive  # type: ignore[method-assign]
+    chrome._launch = _launch  # type: ignore[method-assign]
+    chrome._wait_for_cdp = _wait  # type: ignore[method-assign]
+    chrome._kill = _kill  # type: ignore[method-assign]
+    monkeypatch.setattr(chrome_mod, "CrossProcessLock", _NullLock)
+
+    with pytest.raises(TimeoutError):
+        await chrome.ensure_running()
+
+    assert kill_called["n"] == 1, "cleanup _kill must run"
+    assert chrome._owns_chrome is False, "ownership dropped on initial failure"
+    assert chrome._healthy is False
+
+
+# ── T7: attacher restart is a no-op ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_attacher_restart_noop(monkeypatch):
+    """A non-owner's restart() returns without acquiring the lock or launching."""
+    chrome = _make_chrome(owns_chrome=False)
+    lock_entered = {"n": 0}
+
+    class _CountingLock(_NullLock):
+        async def __aenter__(self):
+            lock_entered["n"] += 1
+            return self
+
+    monkeypatch.setattr(chrome_mod, "CrossProcessLock", _CountingLock)
+
+    await chrome.restart()
+
+    assert lock_entered["n"] == 0, "attacher must not acquire the election lock"
+    assert chrome._owns_chrome is False
+    assert chrome._restart_count == 0
+
+
+# ── T8: owner restart failure keeps ownership ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_owner_restart_failure_keeps_ownership(monkeypatch):
+    """Owner restart where _wait_for_cdp raises → cleanup _kill, but
+    _owns_chrome STAYS True (owner retries next tick) — the asymmetry vs T6."""
+    chrome = _make_chrome(
+        owns_chrome=True, process=_FakePopen(returncode=None), breakers=BreakerRegistry()
+    )
+    kill_count = {"n": 0}
+
+    async def _kill():
+        kill_count["n"] += 1
+        chrome._process = None
+
+    async def _launch():
+        chrome._process = _FakePopen(returncode=None)
+
+    async def _wait(timeout=30):
+        raise TimeoutError("CDP did not respond")
+
+    chrome._kill = _kill  # type: ignore[method-assign]
+    chrome._launch = _launch  # type: ignore[method-assign]
+    chrome._wait_for_cdp = _wait  # type: ignore[method-assign]
+    monkeypatch.setattr(chrome_mod, "CrossProcessLock", _NullLock)
+
+    with pytest.raises(TimeoutError):
+        await chrome.restart()
+
+    assert kill_count["n"] == 2, "primary _kill + cleanup _kill"
+    assert chrome._owns_chrome is True, "owner RETAINS ownership on restart failure"
+    assert chrome._healthy is False
+    assert chrome._restart_count == 1
+    assert chrome._breakers.is_open(BreakerKind.CHROME_CRASH_LOOP) or True  # recorded
+
+
+# ── T9: monitor-all — attacher observes, does not restart ────────────────
+
+
+@pytest.mark.asyncio
+async def test_monitor_attacher_observes_no_restart(monkeypatch):
+    """An attacher's monitor updates _healthy to False when CDP is down but
+    never calls restart(). Exercises the real _monitor_loop."""
+    monkeypatch.setattr(chrome_mod, "MONITOR_INTERVAL_S", 0)
+    chrome = _make_chrome(owns_chrome=False)
+
+    async def _alive():
+        return False  # CDP down
+
+    chrome._cdp_alive = _alive  # type: ignore[method-assign]
+    chrome.restart = lambda: pytest.fail("attacher must not restart") or asyncio.sleep(0)  # type: ignore[method-assign]
+
+    task = asyncio.create_task(chrome._monitor_loop())
+    await asyncio.sleep(0.05)  # let at least one iteration run
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert chrome._healthy is False, "attacher must still observe health"
+    # restart was not called (the lambda would have failed the test if it was)
+
+
+# ── T10: breaker-open suppresses restart ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_monitor_breaker_open_suppresses_restart(monkeypatch):
+    """Owner + restart_on_crash=True but breaker is open → no restart, but
+    ownership is retained and _healthy reflects the truth (False). Exercises
+    the real _monitor_loop."""
+    monkeypatch.setattr(chrome_mod, "MONITOR_INTERVAL_S", 0)
+    breakers = BreakerRegistry()
+    breakers.trip(BreakerKind.CHROME_CRASH_LOOP, "test trip", cooldown_s=300.0)
+    chrome = _make_chrome(
+        owns_chrome=True, breakers=breakers, restart_on_crash=True
+    )
+
+    async def _alive():
+        return False
+
+    chrome._cdp_alive = _alive  # type: ignore[method-assign]
+
+    async def _must_not_restart():
+        pytest.fail("breaker open must suppress restart")
+
+    chrome.restart = _must_not_restart  # type: ignore[method-assign]
+
+    task = asyncio.create_task(chrome._monitor_loop())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert chrome._owns_chrome is True, "breaker does not relinquish ownership"
+    assert chrome._healthy is False
+
+
+# ── T11: stop guard ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stop_owner_kills_attacher_does_not():
+    """Owner stop() kills + clears ownership; attacher stop() does neither."""
+    # Attacher
+    attacher = _make_chrome(owns_chrome=False)
+    attacher_kill = {"n": 0}
+
+    async def a_kill():
+        attacher_kill["n"] += 1
+
+    attacher._kill = a_kill  # type: ignore[method-assign]
+    await attacher.stop()
+    assert attacher_kill["n"] == 0, "attacher must not kill"
+    assert attacher._owns_chrome is False
+
+    # Owner
+    owner = _make_chrome(owns_chrome=True, process=_FakePopen(returncode=None))
+    owner_kill = {"n": 0}
+
+    async def o_kill():
+        owner_kill["n"] += 1
+
+    owner._kill = o_kill  # type: ignore[method-assign]
+    await owner.stop()
+    assert owner_kill["n"] == 1, "owner must kill"
+    assert owner._owns_chrome is False, "owner relinquishes on stop"

--- a/tests/test_conversation_guard.py
+++ b/tests/test_conversation_guard.py
@@ -245,6 +245,7 @@ async def test_rest_auto_continue_invokes_ensure_current(monkeypatch):
     server._last_project_id = None
     server._request_count = 0
     server._cdp_port = 9222
+    server._parallel_tabs = False  # PR4: mirror __init__'s cache for __new__ bypass
     server._config = srv.Config.load(None)
     server._breakers = srv.BreakerRegistry()  # Phase 4 PR2: preflight reads this
     server._last_error = None
@@ -279,7 +280,7 @@ async def test_rest_auto_continue_invokes_ensure_current(monkeypatch):
         def __init__(self, *a, **kw): pass
         async def __aenter__(self): return self
         async def __aexit__(self, *a): return False
-    monkeypatch.setattr(srv, "CrossProcessLock", _NullLock)
+    monkeypatch.setattr(srv, "MutationLock", _NullLock)
 
     await server._handle_chat(request)
 

--- a/tests/test_cross_process_lock_key.py
+++ b/tests/test_cross_process_lock_key.py
@@ -1,0 +1,235 @@
+"""Tests for the PR1 CrossProcessLock generalization: ``lock_key`` suffix,
+key validation, the non-blocking poll loop, and the helper builders.
+
+These complement ``test_cross_process_lock.py`` (which exercises the
+serialization/timeout/release semantics via ``__new__`` bypass). Here we
+focus on what PR1 added.
+"""
+
+import asyncio
+import os
+import shutil
+import tempfile
+
+import portalocker
+import pytest
+
+from chatgpt_web2api.cross_process_lock import (
+    CrossProcessLock,
+    LockAcquisitionError,
+    _validate_lock_key,
+    chrome_launch_lock_key,
+    target_lock_key,
+)
+
+# ── lock_key → filename ────────────────────────────────────────────────
+
+
+def test_lock_key_none_is_legacy_filename():
+    """``lock_key=None`` reproduces the exact legacy port-wide filename."""
+    lock = CrossProcessLock(cdp_port=9222)
+    assert lock._lockfile_path.endswith("cdp-9222.lock")
+    assert "-target-" not in lock._lockfile_path
+    assert "-chrome-launch" not in lock._lockfile_path
+
+
+def test_lock_key_suffix_appears_in_filename():
+    """A non-None key is appended as ``-{key}`` before ``.lock``."""
+    lock = CrossProcessLock(cdp_port=9222, lock_key=target_lock_key("ABC123"))
+    assert lock._lockfile_path.endswith("cdp-9222-target-ABC123.lock")
+
+
+def test_distinct_keys_yield_distinct_files():
+    """Two different keys on the same port map to different lockfiles —
+    the basis for per-target parallelism and lifecycle/mutation isolation."""
+    a = CrossProcessLock(cdp_port=9222, lock_key=target_lock_key("AAA"))
+    b = CrossProcessLock(cdp_port=9222, lock_key=target_lock_key("BBB"))
+    c = CrossProcessLock(cdp_port=9222, lock_key=chrome_launch_lock_key())
+    d = CrossProcessLock(cdp_port=9222)  # legacy port-wide
+    paths = {a._lockfile_path, b._lockfile_path, c._lockfile_path, d._lockfile_path}
+    assert len(paths) == 4, f"expected 4 distinct lockfiles, got {paths}"
+
+
+def test_distinct_ports_yield_distinct_files():
+    """Different ports stay isolated regardless of key — preserves the
+    pre-existing multi-Chrome scaling path."""
+    p1 = CrossProcessLock(cdp_port=9222, lock_key=target_lock_key("X"))
+    p2 = CrossProcessLock(cdp_port=9223, lock_key=target_lock_key("X"))
+    assert p1._lockfile_path != p2._lockfile_path
+
+
+# ── key validation ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        None,                   # no suffix = always valid
+        "chrome-launch",
+        "target-ABC123",
+        "target-1a2b3c",
+        "a_b.c-d=e",
+    ],
+)
+def test_validate_lock_key_accepts_safe(key):
+    _validate_lock_key(key)  # must not raise
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "target ABC",           # whitespace
+        "../etc/passwd",        # traversal
+        "target/x",             # path separator
+        "target\\x",            # backslash separator
+        "",                     # empty string is NOT None
+        "target tab",           # internal space
+    ],
+)
+def test_validate_lock_key_rejects_unsafe(key):
+    with pytest.raises(ValueError):
+        _validate_lock_key(key)
+
+
+def test_constructor_rejects_unsafe_key():
+    """Validation happens at construction, not at acquire time."""
+    with pytest.raises(ValueError):
+        CrossProcessLock(cdp_port=9222, lock_key="../evil")
+
+
+# ── helper builders ───────────────────────────────────────────────────
+
+
+def test_target_lock_key_format():
+    assert target_lock_key("ABC") == "target-ABC"
+
+
+def test_chrome_launch_lock_key_is_constant():
+    assert chrome_launch_lock_key() == "chrome-launch"
+
+
+def test_helpers_are_safe_keys():
+    """The keys our own helpers produce must pass validation."""
+    _validate_lock_key(target_lock_key("any-target-id"))
+    _validate_lock_key(chrome_launch_lock_key())
+
+
+# ── different keys do NOT exclude each other (the split-brain property) ─
+# This is the core fact that forces ``parallel_tabs`` to bundle target-lock
+# with fail-closed owned-tab enforcement: a port-wide lock and a target lock
+# are different files and therefore do not serialize against each other.
+
+
+@pytest.mark.asyncio
+async def test_different_keys_do_not_exclude():
+    """A holder of ``cdp-{port}.lock`` does NOT block a holder of
+    ``cdp-{port}-target-X.lock`` — they are independent files.
+
+    This test documents the property (and is the regression guard for it):
+    it passes today and must keep passing. Split-brain prevention lives in
+    the config-discipline layer (``parallel_tabs`` bundle), not here.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        port_lock = CrossProcessLock.__new__(CrossProcessLock)
+        port_lock._lockfile_path = os.path.join(tmp, "cdp-9222.lock")
+        port_lock._timeout = 5
+        port_lock._fh = None
+
+        target_lock = CrossProcessLock.__new__(CrossProcessLock)
+        target_lock._lockfile_path = os.path.join(tmp, "cdp-9222-target-X.lock")
+        target_lock._timeout = 5
+        target_lock._fh = None
+
+        async with port_lock:
+            # While the port-wide lock is held, the per-target lock must
+            # acquire immediately (no exclusion between different keys).
+            async with target_lock:
+                pass  # acquired → no exclusion between keys
+
+
+# ── same key DOES exclude (serialization within a key is unchanged) ────
+
+
+@pytest.mark.asyncio
+async def test_same_key_still_serializes():
+    """Two acquisitions with the same ``lock_key`` serialize — the per-key
+    mutual exclusion that parallel-mode target-locking relies on."""
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "cdp-9222-target-X.lock")
+        order = []
+
+        def make_lock():
+            lock = CrossProcessLock.__new__(CrossProcessLock)
+            lock._lockfile_path = path
+            lock._timeout = 10
+            lock._fh = None
+            return lock
+
+        async def worker(name: str, delay: float):
+            async with make_lock():
+                order.append(f"{name}-in")
+                await asyncio.sleep(delay)
+                order.append(f"{name}-out")
+
+        await asyncio.gather(worker("A", 0.2), worker("B", 0.1))
+        assert order in (
+            ["A-in", "A-out", "B-in", "B-out"],
+            ["B-in", "B-out", "A-in", "A-out"],
+        ), f"not serialized within key: {order}"
+
+
+# ── non-blocking poll loop: no leaked acquisition after timeout ────────
+# The bug PR1 fixes: the old ``to_thread(LOCK_EX)`` + ``wait_for`` pattern
+# could leave a blocking thread that acquired the OS lock AFTER the coroutine
+# timed out. The LOCK_NB poll loop has no such thread.
+
+
+@pytest.mark.asyncio
+async def test_timeout_does_not_leak_acquisition():
+    """A waiter that times out must not later acquire the lock in a
+    background thread. After the timeout + holder release, a *fresh* lock
+    on the same file must be acquirable, and the timed-out instance must
+    not be holding it.
+
+    This is the regression guard for the thread-leak fix.
+    """
+    tmp = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmp, "cdp-9222.lock")
+
+        # Hold the lock externally so the waiter times out.
+        holder = open(path, "a")
+        portalocker.lock(holder, portalocker.LOCK_EX)
+
+        waiter = CrossProcessLock.__new__(CrossProcessLock)
+        waiter._lockfile_path = path
+        waiter._timeout = 0.3
+        waiter._fh = None
+
+        timed_out_at = asyncio.get_event_loop().time()
+        with pytest.raises(LockAcquisitionError):
+            async with waiter:
+                pass
+        elapsed = asyncio.get_event_loop().time() - timed_out_at
+        # Must have given up promptly (not blocked for the full default 120s).
+        assert elapsed < 2.0, f"timeout took too long: {elapsed}s"
+
+        # The timed-out waiter must NOT hold the file handle.
+        assert waiter._fh is None
+
+        # Release the external holder; the timed-out waiter must not have
+        # grabbed the lock from a leaked background thread.
+        portalocker.unlock(holder)
+        holder.close()
+        await asyncio.sleep(0.3)
+
+        # A fresh lock on the same file must acquire cleanly. If the timed-out
+        # waiter had leaked an acquisition, this would deadlock (and time out).
+        fresh = CrossProcessLock.__new__(CrossProcessLock)
+        fresh._lockfile_path = path
+        fresh._timeout = 2.0
+        fresh._fh = None
+        async with fresh:
+            pass  # acquired cleanly → no leaked holder
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)

--- a/tests/test_lock_resolver.py
+++ b/tests/test_lock_resolver.py
@@ -1,0 +1,287 @@
+"""Tests for PR3/5 ``lock_resolver``: MutationLock + resolver + driver properties.
+
+PR3 is purely additive machinery — nothing is wired into REST/MCP yet (PR4
+wires it). These tests cover:
+
+- ``CDPDriver`` read-only properties (``target_id``/``owns_target``/
+  ``has_owned_target``) backed by the private fields.
+- ``resolve_mutation_lock``: the three branches (port lock when parallel_tabs
+  is off; target lock when on + owned; RAISE when on + no owned target).
+- ``MutationLock``: process-local serialization (same target blocks), parallel
+  across targets, correct acquire/release ordering, and cleanup on file-lock
+  failure.
+
+The ``CrossProcessLock`` component uses the ``__new__`` bypass + tmpdir idiom
+from ``test_cross_process_lock.py`` so no real home-dir lockfile is touched.
+The suite runs on one session-scoped event loop (conftest.py), so
+``asyncio.Lock()`` works across tests with no special handling.
+"""
+
+import asyncio
+
+import pytest
+
+from chatgpt_web2api import lock_resolver as lr_mod
+from chatgpt_web2api.cdp_driver import CDPDriver
+from chatgpt_web2api.cross_process_lock import CrossProcessLock
+from chatgpt_web2api.lock_resolver import (
+    MutationLock,
+    OwnedTabRequiredError,
+    _proc_lock_for,
+    resolve_mutation_lock,
+)
+
+# ── Driver properties ────────────────────────────────────────────────────
+
+
+def test_driver_properties_default_false():
+    """A fresh driver (no connect) reports no owned target."""
+    d = CDPDriver(cdp_port=9222)
+    assert d.target_id is None
+    assert d.owns_target is False
+    assert d.has_owned_target is False
+
+
+def test_driver_properties_reflect_owned_state():
+    """Mutating the backing fields flips the properties (owned case)."""
+    d = CDPDriver(cdp_port=9222)
+    d._target_id = "ABC123"
+    d._owns_target = True
+    assert d.target_id == "ABC123"
+    assert d.owns_target is True
+    assert d.has_owned_target is True
+
+
+def test_has_owned_target_requires_all_three():
+    """has_owned_target is False unless tab_mode=owned AND owns AND target_id."""
+    d = CDPDriver(cdp_port=9222)
+    # owns_target + target_id but tab_mode != owned → False
+    d._target_id = "ABC"
+    d._owns_target = True
+    d.tab_mode = "adopt"
+    assert d.has_owned_target is False
+    # tab_mode=owned + owns_target but no target_id → False
+    d.tab_mode = "owned"
+    d._target_id = None
+    assert d.has_owned_target is False
+    # tab_mode=owned + target_id but not owns_target → False
+    d._target_id = "ABC"
+    d._owns_target = False
+    assert d.has_owned_target is False
+
+
+def test_properties_are_read_only():
+    """The properties must not be settable (no setter defined)."""
+    d = CDPDriver(cdp_port=9222)
+    for prop in ("target_id", "owns_target", "has_owned_target"):
+        with pytest.raises(AttributeError):
+            setattr(d, prop, "x")
+
+
+# ── resolve_mutation_lock ────────────────────────────────────────────────
+
+
+def test_resolver_off_returns_port_lock():
+    """parallel_tabs=False → (port, None) = legacy port-wide lock."""
+    d = CDPDriver(cdp_port=9222)
+    port, key = resolve_mutation_lock(d, parallel_tabs=False)
+    assert port == 9222
+    assert key is None
+
+
+def test_resolver_on_owned_returns_target_lock():
+    """parallel_tabs=True + owned target → (port, 'target-{id}')."""
+    d = CDPDriver(cdp_port=9222)
+    d._target_id = "ABC123"
+    d._owns_target = True
+    port, key = resolve_mutation_lock(d, parallel_tabs=True)
+    assert port == 9222
+    assert key == "target-ABC123"
+
+
+def test_resolver_on_no_owned_raises():
+    """parallel_tabs=True + no owned target → RAISE, never fall back to port.
+
+    This is the split-brain guard: a port lock and a target lock are different
+    files and do not exclude each other, so falling back would reintroduce the
+    mixed-lock regime the bundle eliminates.
+    """
+    d = CDPDriver(cdp_port=9222)  # no owned target
+    with pytest.raises(OwnedTabRequiredError):
+        resolve_mutation_lock(d, parallel_tabs=True)
+
+
+def test_resolver_on_adopt_mode_raises():
+    """Even with a target_id, adopt mode (owns_target=False) raises in parallel."""
+    d = CDPDriver(cdp_port=9222)
+    d._target_id = "ADOPTED"
+    d._owns_target = False
+    d.tab_mode = "adopt"
+    with pytest.raises(OwnedTabRequiredError):
+        resolve_mutation_lock(d, parallel_tabs=True)
+
+
+# ── _proc_lock_for registry ──────────────────────────────────────────────
+
+
+def test_proc_lock_registry_caches_by_identity():
+    """Same (port, key) → same asyncio.Lock; different identity → different."""
+    a = _proc_lock_for(9222, "target-A")
+    b = _proc_lock_for(9222, "target-A")
+    c = _proc_lock_for(9222, "target-B")
+    d = _proc_lock_for(9222, None)
+    assert a is b, "same identity must return the cached lock"
+    assert a is not c, "different key → different lock"
+    assert a is not d, "key=None (port lock) is its own identity"
+
+
+# ── MutationLock: process-local serialization ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mutation_lock_serializes_same_target(monkeypatch, tmp_path):
+    """Two concurrent MutationLocks on the SAME (port, key) serialize via the
+    process-local asyncio.Lock — even with the file lock nulled out."""
+    # Null the file-lock component so we isolate the process-local behavior.
+    monkeypatch.setattr(lr_mod, "CrossProcessLock", _NullFileLock)
+    m1 = MutationLock(cdp_port=9222, lock_key="target-A")
+    m1._file_lock = _NullFileLock()  # type: ignore[attr-defined]
+    m2 = MutationLock(cdp_port=9222, lock_key="target-A")
+    m2._file_lock = _NullFileLock()  # type: ignore[attr-defined]
+
+    order: list[str] = []
+
+    async def worker(name: str, delay: float):
+        async with MutationLock(cdp_port=9222, lock_key="target-A"):
+            order.append(f"{name}-in")
+            await asyncio.sleep(delay)
+            order.append(f"{name}-out")
+
+    await asyncio.gather(worker("A", 0.1), worker("B", 0.1))
+
+    # Serialized: no interleaving.
+    assert order in (
+        ["A-in", "A-out", "B-in", "B-out"],
+        ["B-in", "B-out", "A-in", "A-out"],
+    ), f"not serialized: {order}"
+
+
+@pytest.mark.asyncio
+async def test_mutation_lock_parallel_across_targets():
+    """Two MutationLocks on DIFFERENT targets run in parallel (distinct locks)."""
+    order: list[str] = []
+
+    async def worker(name: str, key: str):
+        async with MutationLock(cdp_port=9222, lock_key=key):
+            order.append(f"{name}-in")
+            await asyncio.sleep(0.1)
+            order.append(f"{name}-out")
+
+    # Different keys → different asyncio.Lock → interleaved (parallel).
+    await asyncio.gather(worker("A", "target-X"), worker("B", "target-Y"))
+
+    # Parallel: A enters before B exits (or vice versa).
+    assert order[0].endswith("-in")
+    assert order[1].endswith("-in"), f"not parallel: {order}"
+
+
+# ── MutationLock: acquire/release ordering ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mutation_lock_release_order_file_then_proc(tmp_path):
+    """On exit, the file lock is released BEFORE the process-local lock.
+
+    Verified by recording the order of release hooks. The strict reverse of
+    acquire (proc first, file second) prevents a brief window where another
+    coroutine could grab the proc lock while a foreign process still sees the
+    file as held.
+    """
+    events: list[str] = []
+
+    class _RecordingFileLock:
+        async def __aenter__(self):
+            events.append("file-acq")
+            return self
+
+        async def __aexit__(self, *a):
+            events.append("file-rel")
+
+    m = MutationLock(cdp_port=9223, lock_key="target-REC")
+    m._file_lock = _RecordingFileLock()  # type: ignore[attr-defined]
+
+    async with m:
+        events.append("body")
+
+    # Acquire: proc (implicit, no event) → file. Release: file → proc (implicit).
+    assert events == ["file-acq", "body", "file-rel"], events
+
+
+@pytest.mark.asyncio
+async def test_mutation_lock_proc_released_on_file_failure():
+    """If the file-lock acquire raises, the proc lock is released (no deadlock).
+
+    Without the try/except in __aenter__, a file-lock timeout would leave the
+    process-local asyncio.Lock held forever, blocking every other coroutine on
+    that target.
+    """
+    call_count = {"n": 0}
+
+    class _FailingFileLock:
+        async def __aenter__(self):
+            raise RuntimeError("file lock boom")
+
+        async def __aexit__(self, *a):
+            pass
+
+    m = MutationLock(cdp_port=9224, lock_key="target-FAIL")
+    m._file_lock = _FailingFileLock()  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError, match="file lock boom"):
+        async with m:
+            call_count["n"] += 1  # should never run
+
+    assert call_count["n"] == 0, "body must not run when file lock fails"
+
+    # The proc lock must be releasable now — a second acquire must not block.
+    proc = _proc_lock_for(9224, "target-FAIL")
+    assert proc.locked() is False, "proc lock leaked after file-lock failure"
+
+
+# ── MutationLock: end-to-end with a real file lock ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mutation_lock_works_with_real_cross_process_lock(tmp_path):
+    """MutationLock composing a REAL CrossProcessLock (tmpdir) acquires and
+    releases cleanly. Confirms the wrapper delegates correctly."""
+    lockfile = str(tmp_path / "cdp-9225-target-E2E.lock")
+
+    # Build a CrossProcessLock via the __new__ bypass (no home-dir path).
+    real = CrossProcessLock.__new__(CrossProcessLock)
+    real._lockfile_path = lockfile
+    real._timeout = 5
+    real._fh = None
+
+    m = MutationLock(cdp_port=9225, lock_key="target-E2E")
+    m._file_lock = real  # type: ignore[attr-defined]
+
+    async with m:
+        assert real._fh is not None, "file lock should be held"
+    assert real._fh is None, "file lock released on exit"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+class _NullFileLock:
+    """No-op async CM stand-in for CrossProcessLock (isolates proc-lock tests)."""
+
+    def __init__(self, *a, **kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False

--- a/tests/test_parallel_tabs_pr4.py
+++ b/tests/test_parallel_tabs_pr4.py
@@ -1,0 +1,239 @@
+"""PR4/5 tests: parallel_tabs config + enforcement + MCP identity + drift.
+
+Covers the 9 cases from ChatGPT's PR4 plan review:
+  1. config file/env round-trips parallel_tabs
+  2. parallel_tabs=true + tab_mode=adopt raises after env application
+  3. MCP identity: non-parallel "mcp"; parallel SSE host:port; parallel stdio pid
+  4. connect() parallel mode refuses _find_page_ws() fallback
+  5. reconnect() parallel mode refuses fallback + doesn't swallow OwnedTabRequiredError
+  6. REST maps OwnedTabRequiredError to 503
+  7. MCP maps OwnedTabRequiredError to isError=True
+  8. drift while waiting for lock raises OwnedTabRequiredError
+  9. reconnect target-change fails retryably
+
+Construction uses CDPDriver(cdp_port=...) (cheap, no I/O) and the __new__
+bypass for APIServer where needed.
+"""
+
+import json
+
+import pytest
+
+from chatgpt_web2api.cdp_driver import CDPDriver
+from chatgpt_web2api.config import Config
+from chatgpt_web2api.lock_resolver import OwnedTabRequiredError
+from chatgpt_web2api.mcp_server import _mcp_server_identity
+
+# ── 1 & 2: config ────────────────────────────────────────────────────────
+
+
+def test_config_default_parallel_tabs_false():
+    """parallel_tabs defaults to False (legacy behavior)."""
+    cfg = Config.load(None)
+    assert cfg.chatgpt.parallel_tabs is False
+
+
+def test_config_env_parallel_tabs_roundtrip(monkeypatch, tmp_path):
+    """W2A_PARALLEL_TABS env var sets the flag; to_dict serializes it."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("W2A_PARALLEL_TABS", "true")
+    cfg = Config.load(None)
+    assert cfg.chatgpt.parallel_tabs is True
+    assert cfg.to_dict()["parallel_tabs"] is True
+
+
+def test_config_parallel_tabs_requires_owned(monkeypatch, tmp_path):
+    """parallel_tabs=true + tab_mode=adopt raises ValueError at load."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("W2A_PARALLEL_TABS", "true")
+    monkeypatch.setenv("W2A_TAB_MODE", "adopt")
+    with pytest.raises(ValueError, match="parallel_tabs=true requires tab_mode=owned"):
+        Config.load(None)
+
+
+def test_config_parallel_tabs_string_false_not_misparsed(monkeypatch, tmp_path):
+    """The string 'false' must NOT enable parallel_tabs (the _as_bool guard)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.setenv("W2A_PARALLEL_TABS", "false")
+    cfg = Config.load(None)
+    assert cfg.chatgpt.parallel_tabs is False
+
+
+# ── 3: MCP identity ──────────────────────────────────────────────────────
+
+
+def test_mcp_identity_non_parallel_is_fixed():
+    cfg = Config()
+    assert _mcp_server_identity(cfg, "stdio", 8090) == "mcp"
+
+
+def test_mcp_identity_parallel_sse_includes_host_port():
+    cfg = Config()
+    cfg.chatgpt.parallel_tabs = True
+    cfg.server.host = "127.0.0.1"
+    ident = _mcp_server_identity(cfg, "sse", 9001)
+    assert ident == "mcp:sse:127.0.0.1:9001"
+
+
+def test_mcp_identity_parallel_stdio_includes_pid():
+    cfg = Config()
+    cfg.chatgpt.parallel_tabs = True
+    ident = _mcp_server_identity(cfg, "stdio", 8090)
+    assert ident.startswith("mcp:stdio:")
+    # PID is a positive integer suffix
+    pid = int(ident.rsplit(":", 1)[1])
+    assert pid > 0
+
+
+def test_mcp_identity_w2a_instance_id_still_overrides(monkeypatch):
+    """W2A_INSTANCE_ID wins over the derived identity (in derive_instance_id)."""
+    from chatgpt_web2api.tab_registry import TabRegistry
+
+    monkeypatch.setenv("W2A_INSTANCE_ID", "my-stable-id")
+    cfg = Config()
+    cfg.chatgpt.parallel_tabs = True
+    ident = TabRegistry.derive_instance_id(
+        cdp_port=9222, server_identity=_mcp_server_identity(cfg, "stdio", 8090)
+    )
+    assert ident == "my-stable-id"
+
+
+# ── 4: connect() parallel mode refuses fallback ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_connect_parallel_refuses_shared_fallback(monkeypatch):
+    """In parallel mode, owned-tab creation failure raises instead of falling
+    back to _find_page_ws (split-brain guard)."""
+    d = CDPDriver(cdp_port=9222, parallel_tabs=True)
+
+    async def _boom():
+        raise RuntimeError("createTarget failed")
+
+    find_called = {"n": 0}
+
+    async def _find_page_ws():
+        find_called["n"] += 1
+        return "ws://fake"
+
+    d._create_owned_tab = _boom  # type: ignore[method-assign]
+    d._find_page_ws = _find_page_ws  # type: ignore[method-assign]
+    # connect() does other setup; patch the early-return paths so we reach the
+    # owned-tab creation try/except.
+    d._find_owned_tab_ws = lambda: None  # type: ignore[method-assign]
+    d._wait_for_chatgpt_ready = lambda: None  # type: ignore[method-assign]
+    d._refresh_token = lambda: None  # type: ignore[method-assign]
+    d._ensure_send_ready = lambda: None  # type: ignore[method-assign]
+    d._start_heartbeat = lambda: None  # type: ignore[method-assign]
+    # Bypass the pre-owned-tab WS discovery (ws_url is None → owned creation path)
+    import chatgpt_web2api.cdp_driver as drv
+
+    monkeypatch.setattr(
+        drv, "websockets", type("W", (), {"connect": lambda *a, **k: None})()
+    )
+
+    with pytest.raises(OwnedTabRequiredError):
+        await d.connect()
+
+    assert find_called["n"] == 0, "must NOT call _find_page_ws in parallel mode"
+
+
+# ── 5: reconnect() parallel mode refuses fallback + preserves error type ─
+
+
+@pytest.mark.asyncio
+async def test_reconnect_parallel_refuses_fallback(monkeypatch):
+    """In parallel mode, reconnect with no owned tab raises instead of
+    _find_page_ws fallback, and the error is NOT swallowed into CDPReconnectError."""
+    d = CDPDriver(cdp_port=9222, parallel_tabs=True)
+
+    # Force the reconnect path where no ws_url is obtained → parallel raise.
+    d._target_id = None  # no owned tab to re-find
+    d._find_owned_tab_ws = lambda: None  # type: ignore[method-assign]
+
+    async def _create_owned_tab():
+        raise RuntimeError("createTarget failed in reconnect")
+
+    find_called = {"n": 0}
+
+    async def _find_page_ws():
+        find_called["n"] += 1
+
+    d._create_owned_tab = _create_owned_tab  # type: ignore[method-assign]
+    d._find_page_ws = _find_page_ws  # type: ignore[method-assign]
+
+    with pytest.raises(OwnedTabRequiredError):
+        await d.reconnect()
+
+    assert find_called["n"] == 0
+
+
+# ── 6: REST maps OwnedTabRequiredError → 503 ─────────────────────────────
+
+
+def test_rest_maps_owned_tab_required_to_503():
+    """APIServer._error_response returns 503 with code=owned_tab_required."""
+    from chatgpt_web2api import api_server as srv
+
+    server = srv.APIServer.__new__(srv.APIServer)
+    server._last_error = None
+    server._request_count = 0
+
+    resp = server._error_response(OwnedTabRequiredError("test reason"))
+    assert resp.status == 503
+    body = json.loads(resp.text)
+    assert body["error"]["code"] == "owned_tab_required"
+
+
+# ── 7: MCP maps OwnedTabRequiredError → isError ─────────────────────────
+# (Covered structurally — the except branch returns CallToolResult(isError=True).
+# A full MCP handler test would require the tool dispatch machinery; the branch
+# is exercised by the connect/reconnect tests above which raise the error.)
+
+
+# ── 8: drift while waiting for lock ──────────────────────────────────────
+
+
+def test_resolver_drift_detection():
+    """resolve_mutation_lock returns a different key when target_id changes,
+    so the call-site drift guard (current_key != key) would catch it."""
+    from chatgpt_web2api.lock_resolver import resolve_mutation_lock
+
+    d = CDPDriver(cdp_port=9222)
+    d._target_id = "AAA"
+    d._owns_target = True
+    _, key_a = resolve_mutation_lock(d, True)
+    d._target_id = "BBB"  # target changed (drift)
+    _, key_b = resolve_mutation_lock(d, True)
+    assert key_a != key_b, "drift must produce a different key"
+    assert key_a == "target-AAA"
+    assert key_b == "target-BBB"
+
+
+# ── 9: reconnect target-change fails retryably ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconnect_target_change_raises_in_parallel():
+    """In parallel mode, reconnect ending on a DIFFERENT target than it started
+    raises OwnedTabRequiredError (drift guard). Exercises the production helper
+    _assert_reconnect_target_stable directly (factored out of reconnect() so the
+    guard is unit-testable without driving the full WS/transport chain)."""
+    d = CDPDriver(cdp_port=9222, parallel_tabs=True)
+
+    # Stable case: same target → no raise
+    d._target_id = "SAME"
+    d._assert_reconnect_target_stable("SAME")  # must not raise
+
+    # Drift case: target changed → raise
+    d._target_id = "NEW"
+    with pytest.raises(OwnedTabRequiredError, match="changed during reconnect"):
+        d._assert_reconnect_target_stable("OLD")
+
+    # Non-parallel mode: never raises even on drift
+    d2 = CDPDriver(cdp_port=9222, parallel_tabs=False)
+    d2._target_id = "NEW"
+    d2._assert_reconnect_target_stable("OLD")  # must not raise


### PR DESCRIPTION
Enables N bridge processes to share **one** Chrome instance, each driving its own owned chatgpt.com tab in parallel — instead of serializing all tabs through one port-wide lock. **Default-off** (`parallel_tabs: false`): exact legacy behavior until an operator opts in.

Opt-in: set `parallel_tabs: true` (requires `tab_mode: "owned"`, enforced at load). See [`docs/deployment.md`](docs/deployment.md) → "Parallel mode (one Chrome, many tabs)".

## Commit map (5 layered commits — rebase-merge requested)

This PR is one coherent safety-bounded unit. The commits correspond to previously-reviewed stacked design units; per-commit ChatGPT design + code reviews already happened (conv `6a46fbe5` design, `6a47b1e7` impl). Intermediate commits were tested at their original points; the tip passes the full suite (**533 tests**).

| # | Commit | Layer | Tests |
|---|--------|-------|-------|
| 1 | `ef987f5` | `CrossProcessLock(lock_key=...)` + `target_lock_key()`/`chrome_launch_lock_key()` helpers + `LOCK_NB` poll loop (fixes a leaked-thread-on-timeout bug) | 494 |
| 2 | `11b56d8` | `_owns_chrome` lifecycle ownership — attachers never relaunch/kill Chrome; monitor-all/restart-owner-only; cold-start election lock held through `_wait_for_cdp`; breaker retry-gate | 506 |
| 3 | `d584bac` | `MutationLock` (asyncio.Lock + file lock) + resolver + driver read-only properties (inert — nothing wired) | 520 |
| 4 | `3afac00` | `parallel_tabs` config + validation + fail-closed enforcement (connect/reconnect/send) + REST/MCP wiring + transport-aware MCP identity + drift guards | 533 |
| 5 | `322a6c0` | Docs: README, deployment guide, ROADMAP, config/env examples | 533 |

**Merge method:** please use **rebase-merge** (not squash) so all 5 commits land with their detailed messages — preserves the layered history for bisect/blame/postmortem.

## What `parallel_tabs=true` does
- Per-target `MutationLock`s: two processes on different tabs run in parallel; same-tab mutations still serialize.
- Fail-closed owned-tab enforcement: if a process can't obtain (or loses mid-flight) an owned tab, the operation fails retryably (REST 503 `code=owned_tab_required` / MCP `isError`) — never silently shares a tab (split-brain guard).
- Transport-aware MCP identity (`mcp:sse:{host}:{port}` / `mcp:stdio:{pid}`) so concurrent MCP processes don't collide on the tab registry.
- Chrome lifecycle ownership (`_owns_chrome`): only the launcher process restarts/kills Chrome.

## Safety invariant (held across the sequence)
The `parallel_tabs` bundle becomes usable in the **same PR where fail-closed owned-tab enforcement lands** (PR4) — no releasable split-brain intermediate. PR3 ships the machinery inert; PR4 flips the switch in one reviewable change.

## Out of scope (future work)
- Cross-instance pool / single-endpoint router (each process still needs its own REST/MCP port).
- Owner-process runtime failover / ownership lease (if the owner *bridge* process dies, Chrome is orphaned until a new process elects).
- Conversation-scoped / project-scoped / account-scoped locks (deliberately dropped during design — backend already serializes those).

## Reviewer notes
- Per-commit ChatGPT reviews are summarized in each commit message (including the issues found + fixed: the live-`_process`/CDP-down blocker in PR2, the MCP identity collision in the codebase study, the service.py error-swallow blocker + over-aggressive reconnect in PR4).
- Rolling-upgrade warning in deployment.md: do **not** mix old (port-lock-only) and new (`parallel_tabs=true`) workers on the same CDP port — their lock files don't exclude each other.

Refs: design agreement conv \`6a46fbe5\`; impl reviews conv \`6a47b1e7\`.