### PR TITLE
fix(dom): increase click_send button-poll budget for composer reset (parallel mode)

### DIFF
--- a/docs/operational-validation.md
+++ b/docs/operational-validation.md
@@ -1,9 +1,8 @@
 # Operational Validation — Parallel Multi-Tab Mode
 
-> Status: **`parallel_tabs` is merged (PR #33) and opt-in available. NOT yet
-> operationally accepted.** This checklist tracks the live validation required
-> to promote the wording to "operationally accepted." Until then, treat the
-> feature as "available, not production-proven."
+> Status: **`parallel_tabs` is merged (PR #33) and opt-in available. Live
+> validation PARTIALLY RUN (2026-07-03): §1 and §2 PASS; §3 surfaced a
+> composer-readiness gap (see Known Gap below). NOT yet operationally accepted.**
 
 This is the operational acceptance gate for the parallel multi-tab feature
 (`parallel_tabs=true`; see [deployment.md → Parallel mode](deployment.md#parallel-mode-one-chrome-many-tabs)).
@@ -12,6 +11,51 @@ It complements — does **not** replace — the unit/integration suites
 which are authoritative for the locking/serialization/fail-closed invariants.
 The checks below exercise those invariants against **real Chrome, real ChatGPT
 DOM, and a real shared account/session**.
+
+## Live validation run — 2026-07-03
+
+Environment: Chrome 149 on CDP 9222 (logged in, account: Nabeel Alajmah),
+master @ `606fdee`. Workers started fresh from master with `W2A_PARALLEL_TABS=1`.
+
+| Section | Result | Evidence |
+|---------|--------|----------|
+| §1 default-off smoke | ✅ PASS | Worker on 8091 (`parallel_tabs=false`) returned 200 / exact "PONG" reply in 11s; no `owned_tab_required` leak. Legacy behavior preserved. |
+| §2 different-tab concurrency | ✅ PASS | Two workers (8092 owns `45EBD607…`, 8093 owns `C25F97E7…` — distinct owned tabs). Two concurrent requests: total window 10.86s ≈ max(individual), NOT sum (21.5s) → ran in **parallel**, not serialized. Per-target `MutationLock` working as designed. |
+| §3 same-tab serialization | ✅ **FIXED** (was GAP) | Pre-fix: 5/5 rounds had a 500 "no send button". Post-fix (10s poll budget): 10/10 same-worker concurrent requests returned 200. Lock serializes correctly; composer-readiness wait now covers the reset window. See Known Gap below. |
+| §4 failure modes | ⏸ deferred | Pending §3 resolution — gap should be understood before declaring the failure modes authoritative. |
+| §5 observability | ⏸ deferred | Worker logs captured; pending §3 resolution. |
+
+### Known Gap: composer-readiness race on back-to-back same-tab sends — FIXED ✅
+
+**Symptom (pre-fix):** Two concurrent requests to the same worker/tab → first
+returned 200, second returned 500 `Send failed: no send button` (from
+`chatgpt_dom.click_send`). Reproduced deterministically (5/5 rounds failed).
+
+**Root cause:** NOT a `MutationLock` failure — the unit test
+`test_lock_resolver::test_mutation_lock_serializes_same_target` confirms the
+in-process `asyncio.Lock` serializes same-target coroutines correctly, and §2's
+parallel timing confirms the lock is active. The gap was a **DOM-readiness
+issue**: `click_send`'s send-button poll budget was ~3s (range(10) × 0.3s),
+too short for ChatGPT's composer to re-enable the send button after a prior
+back-to-back send released the lock. Under legacy single-worker mode requests
+naturally space out, so the race rarely surfaced; parallel mode's tighter
+pipelining exposed it.
+
+**Fix (this PR):** Increased the poll budget to 10s via named constants
+(`SEND_BUTTON_POLL_MAX_WAIT_S`, `SEND_BUTTON_POLL_INTERVAL_S` in
+`chatgpt_dom.py`) and rewrote the loop to be time-budget-based. 10s covers
+observed composer-reset times while still bounding the wait on a genuinely
+broken composer.
+
+**Stress-test result (post-fix):** 5 rounds × 2 concurrent same-worker requests
+= 10/10 returned 200, **0 failures** (was 5/10 before the fix). Timing confirms
+serialization (e.g. round 4: 7.5s + 19.2s — second request waited for the lock,
+then the composer poll waited for the button, then sent). §2 different-tab
+parallelism re-confirmed still parallel.
+
+**Impact on operational acceptance:** The gap that blocked §3 is resolved.
+§4 (failure modes) and §5 (observability) remain to run before promoting to
+"operationally accepted."
 
 ## Preflight gate (must be true before starting)
 

--- a/src/chatgpt_web2api/chatgpt_dom.py
+++ b/src/chatgpt_web2api/chatgpt_dom.py
@@ -84,6 +84,17 @@ COMPOSER_FALLBACK_SELECTOR = "textarea#prompt-textarea"
 SEND_BUTTON_SELECTOR = 'button[aria-label*="Send" i]:not([data-testid="stop-button"])'
 SEND_BUTTON_FALLBACK_SELECTOR = 'button[data-testid="send-button"]'
 
+# Send-button readiness poll. After a prior send completes (or under parallel
+# mode, where the MutationLock releases the instant a send finishes), ChatGPT's
+# composer can take several seconds to re-enable the send button — the composer
+# stays in a "sending"/"regenerating" state with the button disabled or absent
+# until the UI settles. The historical 3s budget (range(10) * 0.3s) was too
+# tight for back-to-back same-tab sends and surfaced as intermittent
+# "no send button" 500s. 10s covers observed reset times without hanging
+# indefinitely on a genuinely broken composer.
+SEND_BUTTON_POLL_INTERVAL_S = 0.3
+SEND_BUTTON_POLL_MAX_WAIT_S = 10.0
+
 
 class ChatGPTDom:
     """ChatGPT-composer DOM interaction, composed by ``CDPDriver``.
@@ -386,8 +397,12 @@ class ChatGPTDom:
         """
         d = self._driver
         # Wait for the send button to appear and be enabled. Try the new
-        # aria-label selector first, then the legacy testid fallback.
-        for _ in range(10):
+        # aria-label selector first, then the legacy testid fallback. Time-
+        # budgeted (not a fixed iteration count) so the wait scales to the
+        # composer-reset window after a prior send — see
+        # SEND_BUTTON_POLL_MAX_WAIT_S for rationale.
+        deadline = time.monotonic() + SEND_BUTTON_POLL_MAX_WAIT_S
+        while time.monotonic() < deadline:
             has_btn = await d._js(
                 "(function() {"
                 f"  var btn = document.querySelector('{SEND_BUTTON_SELECTOR}')"
@@ -397,7 +412,7 @@ class ChatGPTDom:
             )
             if has_btn == "yes":
                 break
-            await asyncio.sleep(0.3)
+            await asyncio.sleep(SEND_BUTTON_POLL_INTERVAL_S)
 
         result = await d._js(
             "(function() {"

--- a/tests/test_chatgpt_dom.py
+++ b/tests/test_chatgpt_dom.py
@@ -262,3 +262,51 @@ def test_breaker_registry_stays_on_driver():
     d = CDPDriver(cdp_port=9222)
     assert hasattr(d, "_breakers")
     assert not hasattr(d._dom, "_breakers")
+
+
+# ── 5. click_send time-budgeted readiness poll (PR #36) ───────────────
+#
+# The poll loop was rewritten from `for _ in range(10)` (fixed 3s) to a
+# time-budgeted `while time.monotonic() < deadline`. These tests guard the
+# loop shape: it must (a) wait until the send button is enabled, then send;
+# (b) raise SendReadinessError when the budget is exhausted. Patching the
+# constants small keeps the tests fast.
+
+
+@pytest.mark.asyncio
+async def test_click_send_waits_then_sends(monkeypatch):
+    """The poll loop waits through several 'no' responses until the button is
+    enabled, then the click succeeds."""
+    import chatgpt_web2api.chatgpt_dom as dom_mod
+
+    monkeypatch.setattr(dom_mod, "SEND_BUTTON_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(dom_mod, "SEND_BUTTON_POLL_MAX_WAIT_S", 2.0)
+
+    dom, driver = _make_dom()
+    # First 3 readiness checks → "no" (button not ready), then "yes", then "sent".
+    driver._js = AsyncMock(side_effect=["no", "no", "no", "yes", "sent"])
+
+    await dom.click_send()  # must not raise
+
+    # The readiness poll should have run 4 times (3×"no" + 1×"yes"), then the
+    # click once ("sent") = 5 total _js calls.
+    assert driver._js.await_count == 5, f"expected 5 _js calls, got {driver._js.await_count}"
+
+
+@pytest.mark.asyncio
+async def test_click_send_raises_on_budget_exhausted(monkeypatch):
+    """When the send button never becomes enabled within the budget, the loop
+    exhausts and the final click raises SendReadinessError."""
+    import chatgpt_web2api.chatgpt_dom as dom_mod
+
+    monkeypatch.setattr(dom_mod, "SEND_BUTTON_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(dom_mod, "SEND_BUTTON_POLL_MAX_WAIT_S", 0.05)
+
+    dom, driver = _make_dom()
+    # Every _js call returns "no" — button never appears.
+    driver._js = AsyncMock(return_value="no")
+
+    from chatgpt_web2api.cdp_driver import SendReadinessError
+
+    with pytest.raises(SendReadinessError, match="Send failed"):
+        await dom.click_send()


### PR DESCRIPTION
Fixes the §3 composer-readiness gap found during live parallel-tabs operational validation. **Not a locking bug** — the \`MutationLock\` serializes correctly (unit-confirmed) and different-tab parallelism works (§2 timing). The gap was \`click_send\`'s send-button poll budget (~3s) being too short for ChatGPT's composer to re-enable its send button after a prior back-to-back send released the lock. Under legacy mode requests space out so the race rarely surfaced; parallel mode's tighter pipelining exposed it.

## Change
- \`chatgpt_dom.py\`: add named constants \`SEND_BUTTON_POLL_MAX_WAIT_S\` (10.0) + \`SEND_BUTTON_POLL_INTERVAL_S\` (0.3) with rationale; rewrite \`click_send\`'s poll loop from \`for _ in range(10)\` (fixed 3s) to time-budgeted \`while time.monotonic() < deadline\`.
- \`docs/operational-validation.md\`: §3 GAP → FIXED with stress-test evidence.

## Stress test (live, master, parallel_tabs=true)
- **Pre-fix:** 5 rounds × 2 concurrent same-worker requests → 5×200, **5×500 \"no send button\"** (deterministic).
- **Post-fix:** 5 rounds × 2 concurrent same-worker requests → **10×200, 0×500**.
- Timing confirms serialization works: e.g. round 4 (7.5s + 19.2s) — second request waited for the lock, then the composer poll waited for the button, then sent.
- §2 different-tab parallelism re-confirmed still parallel (10.86s total ≈ max(individual), not sum).

## Not in scope
- §4 (failure modes) and §5 (observability) of the operational validation — resume after this lands.
- The wording promotion to \"operationally accepted\" — gated on §4 + §5.

Full suite: 533 passed (no regression from the loop rewrite).