### PR TITLE
docs(parallel): operational acceptance checklist + owner-death runbook + canary

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,7 @@ deployment.
 | [deployment.md](deployment.md) | **Installing & sharing.** pip / Docker / cookie-export / remote-deploy options, multiple-instance scaling, `parallel_tabs` (one Chrome, many tabs), plus cross-links to supervision and the runbook. |
 | [os-supervision.md](os-supervision.md) | **Always-on supervision.** systemd (Linux), launchd (macOS), Task Scheduler + NSSM (Windows); `ensure`-on-a-timer and REST+MCP split-service styles. |
 | [runbook.md](runbook.md) | **Operating a running deployment.** Startup checklist, `/health` interpretation, failure modes, breaker states, auth recovery, safe restart, post-deploy validation, logs. Source-cited. |
+| [operational-validation.md](operational-validation.md) | **Accepting a feature into production.** The live validation checklist for `parallel_tabs` (default-off smoke, parallel canary, failure modes, observability). Tracks the "merged" → "operationally accepted" promotion. |
 | [api-reference.md](api-reference.md) | **Calling the API.** OpenAI-compatible REST endpoints and the MCP server surface (tools, transports). |
 
 ---

--- a/docs/operational-validation.md
+++ b/docs/operational-validation.md
@@ -1,0 +1,114 @@
+# Operational Validation — Parallel Multi-Tab Mode
+
+> Status: **`parallel_tabs` is merged (PR #33) and opt-in available. NOT yet
+> operationally accepted.** This checklist tracks the live validation required
+> to promote the wording to "operationally accepted." Until then, treat the
+> feature as "available, not production-proven."
+
+This is the operational acceptance gate for the parallel multi-tab feature
+(`parallel_tabs=true`; see [deployment.md → Parallel mode](deployment.md#parallel-mode-one-chrome-many-tabs)).
+It complements — does **not** replace — the unit/integration suites
+(`test_lock_resolver`, `test_parallel_tabs_pr4`, `test_chrome_lifecycle`),
+which are authoritative for the locking/serialization/fail-closed invariants.
+The checks below exercise those invariants against **real Chrome, real ChatGPT
+DOM, and a real shared account/session**.
+
+## Preflight gate (must be true before starting)
+
+- [ ] **No mixed workers on the CDP port.** Every worker targeting this Chrome
+      instance is on the new `parallel_tabs=true` code, OR every worker is on
+      default-off legacy mode. Old port-lock-only and new per-target-lock
+      workers do **not** exclude each other; mixing them reintroduces
+      split-brain. (See deployment.md rollout warning.)
+- [ ] **Distinct `W2A_INSTANCE_ID` per worker** (or rely on the transport-aware
+      default: `rest:{port}` / `mcp:sse:{host}:{port}` / `mcp:stdio:{pid}`).
+      Do NOT reuse one `W2A_INSTANCE_ID` across live workers — they will collide
+      on one tab-registry entry.
+
+## 1. Default-off smoke
+
+Deploy current `master` with `parallel_tabs=false`.
+
+- [ ] Legacy single-worker behavior is unchanged (one request at a time per tab).
+- [ ] No `owned_tab_required` error leaks into legacy mode.
+- [ ] Restart in dependency order: REST/owner first → wait for Chrome/CDP
+      readiness → MCP/SSE/attachers. (See [runbook §7](runbook.md#7-safe-restart-sequence).)
+
+## 2. Parallel canary (2+ workers, one Chrome)
+
+`parallel_tabs=true`, `tab_mode=owned`, two REST workers on distinct REST ports
+sharing one CDP port. Run `scripts/parallel_canary.py --ports 8081,8082 --cdp-port 9222`.
+
+- [ ] Each worker obtains a **distinct owned tab** (CDP `/json/list` shows ≥2
+      chatgpt.com page targets; canary JSON `cdp_targets.chatgpt_tabs_after ≥ 2`).
+- [ ] Different-tab sends proceed **concurrently** (canary `concurrent.total_window_s`
+      meaningfully less than the sum of individuals).
+- [ ] All concurrent requests return OpenAI-compatible 200s.
+- [ ] No unexpected `circuit_open` / `auth_required` breakers tripped solely by
+      parallel pressure (rate-limit backoff is expected; a *tripped* breaker is
+      the signal to investigate).
+
+## 3. Same-tab serialization (sanity, not re-proof)
+
+Two concurrent requests to the **same** worker (canary `same_worker_serialization`).
+
+- [ ] Timing is consistent with serialization (total ≈ sum of individuals).
+      **Note:** live timing against ChatGPT is noisy — backend latency,
+      streaming, rate limits, and DOM readiness all confound it. Treat this as
+      advisory; the unit suite (`test_lock_resolver::test_mutation_lock_serializes_same_target`)
+      is authoritative. If timing looks parallel, investigate via logs (lock
+      acquire/release order) before concluding a bug.
+
+## 4. Failure-mode validation
+
+- [ ] **Kill an attacher process** → Chrome remains alive; the owner's monitor
+      is unaffected. Restarting the attacher reclaims a tab (or starts a fresh
+      one if its identity was PID-derived stdio MCP).
+- [ ] **Kill the owner process** → Chrome is orphaned until a new process
+      elects. This is **intentional** (deferred failover), not a bug — see
+      [runbook §7a](runbook.md#7a-parallel-mode-process-death--chrome-ownership).
+      Recover via the safe restart sequence.
+- [ ] **Force tab loss / target drift** (e.g. close an owned tab mid-mutation,
+      or force a reconnect that lands on a different target) → the in-flight
+      operation fails **retryably** with REST 503 `code=owned_tab_required` /
+      MCP `isError` marker `(owned_tab_required)`. No silent adoption of
+      another process's tab.
+- [ ] **Concurrent MCP processes** → transport-aware identity (`mcp:sse:…` /
+      `mcp:stdio:…`) gives each a distinct tab-registry entry; no thrash on the
+      shared registry key.
+
+## 5. Observability pass
+
+Capture logs from a normal parallel run AND from each failure mode above.
+
+- [ ] An operator can identify **which worker / REST port / transport** failed
+      without attaching a debugger.
+- [ ] The new log lines from PR2/PR4 surface correctly under parallel mode:
+      owner vs attacher (`_owns_chrome`), "Monitor disabled: attached to
+      existing Chrome", "Refusing restart: not Chrome owner", the
+      `owned_tab_required` markers, drift-guard raises.
+- [ ] `/health` reflects REST-side state (note: MCP has its own breaker
+      registry that REST `/health` does **not** reflect — see
+      [runbook §9](runbook.md#9-log-collection)).
+
+## 6. Exit criterion
+
+When **all** of §1–§5 pass against the live environment:
+
+- [ ] Update release wording from *"merged and opt-in available"* to
+      *"parallel multi-tab mode is operationally accepted."*
+- [ ] Record the validation run (date, environment, canary JSON) alongside this
+      checklist.
+
+Until then, the feature status stays at **opt-in available, not production-proven.**
+
+---
+
+## Out of scope for this validation (tracked as future work)
+
+- Cross-instance pool / single-endpoint router (each worker still needs its own
+  local REST/MCP port).
+- Owner-process runtime failover / ownership lease (owner death orphans Chrome
+  until a new process elects — see runbook §7a).
+- Conversation-scoped / project-scoped / account-scoped locks (deliberately
+  dropped during design — backend serializes those).

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -417,6 +417,38 @@ If `ensure` exits 2, **stop and do auth recovery (§6)** — do not loop `ensure
 
 ---
 
+## 7a. Parallel mode: process death & Chrome ownership
+
+> Applies only when `parallel_tabs=true`. In the default (`parallel_tabs=false`)
+> single-worker mode there is exactly one process and this section does not apply.
+
+When parallel mode is enabled, only the **owner** process (the one that launched
+Chrome) manages the Chrome lifecycle. Other processes are **attachers**. This
+split is structural (`_owns_chrome`), not lock-based — see
+[deployment.md → Parallel mode](deployment.md#parallel-mode-one-chrome-many-tabs).
+
+**Attacher process dies** → Chrome should remain running. The owner's health
+monitor is the only one that restarts; an attacher's monitor no-ops on restart
+by design. No action required beyond restarting the attacher process itself
+(its owned tab is reclaimable on restart only if it uses a stable
+`W2A_INSTANCE_ID`; a stdio MCP process whose identity was PID-derived starts a
+fresh tab).
+
+**Owner process dies** → Chrome may be **orphaned**: it keeps running but no live
+process owns its lifecycle, so no monitor restarts it and attachers will not
+self-promote. This is **intentional in the current design** — runtime owner
+failover / an ownership lease is deferred future work, not an incident. Recover
+with the normal [safe restart sequence (§7)](#7-safe-restart-sequence): restart
+the REST/owner process first, wait for Chrome/CDP readiness, then restart
+MCP/SSE or attachers. A freshly started process finds the CDP port and elects
+owner (or attaches) per `ChromeProcess.ensure_running`.
+
+If an operator depends on restart-on-crash surviving owner death, supervise the
+owner process with OS-level restart (see [os-supervision.md](os-supervision.md))
+so a new owner process starts automatically.
+
+---
+
 ## 8. Post-deploy / post-restart validation
 
 > **After a code/package update, restart in dependency order.** `ensure` does

--- a/scripts/parallel_canary.py
+++ b/scripts/parallel_canary.py
@@ -1,0 +1,236 @@
+"""Parallel-tabs operational canary (run against live Chrome + ChatGPT).
+
+Thin validation harness for the `parallel_tabs=true` mode merged in PR #33.
+Boots NO processes by default — it expects two REST workers already running on
+distinct local ports against ONE shared Chrome/CDP port, each with
+`parallel_tabs=true` (and `tab_mode=owned`). It fires concurrent requests and
+reports whether different-tab sends proceed concurrently and same-tab sends
+serialize, then emits a JSON summary.
+
+This is an operational acceptance tool, NOT a re-proof of the invariants — the
+unit/integration suites (test_lock_resolver, test_parallel_tabs_pr4,
+test_chrome_lifecycle) are authoritative for the locking/serialization logic.
+Live timing against real ChatGPT is noisy (backend latency, streaming,
+rate limits, DOM readiness all confound it), so timing here is advisory; the
+CDP `/json/list` snapshots + log excerpts are the primary evidence.
+
+Usage (default — against already-started endpoints)::
+
+    # Terminal 1
+    W2A_PARALLEL_TABS=1 chatgpt-web2api --port 8081 --cdp-port 9222
+    # Terminal 2
+    W2A_PARALLEL_TABS=1 chatgpt-web2api --port 8082 --cdp-port 9222
+    # Terminal 3 (this script)
+    python scripts/parallel_canary.py --ports 8081,8082 --cdp-port 9222
+
+Args:
+  --ports      Comma-separated REST ports of the two workers (required).
+  --cdp-port   Shared Chrome CDP port (default 9222).
+  --model      Model slug to send (default auto).
+  --prompt     Prompt text (default a timestamped marker).
+  --timeout    Per-request timeout seconds (default 120).
+  --json-out   Path to write the JSON summary (default ./parallel-canary.json).
+
+Exit code: 0 if both workers returned OpenAI-compatible 200s and the CDP
+snapshot shows >=2 distinct chatgpt.com page targets; 1 otherwise. Timing/
+serialization observations are reported but do not fail the exit code (live
+timing is noisy — see module docstring).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+
+def _post_chat(port: int, model: str, prompt: str, timeout: float) -> dict:
+    """POST /v1/chat/completions (non-streaming) to one worker. Returns a
+    result dict with port, status, elapsed, and either content or error."""
+    url = f"http://127.0.0.1:{port}/v1/chat/completions"
+    body = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}
+    )
+    started = time.monotonic()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            payload = json.loads(resp.read())
+        return {
+            "port": port,
+            "status": resp.status,
+            "elapsed_s": round(time.monotonic() - started, 2),
+            "content_preview": (payload.get("choices", [{}])[0]
+                                 .get("message", {})
+                                 .get("content", ""))[:120],
+            "ok": resp.status == 200,
+        }
+    except urllib.error.HTTPError as e:
+        err_body = ""
+        try:
+            err_body = e.read().decode()[:200]
+        except Exception:
+            pass
+        return {
+            "port": port,
+            "status": e.code,
+            "elapsed_s": round(time.monotonic() - started, 2),
+            "error": err_body,
+            "ok": False,
+        }
+    except Exception as e:
+        return {
+            "port": port,
+            "status": None,
+            "elapsed_s": round(time.monotonic() - started, 2),
+            "error": f"{type(e).__name__}: {e}",
+            "ok": False,
+        }
+
+
+def _cdp_targets(cdp_port: int) -> list[dict]:
+    """Snapshot /json/list page targets (best-effort; non-fatal)."""
+    try:
+        with urllib.request.urlopen(
+            urllib.request.Request(f"http://127.0.0.1:{cdp_port}/json/list"),
+            timeout=5,
+        ) as resp:
+            targets = json.loads(resp.read())
+        return [
+            {
+                "type": t.get("type"),
+                "url": (t.get("url") or "")[:100],
+                "title": (t.get("title") or "")[:60],
+            }
+            for t in targets
+            if t.get("type") == "page"
+        ]
+    except Exception as e:
+        return [{"error": f"{type(e).__name__}: {e}"}]
+
+
+def _health(port: int) -> dict:
+    try:
+        with urllib.request.urlopen(
+            urllib.request.Request(f"http://127.0.0.1:{port}/health"), timeout=5
+        ) as resp:
+            return {"port": port, "status": resp.status, "body": json.loads(resp.read())}
+    except Exception as e:
+        return {"port": port, "error": f"{type(e).__name__}: {e}"}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--ports", required=True, help="Comma-separated REST ports (2+)")
+    ap.add_argument("--cdp-port", type=int, default=9222)
+    ap.add_argument("--model", default="auto")
+    ap.add_argument(
+        "--prompt", default=f"parallel-canary-{int(time.time())}: reply with one word."
+    )
+    ap.add_argument("--timeout", type=float, default=120.0)
+    ap.add_argument("--json-out", default="parallel-canary.json")
+    args = ap.parse_args()
+
+    ports = [int(p.strip()) for p in args.ports.split(",") if p.strip()]
+    if len(ports) < 2:
+        print("ERROR: --ports needs at least 2 workers", file=sys.stderr)
+        return 2
+
+    summary: dict = {
+        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "cdp_port": args.cdp_port,
+        "ports": ports,
+        "prompt": args.prompt,
+    }
+
+    # 1. Preflight health on both workers (advisory — does not gate exit code).
+    summary["health"] = [_health(p) for p in ports]
+
+    # 2. CDP snapshot before (count of chatgpt.com page targets).
+    targets_before = _cdp_targets(args.cdp_port)
+    chatgpt_tabs_before = sum(
+        1 for t in targets_before if "chatgpt.com" in t.get("url", "")
+    )
+
+    # 3. Fire concurrent requests, one per worker (different-tab parallel path).
+    concurrent_started = time.monotonic()
+    with ThreadPoolExecutor(max_workers=len(ports)) as pool:
+        futs = {
+            pool.submit(_post_chat, p, args.model, args.prompt, args.timeout): p
+            for p in ports
+        }
+        concurrent_results = [f.result() for f in as_completed(futs)]
+    concurrent_results.sort(key=lambda r: r["port"])
+    concurrent_window_s = round(time.monotonic() - concurrent_started, 2)
+
+    # 4. Same-tab serialization sanity: two requests to the SAME worker.
+    # Timing is advisory (live latency is noisy); logged for human inspection.
+    same_port = ports[0]
+    serial_started = time.monotonic()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        sfuts = {
+            pool.submit(_post_chat, same_port, args.model, args.prompt, args.timeout): i
+            for i in range(2)
+        }
+        serial_results = [f.result() for f in as_completed(sfuts)]
+    serial_window_s = round(time.monotonic() - serial_started, 2)
+
+    # 5. CDP snapshot after.
+    targets_after = _cdp_targets(args.cdp_port)
+    chatgpt_tabs_after = sum(
+        1 for t in targets_after if "chatgpt.com" in t.get("url", "")
+    )
+
+    summary["concurrent"] = {
+        "results": concurrent_results,
+        "total_window_s": concurrent_window_s,
+        "note": (
+            "different-tab sends should overlap; if total_window is close to "
+            "max(individual), they serialized (unexpected for parallel mode)."
+        ),
+    }
+    summary["same_worker_serialization"] = {
+        "port": same_port,
+        "results": serial_results,
+        "total_window_s": serial_window_s,
+        "note": (
+            "same-tab sends SHOULD serialize; total_window should be roughly "
+            "sum of individuals. Timing is advisory — see module docstring."
+        ),
+    }
+    summary["cdp_targets"] = {
+        "chatgpt_tabs_before": chatgpt_tabs_before,
+        "chatgpt_tabs_after": chatgpt_tabs_after,
+        "sample_after": targets_after[:6],
+    }
+
+    # 6. Exit decision: both concurrent 200s AND >=2 chatgpt tabs after.
+    all_ok = all(r["ok"] for r in concurrent_results)
+    distinct_tabs_ok = chatgpt_tabs_after >= 2
+    summary["passed"] = bool(all_ok and distinct_tabs_ok)
+
+    with open(args.json_out, "w") as f:
+        json.dump(summary, f, indent=2)
+
+    print(json.dumps(summary, indent=2))
+    print(f"\nJSON summary written to {args.json_out}", file=sys.stderr)
+    print(
+        f"PASS={summary['passed']} (concurrent_all_200={all_ok}, "
+        f"distinct_tabs_after={chatgpt_tabs_after}>=2={distinct_tabs_ok})",
+        file=sys.stderr,
+    )
+    return 0 if summary["passed"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Lands the operator-facing artifacts for the parallel-tabs **operational acceptance gate** (PR #33 is merged but not yet operationally accepted). Agreed with ChatGPT as the work I can do without a live environment; the live validation runs themselves (default-off smoke, parallel canary, failure modes) need a logged-in Chrome + real ChatGPT account and are tracked as unchecked boxes in the checklist.

## What's in this PR

- **`docs/runbook.md` §7a** — "Parallel mode: process death & Chrome ownership". Documents that attacher death leaves Chrome alive, **owner death orphans Chrome until a new process elects** (intentional — deferred failover is future work, not a bug), and recovery is the safe restart sequence. Prevents operators filing the orphan-on-owner-death behavior as a regression.
- **`docs/operational-validation.md`** — the live acceptance checklist: preflight gate (no mixed old/new workers; distinct instance IDs), §1 default-off smoke, §2 parallel canary (distinct tabs, concurrent different-tab sends), §3 same-tab serialization (sanity, not re-proof — unit tests authoritative, live timing noisy), §4 failure modes (attacher/owner death, drift fail-closed, MCP identity), §5 observability pass, §6 exit criterion (wording promotion to "operationally accepted"). Explicitly notes unit/integration suites are authoritative for invariants.
- **`scripts/parallel_canary.py`** — thin operational canary. Runs against already-started REST workers; fires concurrent requests + same-worker serialization sanity; snapshots CDP `/json/list` before/after; emits JSON summary. Exit code gated on concurrent-200s + ≥2 distinct chatgpt tabs. Matches the repo's stdlib-script convention. **Not** a test framework — it's the repeatable acceptance harness + future regression tool.
- **`docs/INDEX.md`** — cross-link to the new validation doc.

## What's NOT in this PR (honest scope)
- The live validation runs themselves (need a logged-in Chrome + real account) — tracked as unchecked boxes in `operational-validation.md` §1-§5.
- The wording promotion to "operationally accepted" — gated on those runs passing (§6).
- `live_parallel_tabs` pytest marker — deferred; the canary script covers repeatable validation more directly.
- E501 lint hygiene — separate PR, unrelated.

## ChatGPT review
Joint action plan agreed in conv \`6a47e316. ChatGPT's three refinements adopted: (1) added observability validation to the checklist, (2) "same-tab serialize" framed as live sanity not re-proof, (3) upgrade hygiene is a preflight gate not just a criterion. Also adopted its suggested runbook wording for owner-death.

This PR is docs + one script (no source changes); CI lint + suite unaffected locally.