### PR TITLE
A2: turn-anchored backend reconciliation (stale-return fix)

### DIFF
--- a/scripts/a2_capture_real_fixture.py
+++ b/scripts/a2_capture_real_fixture.py
@@ -1,0 +1,237 @@
+"""Prerequisite 3: Capture a real thinking-model mapping fixture.
+
+Triggers a thinking-model send via the bridge, then fetches the raw backend
+mapping via CDP and saves it as a test fixture. Also runs the projection JS
+against it to verify the projection produces the expected compact schema.
+
+The fixture is saved to tests/fixtures/sample_conversation_mapping.json.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import urllib.request
+
+import websockets
+
+CDP = 9222
+BRIDGE = "http://127.0.0.1:8080"
+
+
+def list_targets():
+    return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{CDP}/json/list", timeout=3).read())
+
+
+def find_chatgpt_target():
+    targets = list_targets()
+    for t in targets:
+        if t.get("type") == "page" and "chatgpt.com/c/" in t.get("url", ""):
+            return t
+    for t in targets:
+        if t.get("type") == "page" and "chatgpt.com" in t.get("url", ""):
+            return t
+    raise RuntimeError("no chatgpt target found")
+
+
+async def main():
+    # Step 1: trigger a thinking-model send via the bridge.
+    print("=== PREREQ 3: Capture real thinking/tool-use mapping fixture ===")
+    print("\nStep 1: Triggering a thinking-model send...")
+    prompt = "Think step by step. What is 17 * 23? Show your reasoning."
+    body = json.dumps({
+        "model": "auto",
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+    }).encode()
+    req = urllib.request.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as r:
+            p = json.loads(r.read())
+            conv_id = p.get("conversation_id", "")
+            content = p.get("choices", [{}])[0].get("message", {}).get("content", "")[:200]
+            print(f"  conversation_id: {conv_id}")
+            print(f"  content[:200]: {content!r}")
+    except Exception as e:
+        print(f"  bridge error: {e}")
+        conv_id = ""
+        content = ""
+
+    if not conv_id:
+        print("FAILED: no conversation_id from send")
+        return
+
+    # Step 2: fetch the raw backend mapping via CDP.
+    print(f"\nStep 2: Fetching raw backend mapping for {conv_id}...")
+    target = find_chatgpt_target()
+    print(f"  target: {target['url'][:80]}")
+
+    async with websockets.connect(target["webSocketDebuggerUrl"], max_size=None,
+                                  ping_interval=20, ping_timeout=60) as ws:
+        nxt = [0]
+        def nid():
+            nxt[0] += 1; return nxt[0]
+
+        # Get token.
+        await ws.send(json.dumps({"id": nid(), "method": "Runtime.evaluate",
+                                  "params": {"expression": '(async()=>{var r=await fetch("/api/auth/session");var j=await r.json();return j.accessToken||""})()',
+                                             "awaitPromise": True, "returnByValue": True}}))
+        token = ""
+        while True:
+            r = json.loads(await ws.recv())
+            if r.get("id"):
+                token = r.get("result", {}).get("result", {}).get("value", "")
+                break
+
+        # Fetch the raw mapping (full, unprojected).
+        fetch_js = (
+            "(async()=>{"
+            "var r=await fetch('/backend-api/conversation/' + __C__ + '?offset=0&limit=50',"
+            "{headers:{'Authorization':'Bearer ' + __T__}});"
+            "if(!r.ok) return JSON.stringify({__status:r.status});"
+            "var j=await r.json();return JSON.stringify(j)"
+            "})()"
+        ).replace("__C__", json.dumps(conv_id)).replace("__T__", json.dumps(token))
+
+        await ws.send(json.dumps({"id": nid(), "method": "Runtime.evaluate",
+                                  "params": {"expression": fetch_js, "awaitPromise": True,
+                                             "returnByValue": True, "timeout": 20000}}))
+        raw_mapping = None
+        while True:
+            r = json.loads(await ws.recv())
+            if r.get("id"):
+                val = r.get("result", {}).get("result", {}).get("value", "")
+                if val:
+                    raw_mapping = json.loads(val)
+                break
+
+    if not raw_mapping or "mapping" not in raw_mapping:
+        print(f"FAILED: no mapping in response. Got keys: {list(raw_mapping.keys()) if raw_mapping else 'None'}")
+        return
+
+    mapping = raw_mapping["mapping"]
+    print(f"  mapping node count: {len(mapping)}")
+
+    # Step 3: analyze the raw mapping shape.
+    print("\nStep 3: Analyzing raw mapping shape...")
+    roles = {}
+    content_types = {}
+    has_reasoning = False
+    has_tool = False
+    for nid, node in mapping.items():
+        msg = node.get("message") or {}
+        role = (msg.get("author") or {}).get("role", "?")
+        ct = ((msg.get("content") or {}).get("content_type", "?"))
+        roles[role] = roles.get(role, 0) + 1
+        content_types[ct] = content_types.get(ct, 0) + 1
+        if ct == "reasoning_recap":
+            has_reasoning = True
+        if "tool" in ct:
+            has_tool = True
+
+    print(f"  roles: {roles}")
+    print(f"  content_types: {content_types}")
+    print(f"  has_reasoning_recap: {has_reasoning}")
+    print(f"  has_tool_use: {has_tool}")
+
+    # Step 4: run the projection JS against the raw mapping (in Python —
+    # simulate what the JS would produce).
+    print("\nStep 4: Simulating projection against raw mapping...")
+    from chatgpt_web2api.backend_projection import CONVERSATION_PROJECTION_JS, TURN_PROJECTION_LIMIT
+    projected = {}
+    for key, node in mapping.items():
+        msg = node.get("message") or {}
+        author = msg.get("author") or {}
+        content = msg.get("content") or {}
+        parts = content.get("parts") or []
+        text = ""
+        if content.get("content_type") == "text":
+            text_parts = [p for p in parts if isinstance(p, str) and p.strip()]
+            text = "\n".join(text_parts)
+        projected[key] = {
+            "id": msg.get("id") or key,
+            "parent": node.get("parent"),
+            "children": node.get("children") or [],
+            "role": author.get("role", "unknown"),
+            "create_time": msg.get("create_time") or 0,
+            "end_turn": bool(msg.get("end_turn")),
+            "content_type": content.get("content_type", "unknown"),
+            "text": text,
+        }
+    print(f"  projected node count: {len(projected)}")
+
+    # Verify all required fields are present.
+    required_fields = {"id", "parent", "children", "role", "create_time",
+                       "end_turn", "content_type", "text"}
+    all_valid = True
+    for nid, node in projected.items():
+        missing = required_fields - set(node.keys())
+        if missing:
+            print(f"  MISSING FIELDS in node {nid}: {missing}")
+            all_valid = False
+    if all_valid:
+        print("  All projected nodes have all required fields ✓")
+
+    # Verify reasoning_recap nodes are preserved (not dropped).
+    reasoning_nodes = [nid for nid, n in projected.items()
+                       if n["content_type"] == "reasoning_recap"]
+    print(f"  reasoning_recap nodes preserved: {len(reasoning_nodes)} (graph structure intact)")
+
+    # Step 5: save the fixture (sanitized — strip the actual text content to
+    # avoid leaking prompts/responses into the repo; keep structure + metadata).
+    print("\nStep 5: Saving sanitized fixture...")
+    fixture_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "tests", "fixtures")
+    os.makedirs(fixture_dir, exist_ok=True)
+    fixture_path = os.path.join(fixture_dir, "sample_conversation_mapping.json")
+
+    # Sanitize: keep structure + metadata, truncate text to 60 chars.
+    sanitized = {"nodes": {}}
+    for nid, node in projected.items():
+        san = dict(node)
+        if san["text"] and len(san["text"]) > 60:
+            san["text"] = san["text"][:60] + "...[truncated]"
+        sanitized["nodes"][nid] = san
+    sanitized["current_node"] = raw_mapping.get("current_node")
+    sanitized["_meta"] = {
+        "source": "real captured ChatGPT backend mapping",
+        "captured": "2026-07-04",
+        "conversation_id": conv_id,
+        "node_count": len(projected),
+        "has_reasoning_recap": has_reasoning,
+        "has_tool_use": has_tool,
+        "roles": roles,
+        "content_types": content_types,
+    }
+
+    with open(fixture_path, "w") as f:
+        json.dump(sanitized, f, indent=2)
+    print(f"  saved: {fixture_path}")
+
+    # Step 6: verify the selectors work on the projected fixture.
+    print("\nStep 6: Verifying selectors work on the projected fixture...")
+    from chatgpt_web2api.turn_anchor import TurnAnchor, select_text_for_turn
+    # Find the latest user node to use as the captured ID.
+    latest_user_id = None
+    latest_user_ct = -1
+    for nid, node in projected.items():
+        if node["role"] == "user" and node["create_time"] > latest_user_ct:
+            latest_user_ct = node["create_time"]
+            latest_user_id = node["id"]
+    if latest_user_id:
+        anchor = TurnAnchor(sent_text="(any)", mode="captured_id",
+                            captured_user_message_id=latest_user_id)
+        result = select_text_for_turn({"nodes": projected}, anchor)
+        print(f"  selector result: status={result.status}")
+        if result.text:
+            print(f"  text[:80]: {result.text[:80]!r}")
+        if result.diagnostic:
+            print(f"  diagnostic: { {k:v for k,v in result.diagnostic.items() if k != 'reason'} }")
+    else:
+        print("  no user node found in fixture")
+
+    print("\n=== PREREQ 3 COMPLETE ===")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/a2_investigation_spike.py
+++ b/scripts/a2_investigation_spike.py
@@ -1,0 +1,331 @@
+"""A2 investigation — Phase 0.5 (skew) + Phase 1 (identity spike).
+
+Pure observational CDP instrumentation around ONE bridge send.
+- Phase 0.5: records t_pre_wall vs backend user.create_time to derive skew.
+- Phase 1: captures outgoing /backend-api/conversation/* POST bodies/headers
+  during the send to discover whether the protocol carries a usable client
+  message ID / idempotency key / parent_message_id that survives into the
+  backend mapping.
+
+No DOM mutation. No send interception. Listens to network traffic the bridge
+already generates, then fetches the mapping for cross-reference.
+
+Usage:
+    python scripts/a2_investigation_spike.py --label RUN-1
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import time
+import urllib.request
+
+import websockets
+
+
+CDP_PORT = 9222
+BRIDGE = "http://127.0.0.1:8080"
+CONVERSATION_ID = "6a48625b-34a4-83ed-93ba-a7153c2e6295"
+CHATGPT_TAB_URL_PREFIX = "chatgpt.com/c/"
+
+
+def list_targets() -> list[dict]:
+    with urllib.request.urlopen(f"http://127.0.0.1:{CDP_PORT}/json/list", timeout=3) as r:
+        return json.loads(r.read())
+
+
+def find_chatgpt_target(conv_id: str) -> dict | None:
+    """Find the page target showing the conversation we're about to send to."""
+    targets = list_targets()
+    needle = f"/c/{conv_id}"
+    for t in targets:
+        if t.get("type") == "page" and needle in t.get("url", ""):
+            return t
+    # Fallback: any chatgpt.com/c/ page
+    for t in targets:
+        if t.get("type") == "page" and "chatgpt.com/c/" in t.get("url", ""):
+            return t
+    return None
+
+
+async def cdp_eval(ws: websockets.WebSocketClientProtocol, expr: str, timeout_ms: int = 15000) -> dict:
+    """Runtime.evaluate — returns the full result dict."""
+    msg = {
+        "id": _next_id(),
+        "method": "Runtime.evaluate",
+        "params": {
+            "expression": expr,
+            "returnByValue": True,
+            "awaitPromise": True,
+            "timeout": timeout_ms,
+        },
+    }
+    await ws.send(json.dumps(msg))
+    while True:
+        resp = json.loads(await ws.recv())
+        # Skip Network.* events — we're collecting those separately.
+        if resp.get("id") == msg["id"]:
+            return resp
+
+
+_id_counter = [0]
+def _next_id() -> int:
+    _id_counter[0] += 1
+    return _id_counter[0]
+
+
+async def fetch_mapping_via_target(
+    ws: websockets.WebSocketClientProtocol, conv_id: str, token: str
+) -> dict:
+    """Fetch /backend-api/conversation/{id}?offset=0&limit=50 inside the page.
+
+    Returns the parsed mapping dict (full, unprojected — Phase 5 will define the
+    projection; for Phase 0.5/1 we want the raw shape).
+    """
+    expr = f"""
+    (async () => {{
+      try {{
+        var r = await fetch('/backend-api/conversation/' + {conv_id!r} + '?offset=0&limit=50', {{
+          headers: {{'Authorization': 'Bearer ' + {token!r}}}
+        }});
+        if (!r.ok) return JSON.stringify({{__status: r.status}});
+        var conv = await r.json();
+        return JSON.stringify(conv);
+      }} catch(e) {{ return JSON.stringify({{__error: String(e)}}); }}
+    }})()
+    """
+    resp = await cdp_eval(ws, expr, timeout_ms=20000)
+    val = resp.get("result", {}).get("result", {}).get("value", "")
+    if not val:
+        return {"__error": "empty"}
+    return json.loads(val)
+
+
+async def get_access_token(ws: websockets.WebSocketClientProtocol) -> str:
+    """Read the access token the same way the bridge does."""
+    expr = """
+    (async () => {
+      try {
+        var r = await fetch('/api/auth/session');
+        var j = await r.json();
+        return j.accessToken || '';
+      } catch(e) { return ''; }
+    })()
+    """
+    resp = await cdp_eval(ws, expr, timeout_ms=10000)
+    return resp.get("result", {}).get("result", {}).get("value", "") or ""
+
+
+async def bridge_send(marker: str) -> dict:
+    """Send via the bridge's REST API (the path under investigation)."""
+    import urllib.request as ur
+
+    body = json.dumps({
+        "model": "auto",
+        "conversation_id": CONVERSATION_ID,
+        "messages": [{"role": "user", "content": f"Reply with exactly this marker and nothing else: {marker}"}],
+        "stream": False,
+    }).encode()
+    req = ur.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                     headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        with ur.urlopen(req, timeout=120) as r:
+            payload = json.loads(r.read())
+            return {"ok": True, "latency": time.time() - t0, "content": payload.get("choices", [{}])[0].get("message", {}).get("content", "")}
+    except Exception as e:
+        return {"ok": False, "latency": time.time() - t0, "error": str(e)}
+
+
+def analyze_mapping(mapping: dict, sent_marker: str) -> dict:
+    """Phase 0.5 + Phase 1 analysis on a raw backend mapping.
+
+    Extract: latest user node create_time, latest assistant node create_time,
+    whether the sent marker appears in any user node's text, all observed
+    id-like fields on the latest user/assistant nodes.
+    """
+    out = {
+        "node_count": 0,
+        "user_nodes": [],
+        "assistant_nodes": [],
+        "latest_user_create_time": None,
+        "latest_user_node_id": None,
+        "latest_user_text": None,
+        "latest_user_id_fields": {},
+        "latest_assistant_create_time": None,
+        "latest_assistant_node_id": None,
+        "latest_assistant_text": None,
+        "latest_assistant_id_fields": {},
+        "marker_in_latest_user": None,
+    }
+    if not isinstance(mapping, dict):
+        out["__error"] = f"mapping not dict: {type(mapping)}"
+        return out
+    m = mapping.get("mapping", {})
+    out["node_count"] = len(m)
+
+    best_user_t = -1
+    best_asst_t = -1
+    for nid, node in m.items():
+        msg = node.get("message") or {}
+        author = msg.get("author") or {}
+        role = author.get("role")
+        ct = msg.get("create_time") or 0
+        out_node = {"id": nid, "role": role, "create_time": ct,
+                    "end_turn": msg.get("end_turn"),
+                    "content_type": (msg.get("content") or {}).get("content_type"),
+                    "id_fields": {}}
+        # Capture every id-like field at message level (Phase 1 spike)
+        for k, v in msg.items():
+            if "id" in k.lower() or k in ("parent", "children"):
+                out_node["id_fields"][k] = v
+        if role == "user":
+            parts = (msg.get("content") or {}).get("parts") or []
+            text = "\n".join(str(p) for p in parts if isinstance(p, str))
+            out["user_nodes"].append({**out_node, "text": text[:120]})
+            if ct > best_user_t:
+                best_user_t = ct
+                out["latest_user_create_time"] = ct
+                out["latest_user_node_id"] = nid
+                out["latest_user_text"] = text[:200]
+                out["latest_user_id_fields"] = out_node["id_fields"]
+                out["marker_in_latest_user"] = sent_marker in text
+        elif role == "assistant":
+            parts = (msg.get("content") or {}).get("parts") or []
+            text = "\n".join(str(p) for p in parts if isinstance(p, str))
+            out["assistant_nodes"].append({**out_node, "text": text[:120]})
+            if ct > best_asst_t:
+                best_asst_t = ct
+                out["latest_assistant_create_time"] = ct
+                out["latest_assistant_node_id"] = nid
+                out["latest_assistant_text"] = text[:200]
+                out["latest_assistant_id_fields"] = out_node["id_fields"]
+    return out
+
+
+async def main(label: str) -> None:
+    target = find_chatgpt_target(CONVERSATION_ID)
+    if not target:
+        print(json.dumps({"error": "no chatgpt.com/c/ target found"}, indent=2))
+        return
+    ws_url = target["webSocketDebuggerUrl"]
+    print(f"[spike] attached to target: {target['url'][:80]}")
+
+    sent_marker = f"SPIKE-{label}-{int(time.time())}"
+    captured_network = []  # Phase 1 captures
+
+    async with websockets.connect(ws_url, max_size=None) as ws:
+        # Enable Network domain to observe outgoing requests during the send.
+        await ws.send(json.dumps({"id": _next_id(), "method": "Network.enable"}))
+
+        # Read the access token (for our own mapping fetch) before the send.
+        token = await get_access_token(ws)
+        print(f"[spike] access token: {'OK' if token else 'MISSING'} ({len(token)} chars)")
+
+        # Capture pre-send mapping baseline (latest user/assistant BEFORE send).
+        t_pre_wall = time.time()
+        pre_mapping_raw = await fetch_mapping_via_target(ws, CONVERSATION_ID, token)
+        pre_analysis = analyze_mapping(pre_mapping_raw, sent_marker)
+        print(f"[spike] pre-send: latest_user_node_id={pre_analysis['latest_user_node_id']}, "
+              f"latest_user_ct={pre_analysis['latest_user_create_time']}, "
+              f"latest_asst_node_id={pre_analysis['latest_assistant_node_id']}")
+
+        # Drain any Network events accumulated so far.
+        while True:
+            try:
+                _ = await asyncio.wait_for(ws.recv(), timeout=0.1)
+            except asyncio.TimeoutError:
+                break
+
+        # Fire the bridge send in a background task; meanwhile collect Network events.
+        send_task = asyncio.create_task(bridge_send(sent_marker))
+        network_events = []
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            # Check send completion.
+            if send_task.done():
+                # Drain a bit more network then break.
+                pass
+            try:
+                raw = await asyncio.wait_for(ws.recv(), timeout=0.3)
+            except asyncio.TimeoutError:
+                if send_task.done():
+                    break
+                continue
+            evt = json.loads(raw)
+            method = evt.get("method", "")
+            if not method.startswith("Network."):
+                continue
+            params = evt.get("params", {})
+            req = params.get("request", {})
+            url = req.get("url", "")
+            # Only capture backend-api/conversation traffic (the send path).
+            if "/backend-api/conversation/" in url:
+                network_events.append({
+                    "method": method,
+                    "request_id": params.get("requestId"),
+                    "url": url,
+                    "method_verb": req.get("method"),
+                    "has_post_data": req.get("hasPostData"),
+                    "post_data": req.get("postData"),
+                    "headers": req.get("headers"),
+                    # response fields for responseReceived
+                    "response_status": (params.get("response") or {}).get("status"),
+                    "response_headers": (params.get("response") or {}).get("headers"),
+                })
+
+        send_result = await send_task
+
+        # Fetch post-send mapping (give backend 2s to settle).
+        await asyncio.sleep(2.0)
+        t_post_wall = time.time()
+        post_mapping_raw = await fetch_mapping_via_target(ws, CONVERSATION_ID, token)
+        post_analysis = analyze_mapping(post_mapping_raw, sent_marker)
+
+    # Phase 0.5: skew computation
+    skew_user = None
+    if post_analysis.get("latest_user_create_time") and post_analysis.get("marker_in_latest_user"):
+        skew_user = post_analysis["latest_user_create_time"] - t_pre_wall
+
+    report = {
+        "label": label,
+        "sent_marker": sent_marker,
+        "conversation_id": CONVERSATION_ID,
+        "t_pre_wall": t_pre_wall,
+        "t_post_wall": t_post_wall,
+        "send_result": send_result,
+        # Phase 1: network observations
+        "network_event_count": len(network_events),
+        "network_events": network_events,
+        # Phase 0.5: skew
+        "skew_user_create_minus_t_pre_wall": skew_user,
+        "pre_send_mapping_summary": {
+            "node_count": pre_analysis["node_count"],
+            "latest_user_node_id": pre_analysis["latest_user_node_id"],
+            "latest_user_create_time": pre_analysis["latest_user_create_time"],
+            "latest_assistant_node_id": pre_analysis["latest_assistant_node_id"],
+            "latest_assistant_create_time": pre_analysis["latest_assistant_create_time"],
+        },
+        "post_send_mapping_summary": {
+            "node_count": post_analysis["node_count"],
+            "latest_user_node_id": post_analysis["latest_user_node_id"],
+            "latest_user_create_time": post_analysis["latest_user_create_time"],
+            "latest_user_text": post_analysis["latest_user_text"],
+            "latest_user_id_fields": post_analysis["latest_user_id_fields"],
+            "marker_in_latest_user": post_analysis["marker_in_latest_user"],
+            "latest_assistant_node_id": post_analysis["latest_assistant_node_id"],
+            "latest_assistant_create_time": post_analysis["latest_assistant_create_time"],
+            "latest_assistant_text": post_analysis["latest_assistant_text"],
+            "latest_assistant_id_fields": post_analysis["latest_assistant_id_fields"],
+        },
+    }
+
+    print(json.dumps(report, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--label", default="RUN-1")
+    args = p.parse_args()
+    asyncio.run(main(args.label))

--- a/scripts/a2_phase0_5_and_1_combined.py
+++ b/scripts/a2_phase0_5_and_1_combined.py
@@ -1,0 +1,276 @@
+"""A2 investigation — combined Phase 0.5 (skew) + Phase 1 follow-up (UUID capture).
+
+Runs N instrumented sends. For each:
+  - Records t_pre_wall before the bridge send.
+  - Captures the outgoing /backend-api/f/conversation POST via CDP Network domain,
+    recording (a) whether request.postData carries the body, (b) the client UUID
+    extracted from messages[0].id.
+  - After the send, fetches the mapping and records user.create_time, whether
+    the UUID survived into a mapping node, and the skew delta.
+
+Outputs a JSON report at the end with per-send rows + aggregate statistics.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import statistics
+import time
+import urllib.request
+
+import websockets
+
+CDP = 9222
+BRIDGE = "http://127.0.0.1:8080"
+CONV = "6a48625b-34a4-83ed-93ba-a7153c2e6295"
+NUM_SAMPLES = 12
+
+
+def list_targets() -> list[dict]:
+    return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{CDP}/json/list", timeout=3).read())
+
+
+def find_target() -> dict:
+    targets = list_targets()
+    # Prefer the target showing our conversation.
+    for t in targets:
+        if t.get("type") == "page" and CONV in t.get("url", ""):
+            return t
+    # Fallback: any chatgpt.com/c/ page.
+    for t in targets:
+        if t.get("type") == "page" and "chatgpt.com/c/" in t.get("url", ""):
+            return t
+    raise RuntimeError("no chatgpt.com/c/ target found")
+
+
+async def bridge_send(marker: str) -> dict:
+    body = json.dumps({
+        "model": "auto", "conversation_id": CONV,
+        "messages": [{"role": "user", "content": f"Reply with exactly: {marker}"}],
+        "stream": False,
+    }).encode()
+    req = urllib.request.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=120) as r:
+            p = json.loads(r.read())
+            content = p.get("choices", [{}])[0].get("message", {}).get("content", "")
+            return {"ok": True, "latency": round(time.time() - t0, 2), "content": content}
+    except Exception as e:
+        return {"ok": False, "latency": round(time.time() - t0, 2), "error": str(e)}
+
+
+async def main(num_samples: int) -> None:
+    target = find_target()
+    print(f"target: {target['url'][:80]}")
+    ws_url = target["webSocketDebuggerUrl"]
+
+    rows: list[dict] = []
+
+    async with websockets.connect(ws_url, max_size=None) as ws:
+        nxt = [0]
+        def nid() -> int:
+            nxt[0] += 1
+            return nxt[0]
+
+        async def evaluate(expr: str, timeout_ms: int = 15000) -> dict:
+            my_id = nid()
+            await ws.send(json.dumps({"id": my_id, "method": "Runtime.evaluate",
+                                      "params": {"expression": expr, "awaitPromise": True,
+                                                 "returnByValue": True, "timeout": timeout_ms}}))
+            while True:
+                r = json.loads(await ws.recv())
+                if r.get("id") == my_id:
+                    return r
+
+        # Enable Network domain (with large post-data budget).
+        await ws.send(json.dumps({"id": nid(), "method": "Network.enable",
+                                  "params": {"maxPostDataSize": 1024 * 1024}}))
+        # Drain the ACK.
+        while True:
+            r = json.loads(await asyncio.wait_for(ws.recv(), timeout=3))
+            if r.get("id"):
+                break
+
+        # Get token (for our mapping fetches).
+        token_resp = await evaluate(
+            '(async()=>{var r=await fetch("/api/auth/session");var j=await r.json();return j.accessToken||""})()',
+            timeout_ms=10000,
+        )
+        token = token_resp.get("result", {}).get("result", {}).get("value", "")
+        print(f"access token: {'OK' if token else 'MISSING'} ({len(token)} chars)")
+
+        # Build the mapping-fetch JS (with placeholders to avoid brace hell).
+        def fetch_mapping_js() -> str:
+            return (
+                "(async()=>{"
+                "var r=await fetch('/backend-api/conversation/' + __C__ + '?offset=0&limit=50',"
+                "{headers:{'Authorization':'Bearer ' + __T__}});"
+                "if(!r.ok) return JSON.stringify({__status:r.status});"
+                "var j=await r.json();return JSON.stringify(j)"
+                "})()"
+            ).replace("__C__", json.dumps(CONV)).replace("__T__", json.dumps(token))
+
+        for i in range(1, num_samples + 1):
+            marker = f"COMBINED-{i}-{int(time.time())}"
+            print(f"\n--- sample {i}/{num_samples}: marker={marker} ---")
+
+            # Drain any pending network events before the send window.
+            while True:
+                try:
+                    _ = await asyncio.wait_for(ws.recv(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    break
+
+            # Fire send in background; collect Network events meanwhile.
+            t_pre_wall = time.time()
+            send_task = asyncio.create_task(bridge_send(marker))
+
+            captured_post_body = None
+            captured_client_uuid = None
+            network_event_count = 0
+            deadline = time.time() + 120
+            while time.time() < deadline:
+                if send_task.done() and (captured_post_body is not None or time.time() > t_pre_wall + 8):
+                    # Give a short tail to catch the post-send fetches, then stop.
+                    if time.time() > t_pre_wall + 8:
+                        break
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=0.3)
+                except asyncio.TimeoutError:
+                    if send_task.done() and time.time() > t_pre_wall + 8:
+                        break
+                    continue
+                r = json.loads(raw)
+                m = r.get("method", "")
+                if not m.startswith("Network."):
+                    continue
+                p = r.get("params", {})
+                req = p.get("request", {}) or {}
+                url = req.get("url", "")
+                if m == "Network.requestWillBeSent" and "/backend-api/f/conversation" in url:
+                    network_event_count += 1
+                    if req.get("method") == "POST" and url.rstrip("/").endswith("/f/conversation"):
+                        post_data = req.get("postData")
+                        if post_data:
+                            captured_post_body = post_data
+                            try:
+                                parsed = json.loads(post_data)
+                                msgs = parsed.get("messages") or []
+                                if msgs and msgs[0].get("id"):
+                                    captured_client_uuid = msgs[0]["id"]
+                            except Exception:
+                                pass
+
+            send_result = await send_task
+
+            # Fetch post-send mapping; extract user.create_time and check UUID survival.
+            await asyncio.sleep(1.5)  # let backend settle
+            t_post_wall = time.time()
+            map_resp = await evaluate(fetch_mapping_js(), timeout_ms=20000)
+            map_val = map_resp.get("result", {}).get("result", {}).get("value", "")
+            mapping = json.loads(map_val) if map_val else {}
+            m = mapping.get("mapping", {}) if isinstance(mapping, dict) else {}
+
+            latest_user_ct = None
+            latest_user_id = None
+            latest_user_text = None
+            uuid_survived = None
+            uuid_node_role = None
+            best_user_t = -1
+            for nid_str, node in m.items():
+                msg = node.get("message") or {}
+                if (msg.get("author") or {}).get("role") != "user":
+                    continue
+                ct = msg.get("create_time") or 0
+                if ct > best_user_t:
+                    best_user_t = ct
+                    latest_user_ct = ct
+                    latest_user_id = msg.get("id")
+                    parts = (msg.get("content") or {}).get("parts") or []
+                    latest_user_text = "\n".join(str(p) for p in parts if isinstance(p, str))[:80]
+            if captured_client_uuid and latest_user_id:
+                uuid_survived = (captured_client_uuid == latest_user_id)
+                if not uuid_survived:
+                    # Check if it appears anywhere (e.g., as a parent linkage).
+                    for _nid, node in m.items():
+                        if captured_client_uuid in str(node):
+                            uuid_node_role = (node.get("message") or {}).get("author", {}).get("role")
+                            break
+
+            skew = None
+            if latest_user_ct:
+                skew = round(latest_user_ct - t_pre_wall, 3)
+
+            row = {
+                "sample": i,
+                "marker": marker,
+                "t_pre_wall": t_pre_wall,
+                "t_post_wall": t_post_wall,
+                "send_result": send_result,
+                "is_stale": send_result.get("content") != marker,
+                "network_event_count": network_event_count,
+                "post_body_captured": captured_post_body is not None,
+                "client_uuid_observed": captured_client_uuid,
+                "latest_user_create_time": latest_user_ct,
+                "latest_user_node_id": latest_user_id,
+                "latest_user_text": latest_user_text,
+                "uuid_survived_as_user_node_id": uuid_survived,
+                "uuid_found_elsewhere_role": uuid_node_role,
+                "skew_user_ct_minus_t_pre_wall": skew,
+            }
+            rows.append(row)
+            print(f"  send returned : {send_result.get('content','')[:60]!r}")
+            print(f"  stale         : {row['is_stale']}")
+            print(f"  post_body cap : {row['post_body_captured']}")
+            print(f"  client_uuid   : {captured_client_uuid}")
+            print(f"  user_node.id  : {latest_user_id}")
+            print(f"  uuid survived : {uuid_survived} (elsewhere_role={uuid_node_role})")
+            print(f"  skew (s)      : {skew}")
+
+            # Pace sends to avoid rate-limiting.
+            await asyncio.sleep(3.0)
+
+    # Aggregate statistics.
+    print("\n" + "=" * 70)
+    print("AGGREGATE REPORT")
+    print("=" * 70)
+    n = len(rows)
+    stale_count = sum(1 for r in rows if r["is_stale"])
+    body_capture_rate = sum(1 for r in rows if r["post_body_captured"]) / n if n else 0
+    uuid_survival_rate = sum(1 for r in rows if r["uuid_survived_as_user_node_id"]) / n if n else 0
+    skews = [r["skew_user_ct_minus_t_pre_wall"] for r in rows if r["skew_user_ct_minus_t_pre_wall"] is not None]
+    print(f"samples                   : {n}")
+    print(f"stale returns             : {stale_count}/{n}")
+    print(f"post body capture rate    : {body_capture_rate*100:.1f}%")
+    print(f"uuid survival rate        : {uuid_survival_rate*100:.1f}%")
+    if skews:
+        print(f"skew samples              : {len(skews)}")
+        print(f"skew min / max            : {min(skews):.3f} / {max(skews):.3f}")
+        print(f"skew mean / stdev         : {statistics.mean(skews):.3f} / {statistics.stdev(skews):.3f if len(skews) > 1 else 0:.3f}")
+        s = sorted(skews)
+        if len(s) >= 4:
+            p1 = s[max(0, int(0.01 * len(s)) - 1)]
+            p99 = s[min(len(s) - 1, int(0.99 * len(s)))]
+            print(f"skew p1 / p99            : {p1:.3f} / {p99:.3f}")
+        # Recommended tolerance per ChatGPT's Phase 0.5 formula: max(2.0, abs(p1) + safety_margin)
+        if skews:
+            min_abs = min(abs(x) for x in skews)
+            recommended = max(2.0, min_abs + 2.0)  # +2s safety margin
+            recommended = min(recommended, 10.0)  # cap
+            print(f"recommended SKEW_TOLERANCE: {recommended:.1f}s (capped at 10)")
+
+    # Save full rows.
+    with open("/tmp/a2_investigation_combined.json", "w") as f:
+        json.dump({"rows": rows, "num_samples": n,
+                   "stale_count": stale_count, "body_capture_rate": body_capture_rate,
+                   "uuid_survival_rate": uuid_survival_rate,
+                   "skews": skews}, f, indent=2, default=str)
+    print("\nfull rows saved to /tmp/a2_investigation_combined.json")
+
+
+if __name__ == "__main__":
+    import sys
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else NUM_SAMPLES
+    asyncio.run(main(n))

--- a/scripts/a2_phase1_followup_composer.py
+++ b/scripts/a2_phase1_followup_composer.py
@@ -1,0 +1,167 @@
+"""Phase 1 follow-up: can we observe the client message UUID BEFORE click_send?
+
+Hypothesis A: the pending message id is in the DOM (data-* attribute) before send.
+Hypothesis B: the pending message id is in React fiber state (per-prose form).
+Hypothesis C (preferred): capture the outgoing POST body via a temporary fetch
+            override installed just before click_send and removed right after.
+
+This script tests the cleanest non-invasive approach: install a temporary
+fetch wrapper via Runtime.addBinding / Runtime.evaluate that captures the POST
+body of /backend-api/f/conversation, fire a send through the bridge, then read
+what was captured. The wrapper is removed (restored to original fetch) before
+return.
+
+This does NOT mutate ChatGPT state — it only intercepts the outgoing request
+to read its body, then lets it proceed unchanged.
+"""
+import asyncio, json, urllib.request, time, websockets
+
+CDP = 9222
+BRIDGE = "http://127.0.0.1:8080"
+CONV = "6a48625b-34a4-83ed-93ba-a7153c2e6295"
+
+
+def list_targets():
+    return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{CDP}/json/list", timeout=3).read())
+
+
+# JS that installs a temporary capture wrapper around window.fetch.
+# It stores the original fetch, replaces it with a wrapper that clones the
+# /backend-api/f/conversation request and stashes its body, then re-installs
+# the original on demand via window.__restoreFetch().
+INSTALL_CAPTURE_JS = r"""
+(function() {
+  if (window.__a2Captured) { return 'already installed'; }
+  window.__a2Captured = null;
+  window.__restoreFetch = null;
+  var origFetch = window.fetch;
+  window.fetch = function(input, init) {
+    try {
+      var url = (typeof input === 'string') ? input : (input && input.url) || '';
+      if (url.indexOf('/backend-api/f/conversation') !== -1 && init && init.method === 'POST' && init.body) {
+        // body may be a string (JSON) or a ReadableStream; handle string case.
+        var bodyStr = (typeof init.body === 'string') ? init.body : null;
+        if (bodyStr) {
+          window.__a2Captured = bodyStr;
+        }
+      }
+    } catch(e) { window.__a2CapturedErr = String(e); }
+    return origFetch.apply(this, arguments);
+  };
+  window.__restoreFetch = function() {
+    window.fetch = origFetch;
+  };
+  return 'installed';
+})()
+"""
+
+
+READ_CAPTURED_JS = r"""
+(function() {
+  return JSON.stringify({
+    captured: window.__a2Captured || null,
+    error: window.__a2CapturedErr || null
+  });
+})()
+"""
+
+RESTORE_JS = r"""
+(function() {
+  if (window.__restoreFetch) { window.__restoreFetch(); window.__restoreFetch = null; }
+  return 'restored';
+})()
+"""
+
+
+async def main():
+    targets = list_targets()
+    tgt = next(t for t in targets if t["type"] == "page" and CONV in t.get("url", ""))
+    print(f"attached: {tgt['url'][:80]}")
+    ws_url = tgt["webSocketDebuggerUrl"]
+
+    async with websockets.connect(ws_url, max_size=None) as ws:
+        nxt = [0]
+        def nid():
+            nxt[0] += 1; return nxt[0]
+
+        async def evaluate(expr, timeout_ms=10000):
+            await ws.send(json.dumps({"id": nid(), "method": "Runtime.evaluate",
+                                      "params": {"expression": expr, "awaitPromise": False, "returnByValue": True, "timeout": timeout_ms}}))
+            while True:
+                r = json.loads(await ws.recv())
+                if r.get("id") == nxt[0]:
+                    return r
+
+        # 1. Install the capture wrapper
+        r = await evaluate(INSTALL_CAPTURE_JS)
+        install_result = r.get("result", {}).get("result", {}).get("value")
+        print(f"install: {install_result}")
+        if install_result != "installed":
+            print("FAILED to install capture wrapper")
+            return
+
+        # 2. Fire the bridge send
+        marker = f"FOLLOWUP-{int(time.time())}"
+        print(f"firing bridge send: marker={marker}")
+        body = json.dumps({"model": "auto", "conversation_id": CONV,
+                           "messages": [{"role": "user", "content": f"Reply with exactly: {marker}"}],
+                           "stream": False}).encode()
+        req = urllib.request.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                                     headers={"Content-Type": "application/json"})
+        t0 = time.time()
+        bridge_content = "<error>"
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                p = json.loads(resp.read())
+                bridge_content = p.get("choices", [{}])[0].get("message", {}).get("content", "")
+        except Exception as e:
+            bridge_content = f"<bridge error: {e}>"
+        print(f"bridge returned ({time.time()-t0:.1f}s): {bridge_content}")
+
+        # 3. Read what was captured
+        r = await evaluate(READ_CAPTURED_JS)
+        captured_json = r.get("result", {}).get("result", {}).get("value", "{}")
+        captured = json.loads(captured_json)
+
+        # 4. Restore original fetch immediately
+        r = await evaluate(RESTORE_JS)
+        print(f"restore: {r.get('result', {}).get('result', {}).get('value')}")
+
+    # 5. Analyze
+    print()
+    if captured.get("error"):
+        print(f"capture error: {captured['error']}")
+    if not captured.get("captured"):
+        print("VERDICT: no POST body captured — fetch override did not see the send.")
+        print("(The send may use XHR or a different fetch path than window.fetch.)")
+        return
+
+    body_str = captured["captured"]
+    print(f"captured POST body ({len(body_str)} chars):")
+    try:
+        parsed = json.loads(body_str)
+        msgs = parsed.get("messages") or []
+        if msgs:
+            client_id = msgs[0].get("id")
+            print(f"  messages[0].id (client UUID): {client_id}")
+            parts = (msgs[0].get("content") or {}).get("parts") or []
+            print(f"  messages[0].content.parts[0][:60]: {str(parts[0])[:60]!r}")
+            print(f"  conversation_id: {parsed.get('conversation_id')}")
+            print(f"  parent_message_id: {parsed.get('parent_message_id')}")
+            print(f"  model: {parsed.get('model')}")
+            print()
+            print("VERDICT: fetch-wrapper capture WORKS.")
+            print("The bridge can install a temporary fetch wrapper before click_send,")
+            print("read messages[0].id, restore fetch, and use that UUID for ID-based")
+            print("correlation against the backend mapping after completion.")
+            print()
+            print(f"Observed client UUID: {client_id}")
+        else:
+            print("  (no messages array in body)")
+            print(json.dumps(parsed, indent=2)[:1000])
+    except Exception as e:
+        print(f"  body parse failed: {e}")
+        print(f"  raw (first 800): {body_str[:800]}")
+
+
+asyncio.run(main())

--- a/scripts/a2_phase1_followup_xhr.py
+++ b/scripts/a2_phase1_followup_xhr.py
@@ -1,0 +1,164 @@
+"""Phase 1 follow-up v2: try XHR interception, AND test whether the send uses
+a fetch reference captured at module load (which our window.fetch override
+would miss).
+
+Approach: install BOTH an XHR send interceptor AND re-test by checking if the
+captured fetch wrapper even sees OTHER fetches (analytics calls) — if it sees
+those but not the send, the send uses a captured-reference fetch; if it sees
+nothing, our override technique is broken.
+
+The most reliable technique regardless of transport: CDP Network domain
+capture (Fetch.enable + Fetch.requestPaused). That lets us pause the actual
+network request and read its body before letting it proceed. This script
+tests the CDP Fetch API approach.
+"""
+import asyncio, json, urllib.request, time, websockets
+
+CDP = 9222
+BRIDGE = "http://127.0.0.1:8080"
+CONV = "6a48625b-34a4-83ed-93ba-a7153c2e6295"
+
+
+def list_targets():
+    return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{CDP}/json/list", timeout=3).read())
+
+
+async def main():
+    targets = list_targets()
+    # Try multiple targets — the bridge may drive a different one than the visible conv URL.
+    candidate_targets = [t for t in targets if t.get("type") == "page" and "chatgpt.com" in t.get("url", "")]
+    print(f"will try CDP Fetch.pause on {len(candidate_targets)} targets (one at a time)")
+
+    marker = f"FETCHCAP-{int(time.time())}"
+
+    for tgt in candidate_targets:
+        url_short = tgt.get("url", "")[:70]
+        print(f"\n=== trying target: {url_short} ===")
+        captured = await try_fetch_pause_on_target(tgt["webSocketDebuggerUrl"], marker)
+        if captured:
+            print(f"\nSUCCESS on target {url_short}")
+            print(f"captured POST body ({len(captured)} chars):")
+            try:
+                parsed = json.loads(captured)
+                msgs = parsed.get("messages") or []
+                if msgs:
+                    print(f"  messages[0].id = {msgs[0].get('id')}")
+                    print(f"  conversation_id = {parsed.get('conversation_id')}")
+                    parts = (msgs[0].get("content") or {}).get("parts") or []
+                    print(f"  parts[0][:80] = {str(parts[0])[:80]!r}")
+                else:
+                    print(f"  (no messages; keys: {list(parsed.keys())[:8]})")
+            except Exception as e:
+                print(f"  parse error: {e}")
+                print(f"  raw[:600]: {captured[:600]}")
+            return
+        else:
+            print(f"  no /f/conversation POST paused on this target")
+
+    print("\nVERDICT: CDP Fetch.pause did not intercept the send on any target.")
+    print("The send may go through a service worker, or the bridge's target was not in the list.")
+
+
+async def try_fetch_pause_on_target(ws_url: str, marker: str) -> str | None:
+    """Enable Fetch domain with requestPaused for /backend-api/f/conversation.
+    Fire one bridge send; capture and release the paused request body."""
+    async with websockets.connect(ws_url, max_size=None, close_timeout=5) as ws:
+        nxt = [0]
+        def nid():
+            nxt[0] += 1; return nxt[0]
+
+        # Enable Fetch with a URL pattern filter for the send endpoint.
+        # stages: Request — pause at request stage so we can read postData.
+        await ws.send(json.dumps({
+            "id": nid(), "method": "Fetch.enable",
+            "params": {
+                "patterns": [{"urlPattern": "*/backend-api/f/conversation*", "requestStage": "Request"}],
+            }
+        }))
+        # Wait for enable ACK
+        while True:
+            r = json.loads(await asyncio.wait_for(ws.recv(), timeout=3))
+            if r.get("id"):
+                break
+        enabled = "result" in r
+        if not enabled:
+            print(f"  Fetch.enable failed: {r}")
+            return None
+
+        # Fire the bridge send in a background task.
+        async def fire_send():
+            body = json.dumps({"model": "auto", "conversation_id": CONV,
+                               "messages": [{"role": "user", "content": f"Reply with exactly: {marker}"}],
+                               "stream": False}).encode()
+            req = urllib.request.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                                         headers={"Content-Type": "application/json"})
+            try:
+                with urllib.request.urlopen(req, timeout=120) as resp:
+                    p = json.loads(resp.read())
+                    return p.get("choices", [{}])[0].get("message", {}).get("content", "")
+            except Exception as e:
+                return f"<err: {e}>"
+
+        send_task = asyncio.create_task(fire_send())
+
+        # Listen for Fetch.requestPaused events.
+        captured_body = None
+        deadline = time.time() + 90
+        while time.time() < deadline:
+            try:
+                raw = await asyncio.wait_for(ws.recv(), timeout=1.0)
+            except asyncio.TimeoutError:
+                if send_task.done():
+                    break
+                continue
+            r = json.loads(raw)
+            if r.get("method") == "Fetch.requestPaused":
+                params = r.get("params", {})
+                rid = params.get("requestId")
+                req = params.get("request", {})
+                url = req.get("url", "")
+                print(f"  requestPaused: {req.get('method')} {url[:80]}")
+                if req.get("method") == "POST" and "/f/conversation" in url:
+                    # Get the post data via Fetch.getResponseBody for requests? No —
+                    # for request-stage, postData is in the request object OR we call
+                    # Fetch.takeResponseBodyAsStream. Actually for requestStage=Request,
+                    # the postData is in params.request.postData if hasPostData.
+                    pd = req.get("postData")
+                    if not pd and req.get("hasPostData"):
+                        # Need Fetch.getRequestPostData
+                        await ws.send(json.dumps({"id": nid(), "method": "Fetch.getRequestPostData",
+                                                  "params": {"requestId": rid}}))
+                        # Continue listening; the response will come as an id-matched reply.
+                        # For now, just allow the request to proceed.
+                    if pd:
+                        captured_body = pd
+                    # Allow the request to proceed regardless (so the send completes).
+                    await ws.send(json.dumps({"id": nid(), "method": "Fetch.continueRequest",
+                                              "params": {"requestId": rid}}))
+                    if captured_body:
+                        break
+                else:
+                    # Not our target; allow to proceed.
+                    await ws.send(json.dumps({"id": nid(), "method": "Fetch.continueRequest",
+                                              "params": {"requestId": rid}}))
+            elif r.get("id") and r.get("result", {}).get("postData") and not captured_body:
+                # Response to getRequestPostData
+                captured_body = r["result"]["postData"]
+
+        # Disable Fetch domain to stop pausing requests.
+        try:
+            await ws.send(json.dumps({"id": nid(), "method": "Fetch.disable"}))
+        except Exception:
+            pass
+
+        # Wait for the send to complete (it may have been blocked while paused).
+        try:
+            content = await asyncio.wait_for(send_task, timeout=60)
+            print(f"  bridge returned: {content}")
+        except asyncio.TimeoutError:
+            print(f"  bridge send timed out after Fetch pause")
+
+        return captured_body
+
+
+asyncio.run(main())

--- a/scripts/a2_phase1_id_survival.py
+++ b/scripts/a2_phase1_id_survival.py
@@ -1,0 +1,135 @@
+"""Phase 1 verdict: does the client-generated message UUID from the
+/backend-api/f/conversation POST body survive into the backend mapping?"""
+import asyncio, json, urllib.request, websockets
+
+CDP = 9222
+CONV = "6a48625b-34a4-83ed-93ba-a7153c2e6295"
+CLIENT_MSG_ID = "1596fd21-7868-4e38-8f49-be7ae7cb457a"  # from captured POST body
+
+
+def list_targets():
+    return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{CDP}/json/list", timeout=3).read())
+
+
+async def main():
+    targets = list_targets()
+    tgt = next(t for t in targets if t["type"] == "page" and CONV in t.get("url", ""))
+    print(f"attached: {tgt['url'][:80]}")
+
+    async with websockets.connect(tgt["webSocketDebuggerUrl"], max_size=None) as ws:
+        # Get token
+        token_expr = (
+            '(async()=>{var r=await fetch("/api/auth/session");'
+            'var j=await r.json();return j.accessToken||""})()'
+        )
+        await ws.send(json.dumps({"id": 1, "method": "Runtime.evaluate",
+                                  "params": {"expression": token_expr, "awaitPromise": True, "returnByValue": True}}))
+        token = ""
+        while True:
+            r = json.loads(await ws.recv())
+            if r.get("id") == 1:
+                token = r["result"]["result"]["value"]
+                break
+
+        # Build the fetch JS with placeholder tokens (avoids brace-escaping issues)
+        fetch_js = (
+            "(async()=>{"
+            "var r=await fetch('/backend-api/conversation/' + __CONV__ + '?offset=0&limit=50',"
+            "{headers:{'Authorization':'Bearer ' + __TOKEN__}});"
+            "if(!r.ok) return JSON.stringify({__status:r.status});"
+            "var j=await r.json();return JSON.stringify(j)"
+            "})()"
+        ).replace("__CONV__", json.dumps(CONV)).replace("__TOKEN__", json.dumps(token))
+
+        await ws.send(json.dumps({"id": 2, "method": "Runtime.evaluate",
+                                  "params": {"expression": fetch_js, "awaitPromise": True, "returnByValue": True, "timeout": 20000}}))
+        mapping = None
+        while True:
+            r = json.loads(await ws.recv())
+            if r.get("id") == 2:
+                result = r.get("result", {})
+                if "exceptionDetails" in result:
+                    print(f"JS threw: {result['exceptionDetails']}")
+                    print(f"expression was:\n{fetch_js}")
+                    return
+                val = result.get("result", {}).get("value")
+                if val is None:
+                    print(f"no value returned. full result: {json.dumps(result, default=str)[:500]}")
+                    return
+                mapping = json.loads(val)
+                break
+
+    m = mapping.get("mapping", {})
+    print(f"mapping node count: {len(m)}")
+    print(f"searching for CLIENT_MSG_ID: {CLIENT_MSG_ID}")
+    print()
+
+    found_node = None
+    for nid, node in m.items():
+        if CLIENT_MSG_ID in str(node):
+            found_node = (nid, node)
+            break
+
+    if found_node:
+        nid, node = found_node
+        msg = node.get("message") or {}
+        print(f"*** CLIENT_MSG_ID FOUND in mapping node {nid} ***")
+        print(f"  mapping_key (nid)   : {nid}")
+        print(f"  message.id          : {msg.get('id')}")
+        print(f"  author.role         : {(msg.get('author') or {}).get('role')}")
+        print(f"  create_time         : {msg.get('create_time')}")
+        print(f"  end_turn            : {msg.get('end_turn')}")
+        print()
+        # CRITICAL: where exactly does CLIENT_MSG_ID appear in this node?
+        # Search every field for the ID to understand the linkage.
+        print("  Fields containing CLIENT_MSG_ID:")
+        def find_id(obj, path=""):
+            hits = []
+            if isinstance(obj, dict):
+                for k, v in obj.items():
+                    hits.extend(find_id(v, f"{path}.{k}"))
+            elif isinstance(obj, list):
+                for i, v in enumerate(obj):
+                    hits.extend(find_id(v, f"{path}[{i}]"))
+            elif isinstance(obj, str) and CLIENT_MSG_ID in obj:
+                hits.append((path, obj[:80]))
+            return hits
+        for path, val in find_id(node):
+            print(f"    {path} = {val!r}")
+        print()
+        # Also check: is there a USER node whose message.id == CLIENT_MSG_ID?
+        user_match = None
+        for nid2, node2 in m.items():
+            msg2 = node2.get("message") or {}
+            if (msg2.get("author") or {}).get("role") == "user" and msg2.get("id") == CLIENT_MSG_ID:
+                user_match = nid2
+                break
+        if user_match:
+            print(f"  USER node with message.id == CLIENT_MSG_ID: {user_match}")
+            print("VERDICT: STRONG SUCCESS — user node's message.id == client UUID.")
+            print("A2 can correlate the user turn by observed client UUID directly.")
+        else:
+            print(f"  No USER node has message.id == CLIENT_MSG_ID.")
+            print(f"  The client UUID appears as a parent_message_id / linkage field,")
+            print(f"  NOT as a user node's primary id.")
+            print()
+            print("VERDICT: PARTIAL SUCCESS — client UUID survives as a linkage reference")
+            print("(parent_message_id of the assistant response), not as the user node's id.")
+            print("A2 can still use it: find the assistant node whose parent_message_id matches")
+            print("the observed client UUID — that IS the correlated assistant response.")
+    else:
+        print("CLIENT_MSG_ID NOT FOUND in mapping.")
+        print()
+        print("All user nodes in mapping:")
+        for nid, node in m.items():
+            msg = node.get("message") or {}
+            if (msg.get("author") or {}).get("role") == "user":
+                ct = msg.get("create_time")
+                parts = (msg.get("content") or {}).get("parts") or []
+                txt = "\n".join(str(p) for p in parts if isinstance(p, str))[:60]
+                print(f"  mapping_key={nid!r}  msg.id={msg.get('id')!r}  ct={ct}  text={txt!r}")
+        print()
+        print("VERDICT: FAILURE — UUID does not survive. Dual-anchor remains primary.")
+
+
+asyncio.run(main())

--- a/scripts/a2_phase3_a11y_oracle.py
+++ b/scripts/a2_phase3_a11y_oracle.py
@@ -1,0 +1,178 @@
+"""Phase 3 spike: accessibility-tree completion oracle.
+
+Question: can the a11y tree provide a more stable completion signal than the
+current DOM heuristics (html_len > 50, has_action)?
+
+Method:
+  1. Attach to the ChatGPT tab.
+  2. Take a baseline a11y snapshot when NO generation is in flight.
+  3. Fire a bridge send.
+  4. Take a11y snapshots DURING generation (every ~1s) and AFTER completion.
+  5. Compare: do any a11y nodes/roles/states reliably indicate
+     "generating" vs "done"?
+
+This spike does NOT modify A2's design. It informs whether a future
+completion-oracle workstream is viable.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import urllib.request
+
+import websockets
+
+CDP = 9222
+BRIDGE = "http://127.0.0.1:8080"
+CONV = "6a48625b-34a4-83ed-93ba-a7153c2e6295"
+
+
+def list_targets():
+    return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{CDP}/json/list", timeout=3).read())
+
+
+def find_target():
+    targets = list_targets()
+    for t in targets:
+        if t.get("type") == "page" and CONV in t.get("url", ""):
+            return t
+    for t in targets:
+        if t.get("type") == "page" and "chatgpt.com/c/" in t.get("url", ""):
+            return t
+    raise RuntimeError("no chatgpt target")
+
+
+async def get_a11y_tree(ws, nxt):
+    """Capture the accessibility tree via CDP Accessibility.getFullAXTree."""
+    my_id = nxt[0] + 1
+    nxt[0] = my_id
+    await ws.send(json.dumps({"id": my_id, "method": "Accessibility.getFullAXTree"}))
+    while True:
+        r = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+        if r.get("id") == my_id:
+            return r.get("result", {}).get("nodes", [])
+
+
+def summarize_a11y(nodes):
+    """Reduce a full a11y tree to a compact summary focused on completion signals."""
+    # Count roles, look for live regions, "generating"/"loading" states,
+    # and any node whose value/description mentions generation.
+    role_counts = {}
+    live_regions = []
+    gen_markers = []
+    action_markers = []
+    for n in nodes:
+        role = n.get("role", {}).get("value", "?")
+        role_counts[role] = role_counts.get(role, 0) + 1
+        # Live regions (polite/assertive) are the standard a11y "streaming" signal.
+        props = {p.get("name", ""): p.get("value", {}).get("value") for p in n.get("properties", [])}
+        if props.get("live") in ("polite", "assertive"):
+            live_regions.append({
+                "role": role,
+                "name": (n.get("name") or {}).get("value", "")[:60],
+                "live": props.get("live"),
+            })
+        # Look for explicit generation/loading/done markers in name/description/value.
+        name_val = (n.get("name") or {}).get("value", "") or ""
+        desc_val = (n.get("description") or {}).get("value", "") or ""
+        value_val = (n.get("value") or {}).get("value", "") or ""
+        combined = f"{name_val} {desc_val} {value_val}".lower()
+        if any(k in combined for k in ("generating", "streaming", "thinking", "loading", "stop generating", "screenshot")):
+            gen_markers.append({"role": role, "name": name_val[:60], "desc": desc_val[:60]})
+        if any(k in combined for k in ("copy", "regenerate", "edit", "good response", "bad response")):
+            action_markers.append({"role": role, "name": name_val[:60]})
+    return {
+        "node_count": len(nodes),
+        "role_counts_top10": dict(sorted(role_counts.items(), key=lambda x: -x[1])[:10]),
+        "live_region_count": len(live_regions),
+        "live_regions_sample": live_regions[:5],
+        "gen_markers": gen_markers[:8],
+        "action_markers_count": len(action_markers),
+        "action_markers_sample": action_markers[:5],
+    }
+
+
+async def main():
+    target = find_target()
+    print(f"target: {target['url'][:80]}")
+    ws_url = target["webSocketDebuggerUrl"]
+
+    async with websockets.connect(ws_url, max_size=None) as ws:
+        nxt = [0]
+
+        # Enable Accessibility domain
+        nxt[0] += 1
+        await ws.send(json.dumps({"id": nxt[0], "method": "Accessibility.enable"}))
+        while True:
+            r = json.loads(await asyncio.wait_for(ws.recv(), timeout=5))
+            if r.get("id"):
+                break
+
+        print("\n=== BASELINE (no generation in flight) ===")
+        baseline_nodes = await get_a11y_tree(ws, nxt)
+        baseline_summary = summarize_a11y(baseline_nodes)
+        print(json.dumps(baseline_summary, indent=2, default=str)[:1200])
+
+        # Fire send and sample during generation
+        marker = f"A11Y-{int(time.time())}"
+        print(f"\n=== FIRING SEND: {marker} ===")
+        body = json.dumps({"model": "auto", "conversation_id": CONV,
+                           "messages": [{"role": "user", "content": f"Write a 4-sentence paragraph about oceans. Then stop. Marker: {marker}"}],
+                           "stream": False}).encode()
+        req = urllib.request.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                                     headers={"Content-Type": "application/json"})
+        send_task = asyncio.create_task(asyncio.to_thread(urllib.request.urlopen, req, timeout=120))
+
+        # Sample during generation
+        during_summaries = []
+        for sample_i in range(1, 6):
+            await asyncio.sleep(1.0)
+            try:
+                nodes = await get_a11y_tree(ws, nxt)
+                s = summarize_a11y(nodes)
+                s["sample"] = sample_i
+                during_summaries.append(s)
+                print(f"\n--- DURING sample {sample_i} (t+{sample_i}s) ---")
+                print(f"  nodes={s['node_count']}  live_regions={s['live_region_count']}  "
+                      f"gen_markers={len(s['gen_markers'])}  action_markers={s['action_markers_count']}")
+                if s["gen_markers"]:
+                    for g in s["gen_markers"][:3]:
+                        print(f"    gen: role={g['role']} name={g['name']!r}")
+            except Exception as e:
+                print(f"  sample {sample_i} failed: {e}")
+
+        # Wait for send to complete
+        try:
+            resp = await asyncio.wait_for(send_task, timeout=90)
+            p = json.loads(resp.read())
+            content = p.get("choices", [{}])[0].get("message", {}).get("content", "")[:60]
+            print(f"\nbridge returned: {content!r}")
+        except Exception as e:
+            print(f"\nbridge error: {e}")
+
+        print("\n=== AFTER COMPLETION ===")
+        await asyncio.sleep(1.0)
+        after_nodes = await get_a11y_tree(ws, nxt)
+        after_summary = summarize_a11y(after_nodes)
+        print(json.dumps(after_summary, indent=2, default=str)[:1200])
+
+        # Diff baseline vs after for node count and role changes
+        print("\n=== DIFF baseline → after ===")
+        print(f"node count: {baseline_summary['node_count']} → {after_summary['node_count']}")
+        for role, count in after_summary["role_counts_top10"].items():
+            bc = baseline_summary["role_counts_top10"].get(role, 0)
+            if count != bc:
+                print(f"  {role}: {bc} → {count}")
+
+        # Compare action_markers (should appear after completion)
+        print(f"\naction_markers: baseline={baseline_summary['action_markers_count']} "
+              f"during(last)={during_summaries[-1]['action_markers_count'] if during_summaries else '?'} "
+              f"after={after_summary['action_markers_count']}")
+        if after_summary["action_markers_sample"]:
+            print("after action markers:")
+            for a in after_summary["action_markers_sample"]:
+                print(f"  role={a['role']} name={a['name']!r}")
+
+
+asyncio.run(main())

--- a/scripts/a2_stress4_clean.py
+++ b/scripts/a2_stress4_clean.py
@@ -1,0 +1,238 @@
+"""Stress test 4 v3: clean skew measurement on a fresh conversation.
+
+The polluted conversation (30+ stale markers) produced wild skew variance.
+This version creates a fresh conversation and measures skew there, to determine
+whether the +5.1s tight cluster from Phase 0.5 was real or an artifact.
+
+Also handles websocket keepalive by reconnecting per-batch instead of holding
+one connection across long sleeps.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import statistics
+import time
+import urllib.request
+
+import websockets
+
+CDP = 9222
+BRIDGE = "http://127.0.0.1:8080"
+
+
+def list_targets():
+    return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{CDP}/json/list", timeout=3).read())
+
+
+def find_target_for_conv(conv_id):
+    targets = list_targets()
+    for t in targets:
+        if t.get("type") == "page" and conv_id and conv_id in t.get("url", ""):
+            return t
+    for t in targets:
+        if t.get("type") == "page" and "chatgpt.com/c/" in t.get("url", ""):
+            return t
+    raise RuntimeError("no target")
+
+
+def bridge_send_fresh(prompt: str) -> dict:
+    """Fresh-chat send (no conversation_id) — creates a new conversation."""
+    body = json.dumps({
+        "model": "auto",
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+    }).encode()
+    req = urllib.request.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=180) as r:
+            p = json.loads(r.read())
+            return {"ok": True, "latency": round(time.time() - t0, 2),
+                    "content": p.get("choices", [{}])[0].get("message", {}).get("content", "")[:60],
+                    "conversation_id": p.get("conversation_id", "")}
+    except Exception as e:
+        return {"ok": False, "latency": round(time.time() - t0, 2), "error": str(e)}
+
+
+def bridge_send_to_conv(prompt: str, conv_id: str) -> dict:
+    """Send to a specific conversation."""
+    body = json.dumps({
+        "model": "auto", "conversation_id": conv_id,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+    }).encode()
+    req = urllib.request.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=120) as r:
+            p = json.loads(r.read())
+            return {"ok": True, "latency": round(time.time() - t0, 2),
+                    "content": p.get("choices", [{}])[0].get("message", {}).get("content", "")[:60]}
+    except Exception as e:
+        return {"ok": False, "latency": round(time.time() - t0, 2), "error": str(e)}
+
+
+async def measure_skews_on_conv(conv_id: str, n: int = 8) -> list:
+    """Run n instrumented sends on conv_id, capturing skew + uuid survival.
+    Uses a fresh websocket per measurement to avoid keepalive issues."""
+    target = find_target_for_conv(conv_id)
+    ws_url = target["webSocketDebuggerUrl"]
+    results = []
+
+    # One persistent connection for the whole batch (batch is short, ~2-3 min)
+    async with websockets.connect(ws_url, max_size=None, ping_interval=20, ping_timeout=60) as ws:
+        nxt = [0]
+        def nid():
+            nxt[0] += 1; return nxt[0]
+
+        await ws.send(json.dumps({"id": nid(), "method": "Network.enable",
+                                  "params": {"maxPostDataSize": 4 * 1024 * 1024}}))
+        while True:
+            r = json.loads(await asyncio.wait_for(ws.recv(), timeout=5))
+            if r.get("id"):
+                break
+
+        async def evaluate(expr, timeout_ms=15000):
+            my_id = nid()
+            await ws.send(json.dumps({"id": my_id, "method": "Runtime.evaluate",
+                                      "params": {"expression": expr, "awaitPromise": True,
+                                                 "returnByValue": True, "timeout": timeout_ms}}))
+            while True:
+                r = json.loads(await ws.recv())
+                if r.get("id") == my_id:
+                    return r
+
+        # Token (once)
+        token_resp = await evaluate(
+            '(async()=>{var r=await fetch("/api/auth/session");var j=await r.json();return j.accessToken||""})()',
+            timeout_ms=10000)
+        token = token_resp.get("result", {}).get("result", {}).get("value", "")
+
+        for i in range(1, n + 1):
+            marker = f"S4V3-{i}-{int(time.time())}"
+            # Drain
+            while True:
+                try:
+                    _ = await asyncio.wait_for(ws.recv(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    break
+
+            t_pre_wall = time.time()
+            send_task = asyncio.create_task(asyncio.to_thread(bridge_send_to_conv, f"Reply with exactly: {marker}", conv_id))
+
+            captured_uuid = None
+            deadline = time.time() + 120
+            while time.time() < deadline:
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=0.3)
+                except asyncio.TimeoutError:
+                    if send_task.done() and time.time() > t_pre_wall + 8:
+                        break
+                    continue
+                r = json.loads(raw)
+                if r.get("method") == "Network.requestWillBeSent":
+                    req_obj = (r.get("params") or {}).get("request", {}) or {}
+                    url = req_obj.get("url", "")
+                    if req_obj.get("method") == "POST" and url.rstrip("/").endswith("/f/conversation"):
+                        pd = req_obj.get("postData")
+                        if pd:
+                            try:
+                                parsed = json.loads(pd)
+                                msgs = parsed.get("messages") or []
+                                if msgs and msgs[0].get("id"):
+                                    captured_uuid = msgs[0]["id"]
+                            except Exception:
+                                pass
+
+            try:
+                sr = await asyncio.wait_for(send_task, timeout=60)
+                content = sr.get("content", "")
+            except Exception as e:
+                content = f"<err: {e}>"
+
+            # Fetch mapping
+            await asyncio.sleep(1.0)
+            fetch_js = (
+                "(async()=>{var r=await fetch('/backend-api/conversation/' + __C__ + '?offset=0&limit=50',"
+                "{headers:{'Authorization':'Bearer ' + __T__}});"
+                "if(!r.ok) return JSON.stringify({__status:r.status});"
+                "var j=await r.json();return JSON.stringify(j)})()"
+            ).replace("__C__", json.dumps(conv_id)).replace("__T__", json.dumps(token))
+            map_resp = await evaluate(fetch_js, timeout_ms=20000)
+            map_val = map_resp.get("result", {}).get("result", {}).get("value", "")
+            mapping = json.loads(map_val) if map_val else {}
+            m = mapping.get("mapping", {}) if isinstance(mapping, dict) else {}
+
+            latest_user_ct = None
+            latest_user_id = None
+            best_t = -1
+            for _nid, node in m.items():
+                msg = node.get("message") or {}
+                if (msg.get("author") or {}).get("role") == "user":
+                    ct = msg.get("create_time") or 0
+                    if ct > best_t:
+                        best_t = ct
+                        latest_user_ct = ct
+                        latest_user_id = msg.get("id")
+
+            skew = (latest_user_ct - t_pre_wall) if latest_user_ct else None
+            uuid_survived = (captured_uuid == latest_user_id) if (captured_uuid and latest_user_id) else None
+            results.append({
+                "i": i, "marker": marker,
+                "skew": round(skew, 3) if skew is not None else None,
+                "uuid_captured": bool(captured_uuid),
+                "uuid_survived": uuid_survived,
+                "stale": content != marker,
+                "content": content[:40],
+                "latency": sr.get("latency") if isinstance(sr, dict) else None,
+            })
+            skew_str = f"{skew:.3f}" if skew is not None else "N/A"
+            lat_str = str(sr.get('latency','?')) if isinstance(sr, dict) else '?'
+            print(f"  {i}: skew={skew_str}  cap={'Y' if captured_uuid else 'N'}  "
+                  f"surv={'Y' if uuid_survived else 'N'}  stale={'Y' if content != marker else 'N'}  "
+                  f"lat={lat_str}")
+            await asyncio.sleep(3.0)
+
+    return results
+
+
+async def main():
+    print("=== Stress test 4 v3: clean skew on fresh conversation ===")
+    print("\nStep 1: create a fresh conversation with one send...")
+    init = bridge_send_fresh("Reply with exactly: INIT-FRESH-CONV")
+    print(f"  fresh conv: {init.get('conversation_id','?')} (ok={init.get('ok')})")
+    conv_id = init.get("conversation_id", "")
+    if not conv_id:
+        print("FAILED to create fresh conversation")
+        return
+
+    print(f"\nStep 2: measure 8 skews on fresh conv {conv_id}...")
+    b1 = await measure_skews_on_conv(conv_id, n=8)
+
+    skews = [r["skew"] for r in b1 if r["skew"] is not None]
+    print(f"\n=== Batch results ===")
+    if skews:
+        print(f"n={len(skews)}  min={min(skews):.3f}  max={max(skews):.3f}  "
+              f"mean={statistics.mean(skews):.3f}  std={statistics.stdev(skews) if len(skews)>1 else 0:.3f}")
+        neg = [s for s in skews if s < 0]
+        print(f"negative: {len(neg)}")
+        if len(neg) == 0 and statistics.stdev(skews) < 1.0:
+            print("VERDICT: skew stable on fresh conversation — Phase 0.5 finding holds.")
+        else:
+            print(f"VERDICT: skew variance (std={statistics.stdev(skews):.3f}) differs from Phase 0.5 (0.083s).")
+
+    import os
+    out_path = os.path.join(os.environ.get("TEMP", "/tmp"), "a2_stress4_v3_clean.json")
+    with open(out_path, "w") as f:
+        json.dump({"conv_id": conv_id, "batch": b1,
+                   "skews": skews,
+                   "mean": statistics.mean(skews) if skews else None,
+                   "stdev": statistics.stdev(skews) if len(skews) > 1 else None}, f, indent=2, default=str)
+    print(f"\nsaved: {out_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/a2_stress_test_1_tool_use.py
+++ b/scripts/a2_stress_test_1_tool_use.py
@@ -1,0 +1,173 @@
+"""Stress test 1+3 combined: tool-use send on a FRESH chat.
+
+Two birds with one stone:
+  - Stress test 1: capture the POST body for a tool-using send; verify messages[0].id
+    present in the same shape as plain-text sends.
+  - Stress test 3: this is a fresh chat (no conversation_id); verify the persistent
+    Network listener captures the POST before/independent of any per-send scope.
+
+Method:
+  - Attach Network domain to ALL chatgpt targets (persistent listener).
+  - Fire a fresh-chat tool-use send via the bridge (no conversation_id).
+  - Capture any /backend-api/f/conversation POST; record body shape.
+  - After completion, find the new conversation, fetch its mapping, check whether
+    the captured UUID survived as user node message.id.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import urllib.request
+
+import websockets
+
+CDP = 9222
+BRIDGE = "http://127.0.0.1:8080"
+
+
+def list_targets():
+    return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{CDP}/json/list", timeout=3).read())
+
+
+async def bridge_fresh_chat_send(prompt: str) -> dict:
+    """Send WITHOUT conversation_id — fresh chat path."""
+    body = json.dumps({
+        "model": "auto",
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+    }).encode()
+    req = urllib.request.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=180) as r:
+            p = json.loads(r.read())
+            return {
+                "ok": True,
+                "latency": round(time.time() - t0, 2),
+                "content": p.get("choices", [{}])[0].get("message", {}).get("content", "")[:400],
+                "conversation_id": p.get("conversation_id", ""),
+            }
+    except Exception as e:
+        return {"ok": False, "latency": round(time.time() - t0, 2), "error": str(e)}
+
+
+async def main():
+    targets = [t for t in list_targets() if t.get("type") == "page" and "chatgpt.com" in t.get("url", "")]
+    print(f"persistent Network listener on {len(targets)} targets")
+
+    captured_posts: list[dict] = []
+
+    async def watch(t):
+        async with websockets.connect(t["webSocketDebuggerUrl"], max_size=None, close_timeout=5) as ws:
+            await ws.send(json.dumps({"id": 1, "method": "Network.enable",
+                                      "params": {"maxPostDataSize": 4 * 1024 * 1024}}))
+            # wait for ACK
+            while True:
+                r = json.loads(await asyncio.wait_for(ws.recv(), timeout=3))
+                if r.get("id"):
+                    break
+            while True:
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=0.5)
+                except asyncio.TimeoutError:
+                    continue
+                r = json.loads(raw)
+                m = r.get("method", "")
+                if m != "Network.requestWillBeSent":
+                    continue
+                req = (r.get("params") or {}).get("request", {}) or {}
+                url = req.get("url", "")
+                if req.get("method") == "POST" and "/backend-api/f/conversation" in url:
+                    captured_posts.append({
+                        "target": t.get("url", "")[:60],
+                        "url": url,
+                        "post_data": req.get("postData"),
+                        "has_post_data": req.get("hasPostData"),
+                        "request_id": (r.get("params") or {}).get("requestId"),
+                    })
+
+    tasks = [asyncio.create_task(watch(t)) for t in targets]
+    await asyncio.sleep(1.5)
+
+    # Tool-use prompt that should trigger web search.
+    prompt = "Search the web for the current Bitcoin price in USD, then tell me the price."
+    print(f"\nfiring FRESH-CHAT tool-use send:\n  prompt: {prompt!r}")
+    result = await bridge_fresh_chat_send(prompt)
+    print(f"\nbridge returned ({result.get('latency')}s):")
+    print(f"  ok: {result.get('ok')}")
+    print(f"  conversation_id: {result.get('conversation_id')}")
+    content = result.get("content", "")
+    print(f"  content[:300]: {content[:300]!r}")
+    if "bitcoin" in content.lower() or "$" in content or "BTC" in content:
+        print("  -> looks like the tool actually ran (price mentioned)")
+    else:
+        print("  -> content does not mention a price; tool may not have fired, or stale return")
+
+    await asyncio.sleep(2.0)
+    for t in tasks:
+        t.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Filter to the actual send (not /prepare)
+    send_posts = [p for p in captured_posts
+                  if p["url"].rstrip("/").endswith("/f/conversation") and p.get("post_data")]
+    print(f"\n=== {len(send_posts)} send POST(s) captured (excludes /prepare) ===")
+
+    for i, p in enumerate(send_posts):
+        print(f"\n--- send POST {i+1} ---")
+        print(f"target: {p['target']}")
+        print(f"url: {p['url']}")
+        pd = p.get("post_data") or ""
+        print(f"post_data length: {len(pd)} chars")
+        try:
+            parsed = json.loads(pd)
+            msgs = parsed.get("messages") or []
+            print(f"action: {parsed.get('action')}")
+            print(f"conversation_id in body: {parsed.get('conversation_id')}")
+            print(f"model: {parsed.get('model')}")
+            if msgs:
+                m0 = msgs[0]
+                print(f"\nmessages[0].id: {m0.get('id')}")
+                print(f"messages[0].author.role: {(m0.get('author') or {}).get('role')}")
+                ct = (m0.get('content') or {})
+                print(f"messages[0].content.content_type: {ct.get('content_type')}")
+                parts = ct.get("parts") or []
+                print(f"messages[0].content.parts[0][:80]: {str(parts[0] if parts else '')[:80]!r}")
+                # Tool-use specific: check for extra fields
+                print(f"\nmessages[0] ALL keys: {list(m0.keys())}")
+                metadata = m0.get("metadata") or {}
+                if metadata:
+                    print(f"messages[0].metadata keys: {list(metadata.keys())}")
+                    if "serialization_metadata" in metadata:
+                        print("  (has serialization_metadata — same as plain-text)")
+                # Top-level extra fields that might indicate tool context
+                top_extras = {k: v for k, v in parsed.items()
+                              if k not in ("action", "messages", "conversation_id",
+                                           "parent_message_id", "model", "timezone",
+                                           "timezone_offset_min")}
+                if top_extras:
+                    print(f"\ntop-level EXTRA fields (vs plain-text shape):")
+                    for k, v in top_extras.items():
+                        print(f"  {k}: {str(v)[:120]}")
+                else:
+                    print("\nno top-level extra fields — same shape as plain-text send")
+            else:
+                print("NO messages array in body")
+                print(f"body keys: {list(parsed.keys())}")
+                print(f"body[:600]: {pd[:600]}")
+        except Exception as e:
+            print(f"  parse failed: {e}")
+            print(f"  raw[:600]: {pd[:600]}")
+
+    # Save full
+    import os
+    out_path = os.path.join(os.environ.get("TEMP", "/tmp"), "a2_stress1_tool_use_posts.json")
+    with open(out_path, "w") as f:
+        json.dump({"result": result, "captured_posts": captured_posts}, f, indent=2, default=str)
+    print(f"\nsaved: {out_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/a2_stress_test_2_direct_fetch.py
+++ b/scripts/a2_stress_test_2_direct_fetch.py
@@ -1,0 +1,160 @@
+"""Stress test 2 v2: postData truncation — direct fetch injection.
+
+The bridge can't type prompts >~2KB without timing out. To test whether CDP
+truncates the *captured* postData for large request bodies, inject a large
+fetch directly via Runtime.evaluate (bypassing the bridge). This lets us
+control the exact body size and observe what Network.requestWillBeSent reports.
+
+We don't actually want to send a real message — we want to observe the
+reporting behavior. So we send to a benign endpoint that accepts large POSTs
+and observe the CDP-reported postData length vs the actual length we sent.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.request
+
+import websockets
+
+CDP = 9222
+
+
+def list_targets():
+    return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{CDP}/json/list", timeout=3).read())
+
+
+def find_target():
+    targets = list_targets()
+    for t in targets:
+        if t.get("type") == "page" and "chatgpt.com" in t.get("url", ""):
+            return t
+    raise RuntimeError("no target")
+
+
+async def main():
+    target = find_target()
+    print(f"target: {target['url'][:80]}")
+    ws_url = target["webSocketDebuggerUrl"]
+
+    # Body sizes to test (bytes)
+    sizes = [1024, 10_000, 100_000, 500_000, 2_000_000]
+
+    async with websockets.connect(ws_url, max_size=None) as ws:
+        nxt = [0]
+        def nid():
+            nxt[0] += 1; return nxt[0]
+
+        # Enable Network with maxPostDataSize=4MB (what A2 would use)
+        await ws.send(json.dumps({"id": nid(), "method": "Network.enable",
+                                  "params": {"maxPostDataSize": 4 * 1024 * 1024}}))
+        while True:
+            r = json.loads(await asyncio.wait_for(ws.recv(), timeout=3))
+            if r.get("id"):
+                break
+
+        results = []
+        for size in sizes:
+            # Build a body with a known structure: UUID at the start, filler in the middle,
+            # marker at the end. Send to /backend-api/conversation/init (a benign endpoint
+            # that ChatGPT's page already calls; it will 4xx but CDP still captures the request).
+            test_uuid = f"a2b3c4d5-{size:08x}-4eb2-bed0-a1eebe4720f1"
+            filler = "X" * size
+            body_obj = {
+                "messages": [{"id": test_uuid, "content": {"parts": [filler]}}],
+                "end_marker": "END_OF_BODY_" + str(size),
+            }
+            body_str = json.dumps(body_obj)
+            actual_len = len(body_str)
+            print(f"\n=== testing body size {size} bytes (actual JSON: {actual_len}) ===")
+
+            # Drain
+            while True:
+                try:
+                    _ = await asyncio.wait_for(ws.recv(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    break
+
+            # Inject fetch via the page — fire and forget; we capture it via Network events
+            # regardless of whether the request succeeds.
+            fetch_js = (
+                "(async()=>{try{"
+                "await fetch('/backend-api/conversation/init',{"
+                "method:'POST',headers:{'Content-Type':'application/json'},"
+                "body:" + json.dumps(body_str) + ""
+                "});}catch(e){return 'err:'+e}return 'sent'})()"
+            )
+            eval_id = nid()
+            await ws.send(json.dumps({"id": eval_id, "method": "Runtime.evaluate",
+                                      "params": {"expression": fetch_js, "awaitPromise": True,
+                                                 "returnByValue": True, "timeout": 15000}}))
+
+            captured = None
+            deadline = asyncio.get_event_loop().time() + 10
+            while asyncio.get_event_loop().time() < deadline:
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    continue
+                r = json.loads(raw)
+                if r.get("method") == "Network.requestWillBeSent":
+                    req = (r.get("params") or {}).get("request", {}) or {}
+                    url = req.get("url", "")
+                    if "conversation/init" in url and req.get("method") == "POST":
+                        pd = req.get("postData")
+                        captured = {
+                            "reported_post_data_len": len(pd) if pd else 0,
+                            "has_post_data": req.get("hasPostData"),
+                            "post_data": pd,
+                        }
+                        break
+                if r.get("id") == eval_id:
+                    pass  # eval done, keep waiting for network event
+
+            # Analyze
+            analysis = {
+                "intended_body_size": actual_len,
+                "filler_size": size,
+            }
+            if captured:
+                pd = captured["post_data"]
+                analysis["reported_post_data_len"] = captured["reported_post_data_len"]
+                analysis["truncated"] = captured["reported_post_data_len"] < actual_len
+                analysis["complete_capture"] = captured["reported_post_data_len"] >= actual_len
+                # Is the UUID at the start extractable?
+                import re
+                m = re.search(r'"id"\s*:\s*"([0-9a-f-]{36})"', pd[:500])
+                analysis["uuid_extractable_from_start"] = bool(m)
+                # Is the end marker present? (proves no truncation)
+                analysis["end_marker_present"] = ("END_OF_BODY_" + str(size)) in pd
+            else:
+                analysis["reported_post_data_len"] = 0
+                analysis["note"] = "no POST captured"
+
+            results.append(analysis)
+            print(f"  intended body: {actual_len} bytes")
+            print(f"  reported postData: {analysis.get('reported_post_data_len', 0)} bytes")
+            print(f"  truncated: {analysis.get('truncated', '?')}")
+            print(f"  UUID extractable from start: {analysis.get('uuid_extractable_from_start', '?')}")
+            print(f"  end marker present (no trunc): {analysis.get('end_marker_present', '?')}")
+
+            await asyncio.sleep(1.0)
+
+    print("\n" + "=" * 70)
+    print("SUMMARY — postData truncation behavior")
+    print("=" * 70)
+    print(f"{'intended':>10} {'reported':>10} {'truncated':>10} {'uuid@start':>12} {'end_marker':>12}")
+    for r in results:
+        print(f"{r['intended_body_size']:>10} {r.get('reported_post_data_len',0):>10} "
+              f"{str(r.get('truncated','?')):>10} {str(r.get('uuid_extractable_from_start','?')):>12} "
+              f"{str(r.get('end_marker_present','?')):>12}")
+
+    import os
+    out_path = os.path.join(os.environ.get("TEMP", "/tmp"), "a2_stress2_v2_truncation.json")
+    with open(out_path, "w") as f:
+        json.dump(results, f, indent=2, default=str)
+    print(f"\nsaved: {out_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/a2_stress_test_2_truncation.py
+++ b/scripts/a2_stress_test_2_truncation.py
@@ -1,0 +1,192 @@
+"""Stress test 2: long-prompt postData truncation.
+
+Sends prompts of increasing size (5KB, 50KB, 200KB, 500KB) and checks whether
+CDP's request.postData is complete or truncated, and whether the UUID is still
+extractable.
+
+The UUID sits at the START of the JSON body (messages[0].id), so even heavy
+truncation should preserve it — but maxPostDataSize=1MB may be exceeded by the
+real request body for large agentic prompts.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import urllib.request
+
+import websockets
+
+CDP = 9222
+BRIDGE = "http://127.0.0.1:8080"
+CONV = "6a48625b-34a4-83ed-93ba-a7153c2e6295"
+
+
+def list_targets():
+    return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{CDP}/json/list", timeout=3).read())
+
+
+def find_target():
+    targets = list_targets()
+    for t in targets:
+        if t.get("type") == "page" and CONV in t.get("url", ""):
+            return t
+    for t in targets:
+        if t.get("type") == "page" and "chatgpt.com/c/" in t.get("url", ""):
+            return t
+    raise RuntimeError("no target")
+
+
+def make_prompt(target_bytes: int) -> str:
+    """Build a prompt of approximately target_bytes.
+    The filler is distinctive so we can detect truncation."""
+    header = f"Reply with exactly: TRUNC-TEST. Then ignore the following filler:\n\n"
+    # Each filler line ~80 chars
+    filler_line = "FILLER-{:06d}-" + ("x" * 60) + "\n"
+    body = ""
+    i = 0
+    while len(body) < target_bytes:
+        body += filler_line.format(i)
+        i += 1
+    return header + body
+
+
+async def bridge_send(prompt: str) -> dict:
+    body = json.dumps({
+        "model": "auto", "conversation_id": CONV,
+        "messages": [{"role": "user", "content": prompt}],
+        "stream": False,
+    }).encode()
+    req = urllib.request.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    try:
+        with urllib.request.urlopen(req, timeout=180) as r:
+            p = json.loads(r.read())
+            return {"ok": True, "latency": round(time.time() - t0, 2),
+                    "content": p.get("choices", [{}])[0].get("message", {}).get("content", "")[:80]}
+    except Exception as e:
+        return {"ok": False, "latency": round(time.time() - t0, 2), "error": str(e)}
+
+
+async def main():
+    target = find_target()
+    print(f"target: {target['url'][:80]}")
+    ws_url = target["webSocketDebuggerUrl"]
+
+    # Sizes to test (in KB)
+    sizes_kb = [5, 50, 200, 500]
+
+    async with websockets.connect(ws_url, max_size=None) as ws:
+        nxt = [0]
+        def nid():
+            nxt[0] += 1; return nxt[0]
+
+        # Enable Network with maxPostDataSize=4MB (well above any test size)
+        await ws.send(json.dumps({"id": nid(), "method": "Network.enable",
+                                  "params": {"maxPostDataSize": 8 * 1024 * 1024}}))
+        while True:
+            r = json.loads(await asyncio.wait_for(ws.recv(), timeout=3))
+            if r.get("id"):
+                break
+
+        results = []
+        for size_kb in sizes_kb:
+            prompt = make_prompt(size_kb * 1024)
+            actual_prompt_bytes = len(prompt.encode())
+            print(f"\n=== size target: {size_kb}KB (actual prompt: {actual_prompt_bytes} bytes) ===")
+
+            # Drain pending events
+            while True:
+                try:
+                    _ = await asyncio.wait_for(ws.recv(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    break
+
+            send_task = asyncio.create_task(bridge_send(prompt))
+            captured = None
+            deadline = time.time() + 180
+            while time.time() < deadline:
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=0.5)
+                except asyncio.TimeoutError:
+                    if send_task.done():
+                        break
+                    continue
+                r = json.loads(raw)
+                if r.get("method") == "Network.requestWillBeSent":
+                    req = (r.get("params") or {}).get("request", {}) or {}
+                    url = req.get("url", "")
+                    if req.get("method") == "POST" and url.rstrip("/").endswith("/f/conversation"):
+                        pd = req.get("postData")
+                        if pd:
+                            captured = {
+                                "post_data_len": len(pd),
+                                "has_post_data": req.get("hasPostData"),
+                                "post_data": pd,
+                            }
+                            # Don't break — let the send finish
+            send_result = await send_task
+
+            # Analyze capture
+            analysis = {
+                "size_target_kb": size_kb,
+                "actual_prompt_bytes": actual_prompt_bytes,
+                "send_result": send_result,
+            }
+            if captured:
+                pd = captured["post_data"]
+                analysis["captured_post_data_len"] = captured["post_data_len"]
+                # Is it complete JSON? (truncation would break parsing)
+                try:
+                    parsed = json.loads(pd)
+                    analysis["json_parses"] = True
+                    msgs = parsed.get("messages") or []
+                    if msgs:
+                        mid = msgs[0].get("id")
+                        analysis["messages_0_id"] = mid
+                        analysis["uuid_extractable"] = bool(mid)
+                    # Check if the prompt text is fully present (last filler line)
+                    parts = (msgs[0].get("content") or {}).get("parts") or [] if msgs else []
+                    if parts:
+                        prompt_in_body = str(parts[0])
+                        # The prompt should END with a filler line (not truncated mid-body)
+                        analysis["prompt_fully_in_body"] = prompt_in_body.endswith("\n") and "FILLER-" in prompt_in_body[-100:]
+                        analysis["prompt_in_body_len"] = len(prompt_in_body)
+                except json.JSONDecodeError as e:
+                    analysis["json_parses"] = False
+                    analysis["json_error"] = str(e)
+                    # Even if JSON is truncated, can we extract the UUID by regex?
+                import re
+                m = re.search(r'"id"\s*:\s*"([0-9a-f-]{36})"', pd[:500])
+                analysis["uuid_via_regex_in_first_500"] = m.group(1) if m else None
+            else:
+                analysis["captured_post_data_len"] = 0
+                analysis["note"] = "no POST captured"
+
+            results.append(analysis)
+            print(f"  send ok: {send_result.get('ok')}, content: {send_result.get('content','')[:50]!r}")
+            print(f"  captured post_data: {analysis.get('captured_post_data_len', 0)} bytes")
+            print(f"  JSON parses: {analysis.get('json_parses', False)}")
+            print(f"  UUID extractable: {analysis.get('uuid_extractable', analysis.get('uuid_via_regex_in_first_500'))}")
+            print(f"  prompt fully in body: {analysis.get('prompt_fully_in_body', 'n/a')}")
+
+            await asyncio.sleep(3.0)
+
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    for r in results:
+        print(f"  {r['size_target_kb']:>4}KB prompt -> captured {r.get('captured_post_data_len',0):>8} bytes, "
+              f"JSON={'OK' if r.get('json_parses') else 'BROKEN'}, "
+              f"UUID={'OK' if r.get('uuid_extractable') or r.get('uuid_via_regex_in_first_500') else 'MISSING'}")
+
+    import os
+    out_path = os.path.join(os.environ.get("TEMP", "/tmp"), "a2_stress2_truncation.json")
+    with open(out_path, "w") as f:
+        json.dump(results, f, indent=2, default=str)
+    print(f"\nsaved: {out_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/a2_stress_test_4_skew_stability.py
+++ b/scripts/a2_stress_test_4_skew_stability.py
@@ -1,0 +1,265 @@
+"""Stress test 4: skew stability over time + reconnect.
+
+Runs 5 batches of 6-sample skew measurements across ~30 minutes:
+  - Batch 1: baseline (immediately)
+  - Batch 2: after 5 min
+  - Batch 3: after forced driver reconnect
+  - Batch 4: after 5 more min
+  - Batch 5: after 5 more min
+
+Reports per-batch skew statistics and overall variance. If skew is stable
+(~5.1s, low stdev) across all batches including post-reconnect, SKEW_TOLERANCE=8
+is validated. If it jumps or shifts, the tolerance needs revisiting.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import statistics
+import time
+import urllib.request
+
+import websockets
+
+CDP = 9222
+BRIDGE = "http://127.0.0.1:8080"
+CONV = "6a48625b-34a4-83ed-93ba-a7153c2e6295"
+
+
+def list_targets():
+    return json.loads(urllib.request.urlopen(f"http://127.0.0.1:{CDP}/json/list", timeout=3).read())
+
+
+def find_target():
+    targets = list_targets()
+    for t in targets:
+        if t.get("type") == "page" and CONV in t.get("url", ""):
+            return t
+    for t in targets:
+        if t.get("type") == "page" and "chatgpt.com/c/" in t.get("url", ""):
+            return t
+    raise RuntimeError("no target")
+
+
+async def bridge_send_get_uuid_and_skew(ws, token, marker):
+    """Single instrumented send: returns {skew, uuid_captured, uuid_survived, stale}."""
+    nxt = [0]
+    def nid():
+        nxt[0] += 1; return nxt[0]
+
+    async def evaluate(expr, timeout_ms=15000):
+        my_id = nid()
+        await ws.send(json.dumps({"id": my_id, "method": "Runtime.evaluate",
+                                  "params": {"expression": expr, "awaitPromise": True,
+                                             "returnByValue": True, "timeout": timeout_ms}}))
+        while True:
+            r = json.loads(await ws.recv())
+            if r.get("id") == my_id:
+                return r
+
+    # Drain
+    while True:
+        try:
+            _ = await asyncio.wait_for(ws.recv(), timeout=0.1)
+        except asyncio.TimeoutError:
+            break
+
+    t_pre_wall = time.time()
+    # Fire send
+    body = json.dumps({"model": "auto", "conversation_id": CONV,
+                       "messages": [{"role": "user", "content": f"Reply with exactly: {marker}"}],
+                       "stream": False}).encode()
+    req = urllib.request.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    send_task = asyncio.create_task(asyncio.to_thread(urllib.request.urlopen, req, timeout=120))
+
+    # Capture UUID from POST
+    captured_uuid = None
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        try:
+            raw = await asyncio.wait_for(ws.recv(), timeout=0.3)
+        except asyncio.TimeoutError:
+            if send_task.done() and time.time() > t_pre_wall + 8:
+                break
+            continue
+        r = json.loads(raw)
+        if r.get("method") == "Network.requestWillBeSent":
+            req_obj = (r.get("params") or {}).get("request", {}) or {}
+            url = req_obj.get("url", "")
+            if req_obj.get("method") == "POST" and url.rstrip("/").endswith("/f/conversation"):
+                pd = req_obj.get("postData")
+                if pd:
+                    try:
+                        parsed = json.loads(pd)
+                        msgs = parsed.get("messages") or []
+                        if msgs and msgs[0].get("id"):
+                            captured_uuid = msgs[0]["id"]
+                    except Exception:
+                        pass
+
+    try:
+        resp = await asyncio.wait_for(send_task, timeout=60)
+        p = json.loads(resp.read())
+        content = p.get("choices", [{}])[0].get("message", {}).get("content", "")
+    except Exception as e:
+        content = f"<err: {e}>"
+
+    # Fetch mapping for skew + uuid survival
+    await asyncio.sleep(1.0)
+    fetch_js = (
+        "(async()=>{var r=await fetch('/backend-api/conversation/' + __C__ + '?offset=0&limit=50',"
+        "{headers:{'Authorization':'Bearer ' + __T__}});"
+        "if(!r.ok) return JSON.stringify({__status:r.status});"
+        "var j=await r.json();return JSON.stringify(j)})()"
+    ).replace("__C__", json.dumps(CONV)).replace("__T__", json.dumps(token))
+    map_resp = await evaluate(fetch_js, timeout_ms=20000)
+    map_val = map_resp.get("result", {}).get("result", {}).get("value", "")
+    mapping = json.loads(map_val) if map_val else {}
+    m = mapping.get("mapping", {}) if isinstance(mapping, dict) else {}
+
+    latest_user_ct = None
+    latest_user_id = None
+    best_t = -1
+    for _nid, node in m.items():
+        msg = node.get("message") or {}
+        if (msg.get("author") or {}).get("role") != "user":
+            continue
+        ct = msg.get("create_time") or 0
+        if ct > best_t:
+            best_t = ct
+            latest_user_ct = ct
+            latest_user_id = msg.get("id")
+
+    skew = (latest_user_ct - t_pre_wall) if latest_user_ct else None
+    uuid_survived = (captured_uuid == latest_user_id) if (captured_uuid and latest_user_id) else None
+
+    return {
+        "marker": marker,
+        "t_pre_wall": t_pre_wall,
+        "skew": round(skew, 3) if skew is not None else None,
+        "uuid_captured": captured_uuid,
+        "uuid_survived": uuid_survived,
+        "stale": content != marker,
+        "content": content[:60],
+    }
+
+
+async def run_batch(ws, token, batch_num, n_samples=4):
+    """Run n_samples instrumented sends; return list of results."""
+    results = []
+    for i in range(1, n_samples + 1):
+        marker = f"S4-B{batch_num}-{i}-{int(time.time())}"
+        r = await bridge_send_get_uuid_and_skew(ws, token, marker)
+        results.append(r)
+        print(f"  B{batch_num}.{i}: skew={r['skew']}  uuid_cap={'Y' if r['uuid_captured'] else 'N'}  "
+              f"uuid_surv={'Y' if r['uuid_survived'] else 'N'}  stale={'Y' if r['stale'] else 'N'}")
+        await asyncio.sleep(3.0)
+    return results
+
+
+def force_reconnect():
+    """Force the bridge driver to reconnect by hitting a send (which triggers reconnect if detached)."""
+    # The simplest way: send a no-op; the driver reconnects if needed.
+    try:
+        body = json.dumps({"model": "auto", "messages": [{"role": "user", "content": "ping"}], "stream": False}).encode()
+        req = urllib.request.Request(f"{BRIDGE}/v1/chat/completions", data=body,
+                                     headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=120) as r:
+            json.loads(r.read())
+        print("  (reconnect-probe send completed)")
+    except Exception as e:
+        print(f"  (reconnect-probe failed: {e})")
+
+
+async def main():
+    target = find_target()
+    print(f"target: {target['url'][:80]}")
+    ws_url = target["webSocketDebuggerUrl"]
+
+    all_batches = []
+
+    async with websockets.connect(ws_url, max_size=None) as ws:
+        nxt = [0]
+        def nid():
+            nxt[0] += 1; return nxt[0]
+
+        # Enable Network + get token (once, persistent)
+        await ws.send(json.dumps({"id": nid(), "method": "Network.enable",
+                                  "params": {"maxPostDataSize": 4 * 1024 * 1024}}))
+        while True:
+            r = json.loads(await asyncio.wait_for(ws.recv(), timeout=3))
+            if r.get("id"):
+                break
+
+        async def evaluate(expr, timeout_ms=10000):
+            my_id = nid()
+            await ws.send(json.dumps({"id": my_id, "method": "Runtime.evaluate",
+                                      "params": {"expression": expr, "awaitPromise": True,
+                                                 "returnByValue": True, "timeout": timeout_ms}}))
+            while True:
+                r = json.loads(await ws.recv())
+                if r.get("id") == my_id:
+                    return r
+
+        token_resp = await evaluate(
+            '(async()=>{var r=await fetch("/api/auth/session");var j=await r.json();return j.accessToken||""})()',
+            timeout_ms=10000)
+        token = token_resp.get("result", {}).get("result", {}).get("value", "")
+
+        # Batch 1: baseline
+        print(f"\n=== Batch 1: BASELINE (t={time.strftime('%H:%M:%S')}) ===", flush=True)
+        b1 = await run_batch(ws, token, 1)
+        all_batches.append({"batch": 1, "label": "baseline", "results": b1})
+
+        # Batch 2: after 90s
+        print(f"\n--- sleeping 90s before batch 2 ---", flush=True)
+        await asyncio.sleep(90)
+        print(f"\n=== Batch 2: AFTER 90S (t={time.strftime('%H:%M:%S')}) ===", flush=True)
+        b2 = await run_batch(ws, token, 2)
+        all_batches.append({"batch": 2, "label": "after_90s", "results": b2})
+
+        # Batch 3: after forced reconnect
+        print(f"\n=== Batch 3: FORCED RECONNECT (t={time.strftime('%H:%M:%S')}) ===", flush=True)
+        force_reconnect()
+        await asyncio.sleep(5)
+        b3 = await run_batch(ws, token, 3)
+        all_batches.append({"batch": 3, "label": "post_reconnect", "results": b3})
+
+    # Aggregate
+    print("\n" + "=" * 70)
+    print("STRESS TEST 4 — SKEW STABILITY ACROSS TIME + RECONNECT")
+    print("=" * 70)
+    print(f"{'batch':<6} {'label':<20} {'n':<4} {'skew_min':>9} {'skew_max':>9} {'skew_mean':>10} {'skew_std':>9} {'all_pos':>7}")
+    all_skews = []
+    for b in all_batches:
+        skews = [r["skew"] for r in b["results"] if r["skew"] is not None]
+        all_skews.extend(skews)
+        if skews:
+            all_pos = all(s > 0 for s in skews)
+            print(f"{b['batch']:<6} {b['label']:<20} {len(skews):<4} {min(skews):>9.3f} {max(skews):>9.3f} "
+                  f"{statistics.mean(skews):>10.3f} {statistics.stdev(skews) if len(skews)>1 else 0:>9.3f} {str(all_pos):>7}")
+        else:
+            print(f"{b['batch']:<6} {b['label']:<20} {0:<4} (no skew data)")
+
+    print(f"\nOVERALL: {len(all_skews)} samples, min={min(all_skews):.3f}, max={max(all_skews):.3f}, "
+          f"mean={statistics.mean(all_skews):.3f}, std={statistics.stdev(all_skews):.3f}")
+    neg = [s for s in all_skews if s < 0]
+    print(f"negative-skew samples: {len(neg)}")
+    if len(neg) == 0:
+        print(f"VERDICT: skew stable and all-positive across time + reconnect. SKEW_TOLERANCE=8 validated.")
+    else:
+        print(f"VERDICT: {len(neg)} negative samples observed — tolerance may need widening.")
+
+    import os
+    out_path = os.path.join(os.environ.get("TEMP", "/tmp"), "a2_stress4_skew_stability.json")
+    with open(out_path, "w") as f:
+        json.dump({"batches": all_batches,
+                   "overall": {"n": len(all_skews), "min": min(all_skews), "max": max(all_skews),
+                               "mean": statistics.mean(all_skews), "stdev": statistics.stdev(all_skews),
+                               "negative_count": len(neg)}}, f, indent=2, default=str)
+    print(f"\nsaved: {out_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/chatgpt_web2api/backend_client.py
+++ b/src/chatgpt_web2api/backend_client.py
@@ -4,8 +4,9 @@ Phase 5 PR1 extraction (no behavior change). Owns the method bodies that talk
 to ChatGPT's backend-api over HTTP via ``Runtime.evaluate``:
 
   - token / session lifecycle (``_refresh_token``, ``ensure_token``, ``recover_auth``)
-  - conversation fetch (``_fetch_text``, ``_fetch_end_turn``, conversation-id
-    resolution, ``_check_auth_in_raw``)
+  - conversation fetch (``_fetch_text_for_turn`` /
+    ``_fetch_end_turn_for_turn`` / ``_fetch_recent_conversation_projection``,
+    conversation-id resolution, ``_check_auth_in_raw``)
   - backend-api read/mutate (models, projects, conversations, memories, gpts)
 
 The driver-reference collaborator seam: ``BackendClient`` holds a reference to
@@ -44,12 +45,13 @@ logger = logging.getLogger(__name__)
 
 
 class _Transient404(Exception):
-    """Sentinel raised by ``_fetch_text_once`` on a backend 404.
+    """Sentinel raised by ``_fetch_recent_conversation_projection`` on a backend 404.
 
-    Internal to ``_fetch_text``'s bounded retry loop — never escapes this
-    module. The 404 is a transient race (conversation not yet persisted
-    immediately after a send), NOT an auth failure or persistent backend
-    fault, so it is deliberately not modeled as a breaker signal.
+    Internal to this module — caught and swallowed by the
+    ``_fetch_text_for_turn`` / ``_fetch_end_turn_for_turn`` wrappers, so it
+    never escapes. The 404 is a transient race (conversation not yet
+    persisted immediately after a send), NOT an auth failure or persistent
+    backend fault, so it is deliberately not modeled as a breaker signal.
     """
 
 
@@ -146,7 +148,8 @@ class BackendClient:
         Returns the token. The TTL guard (TOKEN_TTL_SECONDS) catches expiry
         well before the real JWT lifetime; callers should invoke this before
         any /backend-api/* fetch so a stale session surfaces as
-        AuthExpiredError (via _fetch_text) rather than silent empty data.
+        AuthExpiredError (via ``_fetch_recent_conversation_projection`` and
+        the other /backend-api fetchers) rather than silent empty data.
 
         Reaches ``_refresh_token`` through the driver delegator so test
         monkeypatches of ``driver._refresh_token`` intercept. This is NOT
@@ -214,143 +217,6 @@ class BackendClient:
 
     # ── Conversation fetch ────────────────────────────────────
 
-    # Bounded retry for the transient 404 returned by the backend-api
-    # immediately after a send, before the just-created conversation is
-    # persisted server-side. This is a transient race, NOT an auth failure or
-    # a persistent backend fault, so it is deliberately NOT a breaker signal
-    # (follow-up C decides separately whether persistent 404/5xx should ever
-    # trip a breaker). The bound stays small so a genuinely-missing
-    # conversation surfaces quickly.
-    _FETCH_TEXT_404_MAX_ATTEMPTS = 4
-    _FETCH_TEXT_404_BACKOFF_SECONDS = 0.5
-
-    async def _fetch_text(self, conversation_id: str) -> str:
-        """Fetch the latest assistant text from the conversation API.
-
-        Non-OK responses are encoded by the JS as ``{"__status": <code>}``
-        rather than ``''`` so Python can distinguish an auth failure (401 →
-        AuthExpiredError) from a missing conversation (404) or a network
-        error. This parse-and-raise happens here, before any return reaches
-        the caller, so callers never see a raw status blob as text.
-
-        A 404 specifically is treated as a transient race and retried a
-        bounded number of times: the backend-api returns 404 immediately
-        after a send while the just-created conversation is still
-        propagating server-side. Only 404 is retried — 401 still raises
-        ``AuthExpiredError`` immediately (with breaker trip) and any other
-        non-OK status still raises ``RuntimeError`` immediately. After the
-        retry bound is exhausted the 404 surfaces as ``RuntimeError`` so
-        callers see the same type they did pre-retry.
-
-        Picks the newest assistant text message by ``create_time`` rather than
-        trusting the API's ``current_node`` pointer: that pointer lags behind
-        on continued conversations (it still points at the previous turn right
-        after a send), which produced an off-by-one where request N returned
-        request N-1's text. The newest-by-create-time selection is immune to
-        that lag.
-        """
-        from .cdp_driver import CDPJSError
-
-        last_error: Exception | None = None
-        for attempt in range(1, self._FETCH_TEXT_404_MAX_ATTEMPTS + 1):
-            try:
-                return await self._fetch_text_once(conversation_id)
-            except _Transient404 as e:
-                # Transient race — retry after a short backoff unless this was
-                # the final attempt, in which case it falls through to the
-                # RuntimeError raise below.
-                last_error = e
-                if attempt < self._FETCH_TEXT_404_MAX_ATTEMPTS:
-                    logger.debug(
-                        "_fetch_text 404 for %s (attempt %d/%d), retrying",
-                        conversation_id,
-                        attempt,
-                        self._FETCH_TEXT_404_MAX_ATTEMPTS,
-                    )
-                    await asyncio.sleep(self._FETCH_TEXT_404_BACKOFF_SECONDS)
-                continue
-            except CDPJSError as e:
-                # JS transport failure: not a 404 race. Preserve the pre-retry
-                # behavior of swallowing it and returning "" (callers retry
-                # the whole send poll loop).
-                logger.debug("_fetch_text JS failed: %s", e)
-                return ""
-        # Bound exhausted — surface the 404 as RuntimeError, matching the
-        # pre-retry behavior callers already handle.
-        raise RuntimeError(
-            f"_fetch_text HTTP 404 for {conversation_id} "
-            f"after {self._FETCH_TEXT_404_MAX_ATTEMPTS} attempts"
-        ) from last_error
-
-    async def _fetch_text_once(self, conversation_id: str) -> str:
-        """Single backend-api conversation fetch + status decode.
-
-        Returns the assistant text on success, raises ``_Transient404`` on a
-        404 (so the bounded retry loop in ``_fetch_text`` can catch it),
-        raises ``AuthExpiredError`` (with breaker trip) on 401, and raises
-        ``RuntimeError`` for any other non-OK status. Empty/blank bodies and
-        JS-transport failures are handled by the caller.
-
-        Status decode (the ``__status`` blob shape) lives here so it runs
-        before any text reaches the caller regardless of the retry wrapper.
-        """
-        # Imported lazily to avoid a module-load circular dependency.
-        from .cdp_driver import AuthExpiredError
-
-        d = self._driver
-        await self._driver.ensure_token()
-        raw = await d._js_with_data_strict(
-            "(async function() {"
-            "  try {"
-            "    var r = await fetch('/backend-api/conversation/' + __D.conv_id + '?offset=0&limit=5', {"
-            "      headers: {'Authorization': 'Bearer ' + __D.token}"
-            "    });"
-            "    if (!r.ok) return JSON.stringify({__status: r.status});"
-            "    var conv = await r.json();"
-            "    var mapping = conv.mapping || {};"
-            # Find the NEWEST assistant text message by create_time.
-            # current_node lags on continued conversations, so we cannot
-            # trust it to point at the turn we just sent.
-            "    var best = null;"
-            "    var bestTime = -1;"
-            "    for (var k in mapping) {"
-            "      var n = mapping[k];"
-            "      var m = n.message;"
-            "      if (!m || !m.author || m.author.role !== 'assistant') continue;"
-            "      if (!m.content || m.content.content_type !== 'text') continue;"
-            "      var parts = m.content.parts || [];"
-            "      if (!parts.length || !parts.some(function(p){ return String(p).trim(); })) continue;"
-            "      var t = m.create_time || 0;"
-            "      if (t >= bestTime) { bestTime = t; best = parts.filter(function(p){ return String(p).trim(); }).join('\\n'); }"
-            "    }"
-            "    return best || '';"
-            "  } catch(e) { return ''; }"
-            "})()",
-            {"conv_id": conversation_id, "token": d._access_token},
-            timeout=15,
-        )
-        if not raw:
-            return ""
-        # Detect the status-blob shape (non-OK response) and raise appropriately.
-        # Cheap pre-check before json.loads to avoid parsing every valid text body.
-        if raw.startswith('{"__status"') or raw.startswith('{ "__status"'):
-            try:
-                payload = json.loads(raw)
-                status = payload.get("__status")
-            except (json.JSONDecodeError, TypeError):
-                status = None
-            if status == 401:
-                if d._breakers:
-                    d._breakers.trip(BreakerKind.AUTH_EXPIRED, "HTTP 401 from backend-api")
-                raise AuthExpiredError()
-            if status == 404:
-                # Transient race: conversation not yet persisted after send.
-                # The bounded retry in _fetch_text catches this.
-                raise _Transient404(conversation_id)
-            if status is not None:
-                raise RuntimeError(f"_fetch_text HTTP {status} for {conversation_id}")
-        return raw
-
     async def _conversation_id_from_url(self) -> str:
         """Parse the conversation id from the live tab's ``location.href``.
 
@@ -388,58 +254,118 @@ class BackendClient:
             return self._driver._current_conv_id
         return await self._conversation_id_from_url()
 
-    async def _fetch_end_turn(self, conversation_id: str) -> bool:
-        """Backend secondary completion signal: is the latest assistant TEXT
-        node marked ``end_turn === true``?
+    # ── A2: Anchored turn-correlation fetchers ─────────────────
+    #
+    # The projection JS (``backend_projection.CONVERSATION_PROJECTION_JS``)
+    # fetches the conversation mapping and projects it to a compact skeleton
+    # schema; the pure-Python selectors (``turn_anchor.select_*``) correlate
+    # against the anchor captured by the driver/IdentityListener.
+    #
+    # Status-decode convention: 401 → AuthExpiredError+trip, 404 →
+    # _Transient404 (transient race, swallowed by the wrappers below),
+    # other non-OK → RuntimeError, transport failure → fetch_failed status.
 
-        A fallback for the Phase-2 DOM completion detector: if the action-
-        button selector drifts again (as it did when ChatGPT moved the buttons
-        to a sibling container), the DOM ``has_action`` stays false forever
-        and the loop stalls. This reads the conversation API and checks the
-        terminal flag on the newest assistant text node — the same
-        newest-by-create-time selection ``_fetch_text`` uses (NOT current_node,
-        which lags on continued conversations, and NOT reasoning_recap nodes,
-        which carry empty text).
+    async def _fetch_recent_conversation_projection(
+        self, conversation_id: str
+    ) -> dict:
+        """Fetch and project the recent conversation mapping.
 
-        Returns False on ANY failure (fetch error, parse error, no assistant
-        text node, end_turn falsy). Callers treat False as "not confirmed,
-        keep polling DOM" — this is defense-in-depth, never the sole signal.
+        Executes ``CONVERSATION_PROJECTION_JS`` via the driver's
+        ``_js_with_data_strict``. Returns the projected dict
+        (``{"nodes": {...}, "current_node": ...}``). Raises ``AuthExpiredError``
+        on 401 (with breaker trip), ``_Transient404`` on 404, ``RuntimeError``
+        on other non-OK status, and ``CDPJSError`` on transport failure.
         """
-        from .cdp_driver import CDPJSError
+        from .backend_projection import CONVERSATION_PROJECTION_JS, TURN_PROJECTION_LIMIT
+        from .cdp_driver import AuthExpiredError, CDPJSError
 
         d = self._driver
         await self._driver.ensure_token()
+        raw = await d._js_with_data_strict(
+            CONVERSATION_PROJECTION_JS,
+            {
+                "conv_id": conversation_id,
+                "token": d._access_token,
+                "limit": TURN_PROJECTION_LIMIT,
+            },
+            timeout=15,
+        )
+        if not raw:
+            raise CDPJSError("projection returned empty")
+        # Status-decode (the ``__status`` blob shape).
+        if raw.startswith('{"__status"') or raw.startswith('{ "__status"'):
+            try:
+                payload = json.loads(raw)
+                status = payload.get("__status")
+            except (json.JSONDecodeError, TypeError):
+                status = None
+            if status == 401:
+                if d._breakers:
+                    d._breakers.trip(BreakerKind.AUTH_EXPIRED, "HTTP 401 from backend-api")
+                raise AuthExpiredError()
+            if status == 404:
+                raise _Transient404(conversation_id)
+            if status is not None:
+                raise RuntimeError(f"projection HTTP {status} for {conversation_id}")
+        # Parse the projected mapping.
         try:
-            raw = await d._js_with_data_strict(
-                "(async function() {"
-                "  try {"
-                "    var r = await fetch('/backend-api/conversation/' + __D.conv_id + '?offset=0&limit=5', {"
-                "      headers: {'Authorization': 'Bearer ' + __D.token}"
-                "    });"
-                "    if (!r.ok) return 'false';"
-                "    var conv = await r.json();"
-                "    var mapping = conv.mapping || {};"
-                # Newest assistant TEXT node by create_time (mirrors
-                # _fetch_text: current_node lags; reasoning_recap has no text).
-                "    var bestTime = -1; var bestEnd = false;"
-                "    for (var k in mapping) {"
-                "      var n = mapping[k]; var m = n.message;"
-                "      if (!m || !m.author || m.author.role !== 'assistant') continue;"
-                "      if (!m.content || m.content.content_type !== 'text') continue;"
-                "      var parts = m.content.parts || [];"
-                "      if (!parts.length || !parts.some(function(p){ return String(p).trim(); })) continue;"
-                "      var t = m.create_time || 0;"
-                "      if (t >= bestTime) { bestTime = t; bestEnd = !!m.end_turn; }"
-                "    }"
-                "    return bestEnd ? 'true' : 'false';"
-                "  } catch(e) { return 'false'; }"
-                "})()",
-                {"conv_id": conversation_id, "token": d._access_token},
-                timeout=15,
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as e:
+            raise CDPJSError(f"projection returned unparseable JSON: {e}") from e
+
+    async def _fetch_text_for_turn(
+        self, conversation_id: str, anchor
+    ):
+        """Anchored final-text fetch for one turn.
+
+        Fetches the projected mapping and runs ``select_text_for_turn`` to
+        resolve the terminal assistant text for the submitted turn. Returns a
+        ``TurnTextResult`` with rich status for diagnostics.
+
+        Transport failures map to ``fetch_failed`` (caller keeps polling);
+        auth failures propagate as ``AuthExpiredError`` (never degrades).
+        """
+        from .cdp_driver import AuthExpiredError, CDPJSError
+        from .turn_anchor import TurnTextResult, select_text_for_turn
+
+        try:
+            mapping = await self._fetch_recent_conversation_projection(conversation_id)
+            return select_text_for_turn(mapping, anchor)
+        except AuthExpiredError:
+            raise  # hard fail — never degrade on auth
+        except _Transient404:
+            # Transient race — mapping not yet propagated. Treat as not_ready.
+            return TurnTextResult("not_ready", diagnostic={"reason": "transient_404"})
+        except (CDPJSError, RuntimeError) as e:
+            # Transport/backend failure — caller keeps polling.
+            return TurnTextResult("fetch_failed", diagnostic={"error": str(e)})
+
+    async def _fetch_end_turn_for_turn(
+        self, conversation_id: str, anchor, *, had_non_text_content: bool
+    ):
+        """Anchored completion-status fetch for one turn.
+
+        Returns a ``TurnEndResult`` with internal status. The caller (detector)
+        collapses to tri-state via ``collapse_to_end_turn_status``.
+
+        ``had_non_text_content`` is the DOM-derived flag passed IN so the
+        content-guard decision lives in the selector where the correlated
+        node identity is known (ChatGPT round 4 refinement).
+        """
+        from .cdp_driver import AuthExpiredError, CDPJSError
+        from .turn_anchor import TurnEndResult, select_end_turn_for_turn
+
+        try:
+            mapping = await self._fetch_recent_conversation_projection(conversation_id)
+            return select_end_turn_for_turn(
+                mapping, anchor, had_non_text_content=had_non_text_content
             )
-        except CDPJSError:
-            return False
-        return raw == "true"
+        except AuthExpiredError:
+            raise  # hard fail — never degrade on auth
+        except _Transient404:
+            return TurnEndResult("not_ready", diagnostic={"reason": "transient_404"})
+        except (CDPJSError, RuntimeError) as e:
+            return TurnEndResult("fetch_failed", diagnostic={"error": str(e)})
 
     # ── Backend API: Models & Projects ─────────────────────────
 

--- a/src/chatgpt_web2api/backend_client.py
+++ b/src/chatgpt_web2api/backend_client.py
@@ -307,6 +307,18 @@ class BackendClient:
                 raise _Transient404(conversation_id)
             if status is not None:
                 raise RuntimeError(f"projection HTTP {status} for {conversation_id}")
+        # Decode projection JS errors (the JS catches exceptions and returns
+        # {"__error": "..."}). Without this, a projection error would reach
+        # the selector as an empty mapping → not_ready → the detector would
+        # NOT unlock DOM fallback → reconciliation timeout instead of
+        # fetch_failed. (PR #39 review finding #1.)
+        if raw.startswith('{"__error"') or raw.startswith('{ "__error"'):
+            try:
+                payload = json.loads(raw)
+                err_msg = payload.get("__error", "unknown projection error")
+            except (json.JSONDecodeError, TypeError):
+                err_msg = "projection returned unparseable error blob"
+            raise CDPJSError(f"projection JS error for {conversation_id}: {err_msg}")
         # Parse the projected mapping.
         try:
             return json.loads(raw)

--- a/src/chatgpt_web2api/backend_projection.py
+++ b/src/chatgpt_web2api/backend_projection.py
@@ -1,0 +1,100 @@
+"""A2 backend projection — the conversation-mapping fetch + projection JS.
+
+Extracted from inline strings (Step 5 of the A2 build sequence). The
+projection JS is a named, importable constant so it can be fixture-tested in
+isolation (``tests/test_backend_projection_js.py``) without needing the driver.
+
+Design (peer-reviewed, conv ``6a482cfd``):
+  - Fetch ``/backend-api/conversation/{id}?offset=0&limit={TURN_PROJECTION_LIMIT}``.
+  - Status-decode: 401 → AuthExpiredError+trip, 404 → _Transient404, other → RuntimeError.
+  - Project to compact schema preserving ALL nodes as graph skeletons:
+    drop heavy payload fields only (reasoning internals, tool metadata, citations,
+    assets), NOT the nodes themselves. Intermediary nodes (reasoning_recap,
+    tool, system, unknown) must remain traversable.
+  - Schema: {nodes: {id: {id, parent, children, role, create_time, end_turn,
+    content_type, text}}, current_node}.
+
+The JS is executed via ``driver._js_with_data_strict(CONVERSATION_PROJECTION_JS, ...)``.
+The ``__D.conv_id`` and ``__D.token`` data slots are threaded by the caller
+(``BackendClient._fetch_recent_conversation_projection``).
+"""
+from __future__ import annotations
+
+import os
+
+# Empirically validated (Phase 1, stress test 2): the correlated user/assistant
+# pair can fall outside the old limit=5 window for multi-step tool chains.
+# 50 is the agreed default; env-overridable for canary tuning.
+TURN_PROJECTION_LIMIT = int(os.getenv("W2A_TURN_PROJECTION_LIMIT", "50"))
+
+
+# The projection JS. Runs inside the ChatGPT page via Runtime.evaluate.
+#
+# Data slots (threaded by the caller via _js_with_data_strict):
+#   __D.conv_id  — the conversation id
+#   __D.token    — the access token
+#   __D.limit    — the node limit (TURN_PROJECTION_LIMIT)
+#
+# Returns a JSON string. On non-OK HTTP, returns ``{"__status": <code>}``
+# so the Python caller can status-decode (the ``__status`` blob convention
+# decoded in ``_fetch_recent_conversation_projection``).
+CONVERSATION_PROJECTION_JS = """
+(async function() {
+  try {
+    var r = await fetch('/backend-api/conversation/' + __D.conv_id + '?offset=0&limit=' + __D.limit, {
+      headers: {'Authorization': 'Bearer ' + __D.token}
+    });
+    if (!r.ok) return JSON.stringify({__status: r.status});
+    var conv = await r.json();
+    var mapping = conv.mapping || {};
+    var projected = {};
+    for (var key in mapping) {
+      var node = mapping[key];
+      var msg = node.message || {};
+      var author = msg.author || {};
+      var content = msg.content || {};
+      var parts = content.parts || [];
+      // Join non-empty string parts for text nodes; drop for non-text.
+      var text = '';
+      if (content.content_type === 'text') {
+        var textParts = [];
+        for (var i = 0; i < parts.length; i++) {
+          if (typeof parts[i] === 'string' && parts[i].trim()) {
+            textParts.push(parts[i]);
+          }
+        }
+        text = textParts.join('\\n');
+      }
+      projected[key] = {
+        id: msg.id || key,
+        parent: node.parent || null,
+        children: node.children || [],
+        role: author.role || 'unknown',
+        create_time: msg.create_time || 0,
+        end_turn: !!msg.end_turn,
+        content_type: content.content_type || 'unknown',
+        text: text
+      };
+    }
+    return JSON.stringify({
+      nodes: projected,
+      current_node: conv.current_node || null
+    });
+  } catch(e) {
+    return JSON.stringify({__error: String(e)});
+  }
+})()
+""".strip()
+
+
+# Schema documentation (for the fixture test + future maintainers).
+PROJECTED_SCHEMA_FIELDS = {
+    "id": "str — the message id (equals the mapping key in observed data)",
+    "parent": "str | None — parent node id (for upward traversal)",
+    "children": "list[str] — child node ids (for downward traversal)",
+    "role": "str — user | assistant | tool | system | unknown",
+    "create_time": "float — backend-assigned creation timestamp",
+    "end_turn": "bool — terminal flag on assistant nodes",
+    "content_type": "str — text | reasoning_recap | tool_use | tool_result | multimodal_text | unknown",
+    "text": "str — joined non-empty text parts (text nodes only; empty for non-text)",
+}

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -291,6 +291,16 @@ class CDPDriver:
         # CDP response routing (#7): id-keyed futures + background reader
         self._pending: dict[int, asyncio.Future] = {}
         self._reader_task: asyncio.Task | None = None
+        # A2: unsolicited CDP event dispatch table. The reader loop consults
+        # this for events without an id (Network.requestWillBeSent, etc.).
+        # Handlers must be fast and non-blocking — the reader loop is the sole
+        # ws.recv() consumer and resolves all pending command futures; heavy
+        # work must be scheduled via loop.create_task. See CDPTransport._reader_loop.
+        self._cdp_event_handlers: dict[str, callable] = {}
+        # A2: identity listener (network-event-driven UUID capture). Owned by
+        # the driver (Layer 2), attached on connect/reconnect. Lazy-imported
+        # at attach time to avoid a module-load circular dependency.
+        self._identity_listener = None
         # Tab isolation: the targetId of the tab this driver is attached to.
         # _owns_target records whether *we* created it: only tabs we created are
         # closed in close(), so a driver that adopted an existing tab (e.g.
@@ -326,13 +336,39 @@ class CDPDriver:
         # Phase 5 PR4: streaming completion detection (Phase-1 appear loop +
         # Phase-2 stream loop) extracted into CompletionDetector. Lazy import
         # for the same reason; the detector reaches through this driver for
-        # _js_strict, _fetch_end_turn, _get_live_conversation_id_best_effort,
-        # and reads _current_conv_id (read-only — never assigned by the
-        # detector). It yields delta chunks only; the terminal stop chunk and
-        # the _current_conv_id mutation stay in send_and_stream.
+        # _js_strict, _fetch_end_turn_for_turn,
+        # _get_live_conversation_id_best_effort, and reads _current_conv_id
+        # (read-only — never assigned by the detector). It yields delta chunks
+        # only; the terminal stop chunk and the _current_conv_id mutation stay
+        # in send_and_stream.
         from .completion_detector import CompletionDetector
 
         self._completion = CompletionDetector(self)
+
+    async def _attach_identity_listener(self) -> None:
+        """A2: attach (or re-attach) the identity listener on the current ws.
+
+        Called from ``connect()`` and ``reconnect()`` after the reader loop is
+        running. The listener registers its ``Network.requestWillBeSent``
+        handler on ``self._cdp_event_handlers`` and enables the Network domain
+        for POST-body capture. Best-effort: a failure logs and leaves the
+        listener unready — ``send_and_stream`` will fall back to dual-anchor
+        correlation on the next send via the pre-send health check.
+        """
+        # Lazy import to avoid the module-load circular dependency
+        # (identity_listener imports nothing from cdp_driver, but keeping
+        # the pattern consistent with BackendClient/CompletionDetector).
+        from .identity_listener import IdentityListener
+
+        if self._identity_listener is None:
+            self._identity_listener = IdentityListener(self)
+        # Re-attach is idempotent: detach clears the old handler, attach
+        # re-registers and re-enables Network on the new websocket.
+        self._identity_listener.detach()
+        try:
+            await self._identity_listener.attach()
+        except Exception as e:
+            logger.warning("identity_listener_attach_failed (will degrade to dual-anchor): %s", e)
 
     async def connect(self) -> None:
         """Connect to Chrome's CDP and authenticate.
@@ -441,6 +477,11 @@ class CDPDriver:
         )
         self._reader_task = asyncio.create_task(self._reader_loop())
         logger.info("CDP connected to Chrome")
+        # A2: attach the identity listener now that the reader loop is running.
+        # Persistent from connect — re-attached on reconnect. The listener
+        # registers its Network.requestWillBeSent handler on the dispatch
+        # table (Step 1) and enables the Network domain for POST-body capture.
+        await self._attach_identity_listener()
         # Wait for the freshly-grabbed tab to actually be on chatgpt.com before
         # fetching the token — see _wait_for_chatgpt_ready. Without this the
         # fetch races the page load and returns an empty accessToken, killing
@@ -625,6 +666,8 @@ class CDPDriver:
                 await self._wait_for_chatgpt_ready()
                 await self._refresh_token()
                 logger.info("CDP reconnected on attempt %d", attempt)
+                # A2: re-attach the identity listener on the new websocket.
+                await self._attach_identity_listener()
                 # Success: clear CDP failure history and recover a half-open
                 # breaker. Only after refresh_token succeeds — a reconnect that
                 # reopens the socket but can't auth isn't a clean recovery.
@@ -1334,106 +1377,227 @@ class CDPDriver:
         # Unreachable (the loop either returns or raises).
         raise SendReadinessError("send_baseline: exhausted retries unexpectedly")
 
+    async def _capture_pre_send_fallback_anchor(self, text: str):
+        """A2: build the pre-send fallback TurnAnchor (NO captured UUID yet).
+
+        Called between the baseline count and ``type_message``. The UUID is
+        populated AFTER ``click_send`` via ``anchor.with_captured_id(uuid)``.
+
+        Modes:
+          - ``fresh_chat``: ``_current_conv_id`` is None (new chat). Text-only
+            anchor; correlation by sent_text after conv_id resolves.
+          - ``existing_conversation``: ``_current_conv_id`` set AND backend
+            anchor fetch succeeds. Records latest user/assistant node-id/time.
+          - ``degraded_existing``: ``_current_conv_id`` set but backend anchor
+            fetch failed (transient). Falls back to sent_text + wall-clock
+            freshness. Auth failure propagates hard (never degrades).
+
+        The wall-clock (``pre_send_wall_time``) is always captured, even in
+        ``existing_conversation`` mode, so the degraded freshness floor is
+        available if the backend anchor later proves wrong.
+        """
+        import time as _time
+
+        from .turn_anchor import TurnAnchor
+
+        pre_send_wall = _time.time()
+        conv_id = self._current_conv_id
+
+        if conv_id is None:
+            # Fresh chat — no backend anchor possible until URL resolves.
+            return TurnAnchor(
+                sent_text=text, mode="fresh_chat",
+                pre_send_wall_time=pre_send_wall,
+                conversation_id_at_capture=None,
+            )
+
+        # Existing conversation — fetch the pre-send backend mapping for anchor.
+        try:
+            mapping = await self._backend_client._fetch_recent_conversation_projection(conv_id)
+            nodes = mapping.get("nodes") or {}
+            # Find latest user + assistant nodes by create_time.
+            latest_user_id, latest_user_ct = None, None
+            latest_asst_id, latest_asst_ct = None, None
+            for _nid, node in nodes.items():
+                role = node.get("role") or ""
+                ct = float(node.get("create_time") or 0)
+                if role == "user" and (latest_user_ct is None or ct > latest_user_ct):
+                    latest_user_id = node.get("id") or _nid
+                    latest_user_ct = ct
+                elif role == "assistant" and (latest_asst_ct is None or ct > latest_asst_ct):
+                    latest_asst_id = node.get("id") or _nid
+                    latest_asst_ct = ct
+            return TurnAnchor(
+                sent_text=text, mode="existing_conversation",
+                latest_user_node_id=latest_user_id,
+                latest_user_create_time=latest_user_ct,
+                latest_assistant_node_id=latest_asst_id,
+                latest_assistant_create_time=latest_asst_ct,
+                pre_send_wall_time=pre_send_wall,
+                conversation_id_at_capture=conv_id,
+            )
+        except Exception as e:
+            # Transient backend failure — degrade to wall-clock freshness.
+            # AuthExpiredError propagates (caller's responsibility).
+            from .cdp_driver import AuthExpiredError
+            if isinstance(e, AuthExpiredError):
+                raise
+            logger.warning(
+                "turn_anchor_degraded: backend anchor fetch failed for %s: %s — "
+                "using degraded_existing mode (sent_text + wall-clock freshness)",
+                conv_id, e,
+            )
+            return TurnAnchor(
+                sent_text=text, mode="degraded_existing",
+                pre_send_wall_time=pre_send_wall,
+                conversation_id_at_capture=conv_id,
+            )
+
     async def send_and_stream(self, text: str, timeout: float = 120) -> AsyncIterator[StreamChunk]:
         """Send a message and yield streaming response chunks.
 
-        This is the main high-level operation:
-        1. Count existing assistant messages
-        2. Type message
-        3. Click send
-        4. Wait for new assistant message to appear
-        5. Poll DOM for streaming text
-        6. Fetch final text from conversation API
+        A2 turn-correlation sequence (peer-reviewed, conv ``6a482cfd``):
+        1. Read assistant-count baseline (A1 fail-closed).
+        2. Health-check the identity listener; re-enable if stale.
+        3. Arm a per-send capture scope (IdentityListener).
+        4. Build a pre-send fallback anchor (existing/degraded/fresh — NO
+           captured UUID yet; the UUID only exists in the POST that
+           click_send generates).
+        5. type_message + click_send.
+        6. Wait for the IdentityListener to capture the UUID (short timeout).
+        7. Anchor = fallback.with_captured_id(uuid) if captured else fallback.
+        8. stream_until_complete(turn_anchor=anchor) + anchored reconciliation.
+        9. ALWAYS: scope.close() in finally (clears capture state on every
+           terminal path — success, timeout, exception, cancellation).
         """
-        # PR4 belt-and-suspenders: refuse to mutate the DOM in parallel mode if
-        # the driver lost its owned tab. The primary gate is the resolver/drift
-        # guard at the REST/MCP lock site; this catches any driver-level path
-        # that reaches send_and_stream without going through the lock.
+        from .identity_listener import hash_sent_text
+        from .turn_anchor import TurnReconciliationError
+
+        # PR4 belt-and-suspenders: refuse to mutate the DOM in parallel mode.
         self._assert_owned_tab_required()
-        # Count existing assistants BEFORE sending. This baseline is the
-        # completion detector's reference: Phase-1 waits for
-        # current_count > initial_count. A wrong baseline (especially 0 on a
-        # conversation that already has assistant messages) makes the detector
-        # treat a PRE-EXISTING assistant node as "new" → stale-return (the
-        # bridge returns the previous turn's text). The old fallback
-        # (`initial_count = 0` on any JS failure) was the dominant root cause
-        # of stale-return during the parallel-tabs operational validation.
-        # See: references/agent-field-notes.md §1 (stale-return).
+        # A1: count existing assistants BEFORE sending (fail-closed baseline).
         initial_count = await self._read_assistant_count_baseline()
 
-        # Type and send
-        await self.type_message(text)
-        await self.click_send()
+        # A2 Step 2: identity-listener health check.
+        capture_scope = None
+        if self._identity_listener is not None:
+            await self._identity_listener.reenable_if_stale()
 
-        # Phase 5 PR4: the Phase-1 (assistant-node appear) and Phase-2 (DOM
-        # streaming + completion-detection) loops were extracted verbatim into
-        # CompletionDetector.stream_until_complete — a delta-only async
-        # sub-generator. Re-yield its chunks with NO buffering / post-processing
-        # so the public yield sequence stays byte-equivalent to pre-extraction.
-        # The detector yields StreamChunk(delta=...) only; the terminal
-        # finish_reason="stop" chunk is emitted by the tail below. The detector
-        # raises RateLimitError / GenerationStuckError on the same conditions
-        # the inline loops did; those propagate out of the async-for unchanged.
-        async for chunk in self._completion.stream_until_complete(
-            initial_count=initial_count,
-            timeout=timeout,
-        ):
-            yield chunk
+        # A2 Step 3+4: arm capture scope + build fallback anchor.
+        # The fallback anchor captures pre-send state (backend node-ids/times
+        # or wall-clock) for dual-anchor correlation if UUID capture fails.
+        fallback_anchor = await self._capture_pre_send_fallback_anchor(text)
+        if self._identity_listener is not None and self._identity_listener.is_alive():
+            capture_scope = self._identity_listener.arm_capture_scope(
+                expected_text_hash=hash_sent_text(text),
+                conversation_id=self._current_conv_id,
+                target_id=self._target_id,
+            )
 
+        try:
+            # Type and send.
+            await self.type_message(text)
+            await self.click_send()
 
-        # Wait for URL to become /c/{id}
-        conv_id = ""
-        for _ in range(30):
-            try:
-                url = await self._js_strict("window.location.href")
-            except CDPJSError:
-                await asyncio.sleep(0.5)
-                continue
-            if "/c/" in url:
-                conv_id = url.split("/c/")[1].split("/")[0].split("?")[0]
-                break
-            await asyncio.sleep(0.5)
+            # A2 Step 6: wait for the IdentityListener to capture the UUID.
+            captured_uuid = None
+            if capture_scope is not None:
+                captured_uuid = await self._identity_listener.wait_for_captured_uuid(timeout=5.0)
 
-        if conv_id:
-            logger.info("Conversation: %s", conv_id)
-            self._current_conv_id = conv_id
-            # last_dom_text is the streamed-text baseline accumulated by the
-            # Phase-2 loop in CompletionDetector; had_non_text_content flags an
-            # image/tool-use turn. Both are surfaced as per-call results on the
-            # detector (read here; the loop owned them pre-extraction).
-            last_dom_text = self._completion.last_dom_text
-            had_non_text_content = self._completion.had_non_text_content
-            # Fetch final text from API (more reliable than DOM for thinking models)
-            for _ in range(60):
-                api_text = await self._fetch_text(conv_id)
-                if api_text and len(api_text) > len(last_dom_text):
-                    yield StreamChunk(delta=api_text[len(last_dom_text) :])
-                    last_dom_text = api_text
-                    break
-                if api_text:
+            # A2 Step 7: build the final anchor (fallback + captured UUID).
+            turn_anchor = fallback_anchor.with_captured_id(captured_uuid)
+
+            # A2 Step 8: stream + completion with the anchored turn.
+            async for chunk in self._completion.stream_until_complete(
+                initial_count=initial_count,
+                timeout=timeout,
+                turn_anchor=turn_anchor,
+            ):
+                yield chunk
+
+            # Wait for URL to become /c/{id}
+            conv_id = ""
+            for _ in range(30):
+                try:
+                    url = await self._js_strict("window.location.href")
+                except CDPJSError:
+                    await asyncio.sleep(0.5)
+                    continue
+                if "/c/" in url:
+                    conv_id = url.split("/c/")[1].split("/")[0].split("?")[0]
                     break
                 await asyncio.sleep(0.5)
-            # If no text was captured but Phase-2 detected non-text content
-            # (image, tool-use, etc.), surface a placeholder so the agent
-            # knows something was generated and where to find it.
-            if not last_dom_text and had_non_text_content:
-                placeholder = (
-                    "[Non-text response generated (image/tool-use/etc.) — "
-                    "use get_conversation to retrieve full content.]"
-                )
-                yield StreamChunk(delta=placeholder)
+
+            if conv_id:
+                logger.info("Conversation: %s", conv_id)
+                self._current_conv_id = conv_id
+                last_dom_text = self._completion.last_dom_text
+                had_non_text_content = self._completion.had_non_text_content
+                # A2: anchored final-text reconciliation. The selector resolves
+                # the terminal assistant text for THIS turn (by captured UUID
+                # or dual-anchor fallback); stale text from a prior turn is
+                # never accepted.
+                last_status = "not_ready"
+                for _ in range(60):
+                    result = await self._fetch_text_for_turn(conv_id, turn_anchor)
+                    last_status = result.status
+                    if result.status == "matched" and result.text:
+                        if len(result.text) > len(last_dom_text):
+                            yield StreamChunk(delta=result.text[len(last_dom_text):])
+                            last_dom_text = result.text
+                        break
+                    if result.status == "non_text":
+                        break  # placeholder path below
+                    if result.status in ("ambiguous", "degraded_not_fresh", "fetch_failed"):
+                        # Keep polling — these may resolve as the backend settles.
+                        pass
+                    # not_ready → keep polling.
+                    await asyncio.sleep(0.5)
+                else:
+                    # Loop exhausted without match — raise typed error.
+                    raise TurnReconciliationError(
+                        conversation_id=conv_id,
+                        anchor_mode=turn_anchor.mode,
+                        last_status=last_status,
+                        diagnostic={
+                            "captured_id": turn_anchor.captured_user_message_id,
+                            "had_non_text_content": had_non_text_content,
+                        },
+                    )
+                # Non-text placeholder (unchanged from pre-A2).
+                if not last_dom_text and had_non_text_content:
+                    placeholder = (
+                        "[Non-text response generated (image/tool-use/etc.) — "
+                        "use get_conversation to retrieve full content.]"
+                    )
+                    yield StreamChunk(delta=placeholder)
+        finally:
+            # A2 Step 9: ALWAYS clear the capture scope (failure-mode E).
+            if capture_scope is not None:
+                capture_scope.close()
 
         yield StreamChunk(delta="", finish_reason="stop")
 
-    async def _fetch_text(self, conversation_id: str) -> str:
-        """Fetch the latest assistant text from the conversation API.
+    async def _fetch_text_for_turn(self, conversation_id: str, anchor):
+        """A2 anchored final-text fetch. Delegated to BackendClient.
 
-        Delegated to BackendClient (Phase 5 PR1 extraction). The 401→
-        AuthExpiredError+trip behavior is preserved exactly; a transient 404
-        (conversation not yet persisted after send) is now retried a bounded
-        number of times before surfacing as RuntimeError (PR #23).
+        Returns a ``TurnTextResult`` (rich status). The detector tail in
+        ``send_and_stream`` uses this to resolve the terminal assistant text
+        for the submitted turn via the captured anchor.
         """
-        return await self._backend_client._fetch_text(conversation_id)
+        return await self._backend_client._fetch_text_for_turn(conversation_id, anchor)
+
+    async def _fetch_end_turn_for_turn(
+        self, conversation_id: str, anchor, *, had_non_text_content: bool
+    ):
+        """A2 anchored completion-status fetch. Delegated to BackendClient.
+
+        Returns a ``TurnEndResult`` (internal status); the detector collapses
+        to tri-state via ``collapse_to_end_turn_status``.
+        """
+        return await self._backend_client._fetch_end_turn_for_turn(
+            conversation_id, anchor, had_non_text_content=had_non_text_content,
+        )
 
     async def _conversation_id_from_url(self) -> str:
         """Parse the conversation id from the live tab's location.href.
@@ -1446,13 +1610,6 @@ class CDPDriver:
 
         Delegated to BackendClient (Phase 5 PR1 extraction)."""
         return await self._backend_client._get_live_conversation_id_best_effort()
-
-    async def _fetch_end_turn(self, conversation_id: str) -> bool:
-        """Backend secondary completion signal: is the latest assistant TEXT
-        node marked ``end_turn === true``?
-
-        Delegated to BackendClient (Phase 5 PR1 extraction)."""
-        return await self._backend_client._fetch_end_turn(conversation_id)
 
     async def dismiss_rate_limit(self) -> bool:
         """Dismiss ChatGPT's 'Too many requests' pop-up by clicking 'Got it'.

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -469,6 +469,12 @@ class CDPDriver:
                 self._target_id = None
                 self._owns_target = False
                 ws_url = await self._find_page_ws()
+        # Keepalive: ping every 20s, allow 10s for pong response. This is
+        # the pre-A2 production value (set during parallel-tabs PR2); the A2
+        # plan proposed ping_timeout=60, but the existing value of 10 passed
+        # the post-idle survival test (130s idle, listener stayed alive) and
+        # is tighter against transient stalls. Kept deliberately; see PR #39
+        # review finding #4.
         self._ws = await websockets.connect(
             ws_url,
             max_size=100 * 1024 * 1024,

--- a/src/chatgpt_web2api/cdp_transport.py
+++ b/src/chatgpt_web2api/cdp_transport.py
@@ -68,9 +68,19 @@ class CDPTransport:
         """Background reader: sole consumer of self._ws.recv().
 
         Routes each incoming CDP message to the matching pending Future by id.
-        Messages without an id (CDP events like Page.frameNavigated) are logged
-        at DEBUG and discarded — no caller subscribes to events today, but the
-        hook is here for future navigation-ready detection.
+        Messages without an id (unsolicited CDP events like
+        ``Network.requestWillBeSent``, ``Page.frameNavigated``) are dispatched
+        to a registered event handler if one exists for the event's method
+        name (via ``driver._cdp_event_handlers``); otherwise they are logged
+        at DEBUG and discarded.
+
+        Event-handler contract: handlers MUST be fast and non-blocking. The
+        reader loop is the sole consumer of ``ws.recv()`` and also resolves
+        all pending CDP command futures — blocking it on heavy work (e.g.
+        parsing a large POST body synchronously) risks unrelated CDP
+        timeouts. Handlers that need to do expensive work should schedule it
+        via ``loop.create_task`` and return immediately. If a handler raises,
+        it is logged and swallowed so one bad handler cannot kill the reader.
 
         On ConnectionClosed, fails all pending futures so callers don't hang.
         """
@@ -85,8 +95,23 @@ class CDPTransport:
                     continue
                 mid = msg.get("id")
                 if mid is None:
-                    # Unsolicited CDP event — no caller subscribes yet.
-                    logger.debug("CDP event: %s", msg.get("method", "?"))
+                    # Unsolicited CDP event. Dispatch to a registered handler
+                    # if one exists for this method name; else debug-log.
+                    method = msg.get("method")
+                    if method:
+                        # Generic dispatch table on the driver (Layer 2 owns
+                        # handler registration — transport is wire-only).
+                        handlers = getattr(d, "_cdp_event_handlers", None)
+                        handler = handlers.get(method) if handlers else None
+                        if handler is not None:
+                            try:
+                                handler(msg)
+                            except Exception:
+                                logger.exception(
+                                    "CDP event handler failed for %s", method
+                                )
+                        elif logger.isEnabledFor(logging.DEBUG):
+                            logger.debug("CDP event: %s", method)
                     continue
                 fut = d._pending.pop(mid, None)
                 if fut and not fut.done():

--- a/src/chatgpt_web2api/completion_detector.py
+++ b/src/chatgpt_web2api/completion_detector.py
@@ -16,21 +16,22 @@ detection surface that was previously inlined in ``CDPDriver.send_and_stream``:
 The driver-reference collaborator seam: ``CompletionDetector`` holds a
 reference to its owning ``CDPDriver`` and reaches through it for the CDP
 transport (``_js_strict``), the backend completion signals
-(``_fetch_end_turn`` / ``_get_live_conversation_id_best_effort``), and the
-in-flight conversation id (``_current_conv_id``, read-only). No state migrates
-into this module — it stays on the driver, and the detector is stateless
-beyond ``_driver``.
+(``_fetch_end_turn_for_turn`` / ``_get_live_conversation_id_best_effort``),
+and the in-flight conversation id (``_current_conv_id``, read-only). No state
+migrates into this module — it stays on the driver, and the detector is
+stateless beyond ``_driver``.
 
 Boundary: this module is the generation-completion detection layer.
 ``send_and_stream`` orchestration (pre-count, type/send, the post-loop
-conversation-id resolve + ``_current_conv_id`` mutation, the ``_fetch_text``
-final reconcile, and the terminal ``finish_reason="stop"`` chunk) stays in
-``cdp_driver.py``. The detector yields **deltas only** — it never emits a
+conversation-id resolve + ``_current_conv_id`` mutation, the
+``_fetch_text_for_turn`` final reconcile, and the terminal
+``finish_reason="stop"`` chunk) stays in ``cdp_driver.py``. The detector
+yields **deltas only** — it never emits a
 ``finish_reason`` and never writes ``_current_conv_id``.
 
 Per-call result surfacing: the driver's post-loop tail consumes two values the
 Phase-2 loop accumulates as locals — ``last_dom_text`` (the streamed-text
-baseline used to emit the ``_fetch_text`` suffix delta) and
+baseline used to emit the ``_fetch_text_for_turn`` suffix delta) and
 ``had_non_text_content`` (drives the non-text placeholder). They cannot be
 re-derived without re-running the poll, so after the generator exhausts the
 driver reads ``self._completion.last_dom_text`` /
@@ -43,7 +44,7 @@ through ``self._driver`` (NOT ``self``) to preserve monkeypatch interception on
 the driver-facing seam (the PR2 lesson):
 
   transport:       self._driver._js_strict(...)
-  backend signals: self._driver._fetch_end_turn(...)
+  backend signals: self._driver._fetch_end_turn_for_turn(...)
                    self._driver._get_live_conversation_id_best_effort(...)
   conv-id read:    self._driver._current_conv_id   (read once into a local;
                    NEVER assigned here)
@@ -131,6 +132,7 @@ class CompletionDetector:
         *,
         initial_count: int,
         timeout: float,
+        turn_anchor,
     ) -> AsyncIterator[StreamChunk]:
         """Run Phase-1 (appear) + Phase-2 (stream) and yield delta chunks.
 
@@ -140,11 +142,20 @@ class CompletionDetector:
         iterating) once generation is detected complete (backend ``end_turn``
         primary, action-button fallback, or a stall raises
         ``GenerationStuckError``).
+
+        A2: ``turn_anchor`` is required. The backend ``end_turn`` completion
+        signal is turn-correlated via ``_fetch_end_turn_for_turn`` (tri-state).
+        The DOM
+        ``has_action`` fallback gate is unchanged — ``backend_fetch_failed`` is
+        set ONLY on ``fetch_failed`` (true transport failure), NOT on
+        ``not_ready``/``ambiguous``/``degraded_not_fresh`` (which collapse to
+        ``not_ready`` and must NOT unlock the DOM fallback).
         """
         # Imported lazily to avoid a module-load circular dependency: cdp_driver
         # top-level re-exports PHASE_STALL_SECONDS / is_rate_limited_text from
         # this module, so this module must not import cdp_driver at load time.
         from .cdp_driver import CDPJSError, GenerationStuckError, RateLimitError, StreamChunk
+        from .turn_anchor import collapse_to_end_turn_status
 
         d = self._driver
 
@@ -348,7 +359,7 @@ class CompletionDetector:
                     # pinned is_thinking=true on every thinking-model turn
                     # and on any answer that mentioned the word "thinking",
                     # which suppressed all delta emission (see the elif below)
-                    # and produced empty responses when _fetch_text lagged.
+                    # and produced empty responses when the backend fetch lagged.
                     # Also recognize a plain "Thinking..." innerText placeholder
                     # (some layouts show reasoning text without .result-thinking)
                     # so the stall clock treats it as active generation, not a stall.
@@ -450,7 +461,19 @@ class CompletionDetector:
             ):
                 last_backend_check = time.monotonic()
                 try:
-                    if await d._fetch_end_turn(conv_id_for_check):
+                    # A2: anchored tri-state completion. The selector returns
+                    # a rich TurnEndResult; collapse_to_end_turn_status maps
+                    # it to the detector's tri-state gate. Critical: not_ready/
+                    # ambiguous/degraded_not_fresh collapse to not_ready and
+                    # must NOT set backend_fetch_failed (would unlock the DOM
+                    # fallback and risk completing off a prior turn's action
+                    # row — the line-493 gate invariant).
+                    end_result = await d._fetch_end_turn_for_turn(
+                        conv_id_for_check, turn_anchor,
+                        had_non_text_content=had_non_text_content,
+                    )
+                    status = collapse_to_end_turn_status(end_result)
+                    if status == "complete":
                         # STRICT: end_turn AND usable content. The saw_thinking
                         # unlock lets us CONSULT the backend during thinking, but
                         # we must not finish on a bare end_turn with no answer.
@@ -465,9 +488,21 @@ class CompletionDetector:
                             "not completing (strict content guard)",
                             conv_id_for_check,
                         )
+                    elif status == "fetch_failed":
+                        backend_fetch_failed = True
+                        logger.debug(
+                            "end_turn fetch failed (status=%s): %s",
+                            end_result.status, end_result.diagnostic,
+                        )
+                    # else: not_ready — no-op (do NOT set backend_fetch_failed).
                 except Exception as e:
+                    # AuthExpiredError or unexpected — preserve existing
+                    # behavior of treating fetch exceptions as fallback-unlock.
+                    # (Auth errors propagate from the fetcher as AuthExpiredError
+                    # and should NOT be swallowed; but preserving the prior
+                    # broad-except for safety during the transition.)
                     backend_fetch_failed = True
-                    logger.debug("end_turn fetch failed (ignored): %s", e)
+                    logger.debug("end_turn fetch raised (ignored): %s", e)
 
             # FALLBACK: DOM action button (has_action). Used ONLY when the primary
             # backend signal can't run: conv_id is unavailable (before the URL
@@ -493,5 +528,5 @@ class CompletionDetector:
 
         # Per-call results (last_dom_text / had_non_text_content) are already
         # mirrored to self.* as they changed during the loop; the driver tail
-        # reads them to emit the _fetch_text suffix delta / non-text placeholder.
+        # reads them to emit the final-text suffix delta / non-text placeholder.
         return

--- a/src/chatgpt_web2api/completion_detector.py
+++ b/src/chatgpt_web2api/completion_detector.py
@@ -154,7 +154,13 @@ class CompletionDetector:
         # Imported lazily to avoid a module-load circular dependency: cdp_driver
         # top-level re-exports PHASE_STALL_SECONDS / is_rate_limited_text from
         # this module, so this module must not import cdp_driver at load time.
-        from .cdp_driver import CDPJSError, GenerationStuckError, RateLimitError, StreamChunk
+        from .cdp_driver import (
+            AuthExpiredError,
+            CDPJSError,
+            GenerationStuckError,
+            RateLimitError,
+            StreamChunk,
+        )
         from .turn_anchor import collapse_to_end_turn_status
 
         d = self._driver
@@ -495,12 +501,14 @@ class CompletionDetector:
                             end_result.status, end_result.diagnostic,
                         )
                     # else: not_ready — no-op (do NOT set backend_fetch_failed).
+                except AuthExpiredError:
+                    # Auth failure must NEVER degrade to DOM fallback.
+                    # (PR #39 review finding #2 — the prior broad except
+                    # swallowed this, violating "auth failure never degrades.")
+                    raise
                 except Exception as e:
-                    # AuthExpiredError or unexpected — preserve existing
-                    # behavior of treating fetch exceptions as fallback-unlock.
-                    # (Auth errors propagate from the fetcher as AuthExpiredError
-                    # and should NOT be swallowed; but preserving the prior
-                    # broad-except for safety during the transition.)
+                    # Transport/backend failure — treat as fetch_failed so the
+                    # DOM fallback unlocks for this poll.
                     backend_fetch_failed = True
                     logger.debug("end_turn fetch raised (ignored): %s", e)
 

--- a/src/chatgpt_web2api/identity_listener.py
+++ b/src/chatgpt_web2api/identity_listener.py
@@ -1,0 +1,399 @@
+"""A2 identity listener — observes the client-generated message UUID from
+ChatGPT's outgoing send POST and exposes it for turn correlation.
+
+Investigation findings (Phase 1, peer-reviewed):
+  - The send goes to ``POST /backend-api/f/conversation`` (note the ``/f/``
+    prefix — fetch/stream).
+  - The POST body's ``messages[0].id`` is a client-generated UUID that
+    survives into the backend conversation mapping as the user node's
+    ``message.id`` (exact match, verified 12/12).
+  - ``Network.requestWillBeSent`` with ``maxPostDataSize=4MB`` carries the
+    POST body in ``request.postData`` (100% capture, 12/12).
+  - ``window.fetch`` runtime override does NOT work (the frontend captures
+    the fetch reference at module load); CDP Network is the ONLY viable
+    capture mechanism.
+
+The listener is a target-lifecycle component owned by ``CDPDriver`` (not the
+transport — the transport is wire-only). The driver attaches it on
+``connect()``/``reconnect()`` and re-arms it on target drift. Per send, the
+driver arms a capture scope before ``click_send`` and consumes the captured
+UUID after the send fires (the UUID only exists in the POST that
+``click_send`` generates).
+
+Handler contract: the ``Network.requestWillBeSent`` handler registered here
+is called synchronously from ``CDPTransport._reader_loop`` (the sole
+``ws.recv()`` consumer). It MUST be fast: it does only a URL/method prefilter
+synchronously and schedules the heavy POST-body parse via
+``loop.create_task`` so the reader loop is never blocked on JSON parsing or
+hashing of large request bodies.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import re
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+# CDP Network.enable parameter for capturing POST bodies. Stress test 2
+# verified no truncation up to 2MB with this value.
+_MAX_POST_DATA_SIZE = 4 * 1024 * 1024
+
+# The send endpoint. Note the /f/ prefix (fetch/stream).
+_SEND_ENDPOINT_SUFFIX = "/backend-api/f/conversation"
+
+# UUID v4 shape (8-4-4-4-12 hex). Used to validate messages[0].id.
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I
+)
+
+
+@dataclass
+class CaptureResult:
+    """The outcome of one capture scope."""
+
+    uuid: str | None = None
+    # Why capture failed/succeeded, for metrics/diagnostics.
+    reason: str = ""
+    # When multiple candidate POSTs matched, this records how we picked.
+    candidate_count: int = 0
+    request_id: str | None = None
+
+
+class CaptureScope:
+    """Per-send capture scope, armed before ``click_send`` and closed in
+    ``finally`` on every terminal path.
+
+    Closing the scope clears the armed state so a late POST from a failed
+    send cannot contaminate the next send (failure-mode E). The scope holds
+    a future that ``wait_for_captured_uuid`` awaits; the handler resolves it
+    when a matching POST is observed or the scope is closed without a match.
+    """
+
+    def __init__(
+        self,
+        listener: IdentityListener,
+        expected_text_hash: str,
+        conversation_id: str | None,
+        target_id: str | None,
+        send_sequence_id: int,
+    ) -> None:
+        self._listener = listener
+        self.expected_text_hash = expected_text_hash
+        self.conversation_id = conversation_id
+        self.target_id = target_id
+        self.send_sequence_id = send_sequence_id
+        self._future: asyncio.Future[CaptureResult] | None = None
+        self._closed = False
+
+    def _arm(self) -> None:
+        """Resolve the wait future when a result lands or the scope closes."""
+        self._future = asyncio.get_event_loop().create_future()
+
+    @property
+    def future(self) -> asyncio.Future[CaptureResult] | None:
+        return self._future
+
+    def close(self) -> None:
+        """Clear armed state. Safe to call multiple times (idempotent)."""
+        if self._closed:
+            return
+        self._closed = True
+        # If wait_for_captured_uuid is still awaiting, unblock it with no UUID.
+        if self._future is not None and not self._future.done():
+            self._future.set_result(CaptureResult(reason="scope_closed"))
+        self._listener._clear_active_scope(self)
+
+    def _resolve(self, result: CaptureResult) -> None:
+        """Called by the listener when a matching POST is observed."""
+        if self._future is not None and not self._future.done():
+            self._future.set_result(result)
+
+
+class IdentityListener:
+    """Persistent per-target CDP Network listener for client-message-ID capture.
+
+    Owned by ``CDPDriver`` (Layer 2). The driver attaches it on connect/reconnect
+    and arms a per-send capture scope before each ``click_send``.
+
+    The listener registers ONE event handler (``Network.requestWillBeSent``)
+    on the driver's ``_cdp_event_handlers`` table (the generic dispatch
+    mechanism added in Step 1). The handler is non-blocking: it does a fast
+    URL/method prefilter and schedules the heavy parse via ``create_task``.
+    """
+
+    def __init__(self, driver) -> None:
+        self._driver = driver
+        self._ready = False
+        self._active_scope: CaptureScope | None = None
+        self._send_sequence = 0
+        # Metrics counters (emitted via structured logs; full metric plumbing
+        # comes with the observability pass).
+        self.capture_success_count = 0
+        self.capture_missed_count = 0
+        self.capture_ambiguous_count = 0
+        self.fallback_reasons: dict[str, int] = {}
+        self.postdata_missing_count = 0
+        self.reenabled_count = 0
+        self.reconnect_count = 0
+
+    # ── Lifecycle ──────────────────────────────────────────────
+
+    async def attach(self) -> None:
+        """Register the event handler and enable the Network domain.
+
+        Called by the driver on connect/reconnect. Idempotent: safe to call
+        when already attached (re-registers the handler, re-enables Network).
+        """
+        d = self._driver
+        # Register the handler on the driver's dispatch table.
+        d._cdp_event_handlers["Network.requestWillBeSent"] = self._on_request_will_be_sent
+        # Enable the Network domain with POST-body capture.
+        try:
+            await d._cdp(
+                "Network.enable",
+                {"maxPostDataSize": _MAX_POST_DATA_SIZE},
+                timeout=10,
+            )
+            self._ready = True
+            self.reconnect_count += 1
+            logger.info("identity_listener_ready (send_seq=%d)", self._send_sequence)
+        except Exception as e:
+            self._ready = False
+            logger.warning("identity_listener_attach_failed: %s", e)
+
+    def detach(self) -> None:
+        """Unregister the handler (e.g., on close or before a fresh attach)."""
+        d = self._driver
+        d._cdp_event_handlers.pop("Network.requestWillBeSent", None)
+        self._ready = False
+
+    def is_alive(self) -> bool:
+        """Health check: is the listener ready to capture?
+
+        This is a liveness signal, not a guarantee that the next POST will be
+        captured. The driver calls this before each send and calls
+        ``reenable_if_stale`` if False.
+        """
+        return self._ready
+
+    async def reenable_if_stale(self) -> bool:
+        """Idempotently re-enable the Network domain if the listener is stale.
+
+        Returns True if the listener is ready after this call. Used as a
+        pre-send health check inside the MutationLock.
+        """
+        if self._ready:
+            return True
+        try:
+            await self._driver._cdp(
+                "Network.enable",
+                {"maxPostDataSize": _MAX_POST_DATA_SIZE},
+                timeout=10,
+            )
+            self._ready = True
+            self.reenabled_count += 1
+            logger.info("identity_listener_reenabled")
+            return True
+        except Exception as e:
+            self._ready = False
+            logger.warning("identity_listener_reenable_failed: %s", e)
+            return False
+
+    # ── Per-send capture ───────────────────────────────────────
+
+    def arm_capture_scope(
+        self,
+        *,
+        expected_text_hash: str,
+        conversation_id: str | None,
+        target_id: str | None,
+    ) -> CaptureScope:
+        """Arm a fresh capture scope before ``click_send``.
+
+        The driver calls this inside the MutationLock, after
+        ``reenable_if_stale``. The returned scope MUST be closed in ``finally``
+        on every terminal path (success, timeout, exception, cancellation).
+        """
+        self._send_sequence += 1
+        scope = CaptureScope(
+            listener=self,
+            expected_text_hash=expected_text_hash,
+            conversation_id=conversation_id,
+            target_id=target_id,
+            send_sequence_id=self._send_sequence,
+        )
+        scope._arm()
+        # Replace any stale active scope (shouldn't happen if close() is used
+        # correctly, but defensive).
+        if self._active_scope is not None and not self._active_scope._closed:
+            logger.warning(
+                "identity_listener: arming new scope while previous is active "
+                "(seq=%d); closing stale", self._active_scope.send_sequence_id
+            )
+            self._active_scope.close()
+        self._active_scope = scope
+        return scope
+
+    async def wait_for_captured_uuid(self, timeout: float = 5.0) -> str | None:
+        """Wait for the armed scope to capture a UUID, or timeout.
+
+        Returns the captured UUID, or None if the scope closed without a
+        capture (timeout, scope closed by finally, or no matching POST).
+        """
+        scope = self._active_scope
+        if scope is None or scope.future is None:
+            return None
+        try:
+            result = await asyncio.wait_for(scope.future, timeout=timeout)
+            return result.uuid
+        except TimeoutError:
+            self.capture_missed_count += 1
+            self._record_fallback_reason("capture_timeout")
+            logger.info(
+                "identity_capture_missed: timeout after %.1fs (seq=%d)",
+                timeout, scope.send_sequence_id,
+            )
+            return None
+
+    def _clear_active_scope(self, scope: CaptureScope) -> None:
+        """Internal: called by CaptureScope.close() to clear the active ref."""
+        if self._active_scope is scope:
+            self._active_scope = None
+
+    def _record_fallback_reason(self, reason: str) -> None:
+        self.fallback_reasons[reason] = self.fallback_reasons.get(reason, 0) + 1
+
+    # ── Event handler (non-blocking) ────────────────────────────
+
+    def _on_request_will_be_sent(self, msg: dict) -> None:
+        """``Network.requestWillBeSent`` handler.
+
+        Called SYNCHRONOUSLY from the reader loop. MUST be fast. Does only
+        a URL/method prefilter; if promising, schedules the heavy parse via
+        ``create_task`` so the reader loop is never blocked.
+        """
+        scope = self._active_scope
+        if scope is None or scope._closed:
+            return  # no capture armed
+        try:
+            params = msg.get("params") or {}
+            req = params.get("request") or {}
+            url = req.get("url") or ""
+            method = req.get("method") or ""
+            # Fast prefilter: only POST to the send endpoint.
+            if method != "POST" or not url.rstrip("/").endswith(_SEND_ENDPOINT_SUFFIX):
+                return
+            # Promising — schedule the heavy parse off the reader loop.
+            loop = asyncio.get_event_loop()
+            loop.create_task(self._process_send_post(scope, msg, url))
+        except Exception:
+            # Never let handler errors escape into the reader loop.
+            logger.exception("identity_listener: handler error in prefilter")
+
+    async def _process_send_post(self, scope: CaptureScope, msg: dict, url: str) -> None:
+        """Heavy parse + validation, scheduled off the reader loop.
+
+        Validates the POST belongs to this send (failure-mode B), extracts
+        the UUID, and resolves the scope's future.
+        """
+        try:
+            params = msg.get("params") or {}
+            req = params.get("request") or {}
+            request_id = params.get("requestId")
+            post_data = req.get("postData")
+
+            if not post_data:
+                # Failure-mode C: postData absent → try getRequestPostData once.
+                self.postdata_missing_count += 1
+                post_data = await self._fetch_post_data(request_id)
+                if not post_data:
+                    self._record_fallback_reason("postdata_missing")
+                    return  # leave scope open; a later POST may match
+
+            # Parse + validate.
+            try:
+                parsed = json.loads(post_data)
+            except (json.JSONDecodeError, TypeError) as e:
+                self._record_fallback_reason("postdata_unparseable")
+                logger.debug("identity_capture: post_data not JSON: %s", e)
+                return
+
+            # Failure-mode B: validate the POST belongs to this send.
+            action = parsed.get("action")
+            if action != "next":
+                return  # not a user send (could be a regenerate/edit/etc.)
+            messages = parsed.get("messages") or []
+            if not messages:
+                return
+            m0 = messages[0]
+            author = (m0.get("author") or {}).get("role")
+            if author != "user":
+                return
+            uuid = m0.get("id")
+            if not uuid or not _UUID_RE.match(str(uuid)):
+                self._record_fallback_reason("uuid_invalid")
+                return
+            # conversation_id match if known.
+            body_conv_id = parsed.get("conversation_id")
+            if scope.conversation_id and body_conv_id and body_conv_id != scope.conversation_id:
+                # Different conversation — not our send.
+                return
+            # text-hash match if available (failure-mode D: multiple POSTs).
+            parts = (m0.get("content") or {}).get("parts") or []
+            body_text = "\n".join(str(p) for p in parts if isinstance(p, str))
+            if body_text:
+                body_hash = hashlib.sha256(body_text.encode("utf-8")).hexdigest()
+                if body_hash != scope.expected_text_hash:
+                    # Text doesn't match — could be a different send (retry,
+                    # regenerate). Don't resolve; leave scope open.
+                    logger.debug(
+                        "identity_capture: text hash mismatch (expected %s, got %s) — "
+                        "not our send, leaving scope open",
+                        scope.expected_text_hash[:12], body_hash[:12],
+                    )
+                    return
+
+            # Success — resolve the scope.
+            self.capture_success_count += 1
+            scope._resolve(CaptureResult(
+                uuid=uuid,
+                reason="matched",
+                candidate_count=1,
+                request_id=request_id,
+            ))
+            logger.info(
+                "identity_capture_success: uuid=%s seq=%d",
+                uuid, scope.send_sequence_id,
+            )
+        except Exception:
+            logger.exception("identity_listener: error processing send POST")
+
+    async def _fetch_post_data(self, request_id: str | None) -> str | None:
+        """Failure-mode C: try Network.getRequestPostData if postData absent."""
+        if not request_id:
+            return None
+        try:
+            result = await self._driver._cdp(
+                "Network.getRequestPostData",
+                {"requestId": request_id},
+                timeout=10,
+            )
+            return (result.get("result") or {}).get("postData")
+        except Exception as e:
+            logger.debug("identity_capture: getRequestPostData failed: %s", e)
+            return None
+
+
+def hash_sent_text(text: str) -> str:
+    """Stable SHA-256 hash of the sent prompt, for capture validation.
+
+    The hash is computed over the *raw* sent text (before any normalization)
+    because the POST body carries the raw text. Used by the capture scope to
+    validate a POST belongs to this send (failure-mode D).
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/src/chatgpt_web2api/turn_anchor.py
+++ b/src/chatgpt_web2api/turn_anchor.py
@@ -338,23 +338,45 @@ def _resolve_user_node(mapping: dict, anchor: TurnAnchor) -> tuple[str | None, s
         return fresh[0][0], "text_match_with_anchor"
 
     if anchor.mode == "degraded_existing":
-        # Wall-clock freshness floor.
+        # Wall-clock freshness floor. SKEW_TOLERANCE_SECONDS is a lower-bound
+        # guard — it rejects sufficiently-old nodes but NOT rapid same-text
+        # repeats (a previous turn sent up to ~13s prior can still pass).
+        #
+        # PR #39 review finding #3: a single degraded text match that passes
+        # the freshness floor could still be the PREVIOUS turn's user node
+        # (if the same text was sent twice rapidly). Without a captured UUID,
+        # we cannot distinguish "the new node propagated" from "the old node
+        # is still fresh enough." So: never silently accept a single degraded
+        # match — return not_ready and let the caller keep polling. When the
+        # new node propagates, either the ID path resolves it (if the UUID
+        # arrives late) or a second match appears (→ ambiguous → poll until
+        # one is clearly newer). This makes degraded_existing a pure "keep
+        # waiting" signal, not a "best guess" — matching the design intent
+        # ("never silently pick an ambiguous candidate").
         fresh = []
+        stale = []
         for nid, node in matching:
             ct = _node_create_time(node)
             if anchor.pre_send_wall_time is not None:
                 if ct >= anchor.pre_send_wall_time - SKEW_TOLERANCE_SECONDS:
                     fresh.append((nid, node))
                 else:
-                    # Single stale match → degraded_not_fresh later.
-                    pass
+                    stale.append((nid, node))
             else:
                 fresh.append((nid, node))  # no wall time; can't freshness-check
+        if fresh and len(fresh) > 1:
+            return None, "ambiguous"
+        if fresh and len(fresh) == 1 and not stale:
+            # Single fresh match, no stale alternatives. This is the normal
+            # case when degraded mode fires on a conversation where the same
+            # text has NOT been sent before — the single match IS the new turn.
+            # Accept it.
+            return fresh[0][0], "degraded_text_match"
+        # Either: no fresh matches (all stale → degraded_not_fresh), or
+        # single fresh + stale alternatives (can't distinguish → keep polling).
         if not fresh:
             return None, "degraded_not_fresh"
-        if len(fresh) > 1:
-            return None, "ambiguous"
-        return fresh[0][0], "degraded_text_match"
+        return None, "degraded_ambiguous_with_stale"
 
     if anchor.mode == "fresh_chat":
         # Text-only; first/only match expected on a fresh chat.

--- a/src/chatgpt_web2api/turn_anchor.py
+++ b/src/chatgpt_web2api/turn_anchor.py
@@ -1,0 +1,559 @@
+"""A2 turn anchor — pure-Python turn-correlation types and selectors.
+
+This module is CDP-free: it operates on the projected mapping dict produced by
+``backend_projection.CONVERSATION_PROJECTION_JS`` and a ``TurnAnchor`` captured
+by the driver/identity-listener. Everything here is unit-testable without a
+real browser.
+
+Two-tier correlation (peer-reviewed, conv ``6a482cfd``):
+
+  Primary: observed client-message-ID.
+    ``TurnAnchor.captured_user_message_id`` (from the IdentityListener) exactly
+    identifies the submitted user node in the backend mapping. The selector
+    finds ``mapping[message.id == captured_id]`` and walks to its terminal
+    assistant response.
+
+  Fallback: dual-anchor (when capture failed).
+    - ``existing_conversation``: sent_text + pre-send backend node-id/time.
+    - ``degraded_existing``: sent_text + wall-clock freshness (TOL=8s, lower-
+      bound guard only — NOT a rapid-same-text discriminator).
+    - ``fresh_chat``: sent_text-only until conv_id resolves.
+
+Selector rules (ChatGPT round 4):
+  - Resolve the user node first, then walk to its assistant response.
+  - Terminal selection: NEWEST ``end_turn=true`` assistant text descendant
+    (NOT first descendant — ChatGPT caught that "first" returns drafts).
+  - Non-text completion only when ``had_non_text_content`` is True (DOM guard).
+  - Bidirectional traversal: children-walk primary, parent-pointer fallback.
+
+Internal status vocabulary collapses to tri-state for the detector:
+  complete ← matched_text_complete, matched_non_text_complete (with DOM guard)
+  not_ready ← not_ready, ambiguous, degraded_not_fresh
+  fetch_failed ← transport_failed
+  auth_failed propagates as AuthExpiredError (never degrades).
+"""
+from __future__ import annotations
+
+# ── Constants ─────────────────────────────────────────────────────────────
+# Empirically derived (Phase 0.5 + stress test 4): backend create_time leads
+# local wall clock by ~5.1s (mean 5.17, std 0.119, all positive). The freshness
+# floor is a lower-bound guard for degraded mode — it rejects sufficiently-old
+# nodes but NOT rapid same-text repeats (a previous turn sent up to ~13s prior
+# can still pass). For rapid same-text repeats, the selector returns ``ambiguous``
+# or ``not_ready`` rather than silently picking. Env-overridable for canary tuning.
+import os as _os
+import unicodedata
+from dataclasses import dataclass, field, replace
+from typing import Literal
+
+try:
+    SKEW_TOLERANCE_SECONDS = float(
+        _os.getenv("W2A_TURN_DEGRADED_SKEW_TOLERANCE_SECONDS", "8.0")
+    )
+except (ValueError, TypeError):
+    SKEW_TOLERANCE_SECONDS = 8.0
+
+# Matcher thresholds (ChatGPT round 1). Full normalized equality for prompts
+# up to this length; truncated-prefix acceptance for longer prompts (backend
+# truncation). No tiny prefixes — agent prompts share boilerplate.
+_PREFIX_MATCH_MIN = 1024
+
+
+# ── Anchor mode ───────────────────────────────────────────────────────────
+
+AnchorMode = Literal[
+    "captured_id",          # primary: IdentityListener captured the UUID
+    "existing_conversation",  # fallback: backend node-id/time anchor
+    "degraded_existing",    # fallback: sent_text + wall-clock freshness
+    "fresh_chat",           # fallback: sent_text-only until conv_id resolves
+]
+
+
+@dataclass(frozen=True)
+class TurnAnchor:
+    """Immutable snapshot of the conversation state around one send.
+
+    Constructed by the driver in ``send_and_stream``. The ``captured_user_message_id``
+    field is populated AFTER ``click_send`` (the UUID only exists in the POST
+    that the send generates) via ``with_captured_id``. Selector priority: if
+    ``captured_user_message_id`` is set, use ID-based correlation; else use the
+    fallback mode.
+    """
+
+    sent_text: str
+    mode: AnchorMode
+    # Primary path: the client UUID observed by the IdentityListener. None
+    # until the POST is captured (or None for the whole send if capture failed).
+    captured_user_message_id: str | None = None
+    # Fallback path: pre-send backend anchors (existing_conversation only).
+    latest_user_node_id: str | None = None
+    latest_user_create_time: float | None = None
+    latest_assistant_node_id: str | None = None
+    latest_assistant_create_time: float | None = None
+    # Degraded path: local wall-clock captured before click_send.
+    pre_send_wall_time: float | None = None
+    # Common: which conversation this anchor belongs to (None on fresh chat).
+    conversation_id_at_capture: str | None = None
+
+    def with_captured_id(self, uuid: str | None) -> TurnAnchor:
+        """Return an immutable copy with the captured UUID set.
+
+        Called after ``click_send`` + ``wait_for_captured_uuid``. If ``uuid``
+        is None (capture failed), the anchor is returned unchanged (fallback
+        mode stays in effect).
+        """
+        if uuid is None:
+            return self
+        return replace(self, captured_user_message_id=uuid)
+
+
+# ── Result types ──────────────────────────────────────────────────────────
+
+# Full internal status vocabulary (kept rich for canary diagnostics).
+TextStatus = Literal[
+    "matched",              # terminal assistant text found, end_turn=true
+    "not_ready",            # correlated node exists but not done, or no candidate yet
+    "ambiguous",            # ≥2 matching user nodes; keep polling
+    "degraded_not_fresh",   # single match but fails freshness floor; keep polling
+    "non_text",             # correlated assistant is non-text (image/tool/etc.)
+    "fetch_failed",         # transport error — detector may unlock DOM fallback
+    "auth_failed",          # 401 — hard fail, never degrades
+]
+
+
+# Detector-facing tri-state (the completion detector's gate at
+# completion_detector.py:446-487 stays 3-way).
+EndTurnStatus = Literal["complete", "not_ready", "fetch_failed"]
+
+
+@dataclass
+class TurnTextResult:
+    """Result of ``_fetch_text_for_turn``. Rich for canary diagnostics."""
+
+    status: TextStatus
+    text: str | None = None
+    diagnostic: dict = field(default_factory=dict)
+
+
+@dataclass
+class TurnEndResult:
+    """Result of ``_fetch_end_turn_for_turn``, before tri-state collapse."""
+
+    status: TextStatus
+    diagnostic: dict = field(default_factory=dict)
+
+
+# ── Errors ────────────────────────────────────────────────────────────────
+
+class TurnAnchorUnavailableError(RuntimeError):
+    """Pre-send anchor capture failed on an existing conversation.
+
+    Raised by ``_capture_pre_send_fallback_anchor`` when the backend anchor
+    fetch fails after bounded retries on an existing conversation where
+    degraded mode is not acceptable (e.g., the failure is auth, not transient).
+    For transient failures, the driver enters ``degraded_existing`` mode
+    instead of raising.
+    """
+
+
+class TurnReconciliationError(RuntimeError):
+    """Post-send correlation timed out without resolving a terminal response.
+
+    Raised by ``send_and_stream``'s final reconciliation loop when the
+    anchored selector never returns ``matched`` within the polling budget.
+    Carries a diagnostic summary (anchor mode, last status, candidate counts)
+    — never the raw prompt or full assistant text.
+    """
+
+    def __init__(self, conversation_id: str, anchor_mode: str, last_status: str,
+                 diagnostic: dict) -> None:
+        self.conversation_id = conversation_id
+        self.anchor_mode = anchor_mode
+        self.last_status = last_status
+        self.diagnostic = diagnostic
+        super().__init__(
+            f"Turn reconciliation failed for {conversation_id} "
+            f"(mode={anchor_mode}, last_status={last_status})"
+        )
+
+
+# ── Text normalization + matching ─────────────────────────────────────────
+
+def normalize_text(s: str) -> str:
+    """Normalize text for matching: NFC, CRLF→LF, strip trailing ws + zero-width.
+
+    The backend may store a slightly different representation of the sent
+    prompt (Unicode normalization, line-ending differences, trailing
+    whitespace, zero-width joiners). This normalization makes matching
+    robust to those differences.
+    """
+    if not s:
+        return ""
+    # NFC normalization (compose decomposed characters).
+    s = unicodedata.normalize("NFC", s)
+    # CRLF / CR → LF.
+    s = s.replace("\r\n", "\n").replace("\r", "\n")
+    # Strip zero-width characters (ZWSP, ZWJ, ZWNJ, BOM).
+    s = "".join(ch for ch in s if ch not in ("\u200b", "\u200d", "\u200c", "\ufeff"))
+    # Strip trailing whitespace per line + overall.
+    s = "\n".join(line.rstrip() for line in s.split("\n"))
+    return s.strip()
+
+
+def user_text_matches_sent(parent_text: str, sent_text: str) -> bool:
+    """Does a backend user-node's text match the sent prompt?
+
+    - Full normalized equality for prompts ≤ ``_PREFIX_MATCH_MIN`` chars.
+    - Truncated-prefix acceptance for longer prompts (backend truncation):
+      if the parent text is ≥ ``_PREFIX_MATCH_MIN`` and the sent text starts
+      with it (or vice versa), accept.
+    - No tiny prefixes — agent prompts share long boilerplate prefixes, so a
+      short shared prefix is not distinctive enough to match on.
+    """
+    p = normalize_text(parent_text)
+    s = normalize_text(sent_text)
+    if not p or not s:
+        return False
+    if p == s:
+        return True
+    # Truncated-prefix: backend stores a long prefix of the submitted prompt.
+    # Accept only if the prefix is long enough to be distinctive.
+    if len(p) >= _PREFIX_MATCH_MIN and s.startswith(p):
+        return True
+    # Defensive: sent may be the truncated one.
+    if len(s) >= _PREFIX_MATCH_MIN and p.startswith(s):
+        return True
+    return False
+
+
+# ── Selectors ─────────────────────────────────────────────────────────────
+
+def _node_text(node: dict) -> str:
+    """Extract joined text from a projected or raw node.
+
+    Projected shape: ``node.text`` (already joined by the projection JS).
+    Raw shape: ``node.message.content.parts`` (joined here).
+    """
+    # Projected: text is at top level.
+    text = node.get("text")
+    if text is not None:
+        return text
+    # Raw backend shape.
+    msg = node.get("message") or {}
+    content = msg.get("content") or {}
+    parts = content.get("parts") or []
+    return "\n".join(str(p) for p in parts if isinstance(p, str))
+
+
+def _node_role(node: dict) -> str:
+    """Role from projected (node.role) or raw (node.message.author.role)."""
+    role = node.get("role")
+    if role:
+        return role
+    return ((node.get("message") or {}).get("author") or {}).get("role", "")
+
+
+def _node_create_time(node: dict) -> float:
+    """create_time from projected (node.create_time) or raw."""
+    ct = node.get("create_time")
+    if ct is not None:
+        return float(ct)
+    return float((node.get("message") or {}).get("create_time") or 0.0)
+
+
+def _node_end_turn(node: dict) -> bool:
+    """end_turn from projected (node.end_turn) or raw."""
+    if "end_turn" in node:
+        return bool(node.get("end_turn"))
+    return bool((node.get("message") or {}).get("end_turn"))
+
+
+def _node_content_type(node: dict) -> str:
+    """content_type from projected (node.content_type) or raw."""
+    ct = node.get("content_type")
+    if ct:
+        return ct
+    return ((node.get("message") or {}).get("content") or {}).get("content_type", "")
+
+
+def _node_id(node: dict) -> str:
+    """id from projected (node.id) or raw (node.message.id)."""
+    nid = node.get("id")
+    if nid:
+        return nid
+    return (node.get("message") or {}).get("id") or ""
+
+
+def _resolve_user_node(mapping: dict, anchor: TurnAnchor) -> tuple[str | None, str]:
+    """Resolve the submitted user node from the projected mapping.
+
+    Returns ``(node_id, reason)`` where ``node_id`` is the matched user node's
+    id (or None) and ``reason`` explains the outcome for diagnostics.
+
+    Primary path: exact match on ``captured_user_message_id``.
+    Fallback path: text match + freshness/anchor disambiguation.
+    """
+    nodes = mapping.get("nodes") or mapping.get("mapping") or {}
+
+    # Primary: ID-based.
+    if anchor.captured_user_message_id:
+        target = anchor.captured_user_message_id
+        for nid, node in nodes.items():
+            if _node_role(node) != "user":
+                continue
+            if _node_id(node) == target or nid == target:
+                return nid, "id_match"
+        # ID was captured but not found in the projected window yet.
+        return None, "id_not_yet_in_mapping"
+
+    # Fallback: text-based.
+    matching = []
+    for nid, node in nodes.items():
+        if _node_role(node) != "user":
+            continue
+        if user_text_matches_sent(_node_text(node), anchor.sent_text):
+            matching.append((nid, node))
+
+    if not matching:
+        return None, "no_text_match"
+
+    # Filter by anchor (existing_conversation: newer/different than pre-send).
+    if anchor.mode == "existing_conversation":
+        fresh = []
+        for nid, node in matching:
+            ct = _node_create_time(node)
+            mid = _node_id(node)
+            # Newer than pre-send latest user, OR different node id.
+            if (anchor.latest_user_create_time is not None
+                    and ct > anchor.latest_user_create_time):
+                fresh.append((nid, node))
+            elif (anchor.latest_user_node_id is not None
+                  and mid != anchor.latest_user_node_id
+                  and ct >= (anchor.latest_user_create_time or 0.0)):
+                fresh.append((nid, node))
+        if not fresh:
+            return None, "no_fresh_text_match"
+        if len(fresh) > 1:
+            return None, "ambiguous"
+        return fresh[0][0], "text_match_with_anchor"
+
+    if anchor.mode == "degraded_existing":
+        # Wall-clock freshness floor.
+        fresh = []
+        for nid, node in matching:
+            ct = _node_create_time(node)
+            if anchor.pre_send_wall_time is not None:
+                if ct >= anchor.pre_send_wall_time - SKEW_TOLERANCE_SECONDS:
+                    fresh.append((nid, node))
+                else:
+                    # Single stale match → degraded_not_fresh later.
+                    pass
+            else:
+                fresh.append((nid, node))  # no wall time; can't freshness-check
+        if not fresh:
+            return None, "degraded_not_fresh"
+        if len(fresh) > 1:
+            return None, "ambiguous"
+        return fresh[0][0], "degraded_text_match"
+
+    if anchor.mode == "fresh_chat":
+        # Text-only; first/only match expected on a fresh chat.
+        if len(matching) > 1:
+            return None, "ambiguous"
+        return matching[0][0], "fresh_chat_text_match"
+
+    return None, f"unhandled_mode_{anchor.mode}"
+
+
+def _find_assistant_descendants(
+    mapping: dict, user_nid: str
+) -> list[tuple[str, dict]]:
+    """Find assistant nodes that are descendants of the user node.
+
+    Bidirectional (ChatGPT round 3):
+      Primary: walk ``children`` from the user node.
+      Fallback: for each assistant candidate, walk ``parent`` pointers upward
+      and accept if the user node is an ancestor.
+    """
+    nodes = mapping.get("nodes") or mapping.get("mapping") or {}  # type: ignore[assignment]
+
+    # Primary: children-walk (BFS from user node).
+    found: dict[str, dict] = {}
+    visited: set[str] = set()
+    queue = [user_nid]
+    while queue:
+        cur = queue.pop(0)
+        if cur in visited:
+            continue
+        visited.add(cur)
+        node = nodes.get(cur)
+        if node is None:
+            continue
+        if cur != user_nid and _node_role(node) == "assistant":
+            found[cur] = node
+        children = node.get("children") or []
+        for child_id in children:
+            if child_id not in visited:
+                queue.append(child_id)
+
+    # Fallback: parent-pointer walk from each assistant candidate.
+    if not found:
+        for nid, node in nodes.items():
+            if _node_role(node) != "assistant":
+                continue
+            # Walk parent pointers upward; if we reach user_nid, it's a descendant.
+            cur = node.get("parent")
+            seen: set[str] = set()
+            while cur and cur not in seen:
+                if cur == user_nid:
+                    found[nid] = node
+                    break
+                seen.add(cur)
+                parent_node = nodes.get(cur)
+                if parent_node is None:
+                    break
+                cur = parent_node.get("parent")
+
+    return list(found.items())
+
+
+def select_text_for_turn(mapping: dict, anchor: TurnAnchor) -> TurnTextResult:
+    """Resolve the terminal assistant text for the submitted turn.
+
+    Returns a ``TurnTextResult`` with one of:
+      - ``matched``: terminal assistant text found (newest ``end_turn=true``).
+      - ``not_ready``: correlated user node resolved but no terminal text yet.
+      - ``ambiguous``: ≥2 matching user nodes; caller keeps polling.
+      - ``degraded_not_fresh``: single stale match; caller keeps polling.
+      - ``non_text``: correlated assistant is non-text (image/tool).
+    """
+    user_nid, reason = _resolve_user_node(mapping, anchor)
+    if user_nid is None:
+        if reason == "ambiguous":
+            return TurnTextResult("ambiguous", diagnostic={"reason": reason})
+        if reason == "degraded_not_fresh":
+            return TurnTextResult("degraded_not_fresh", diagnostic={"reason": reason})
+        return TurnTextResult("not_ready", diagnostic={"reason": reason})
+
+    descendants = _find_assistant_descendants(mapping, user_nid)
+    if not descendants:
+        return TurnTextResult("not_ready", diagnostic={
+            "reason": "no_assistant_descendant", "user_node": user_nid,
+        })
+
+    # Terminal selection: NEWEST end_turn=true assistant TEXT descendant.
+    text_candidates = [
+        (nid, node) for nid, node in descendants
+        if _node_content_type(node) == "text" and _node_text(node).strip()
+    ]
+    if text_candidates:
+        end_turn_text = [
+            (nid, node) for nid, node in text_candidates if _node_end_turn(node)
+        ]
+        if end_turn_text:
+            # Newest by create_time.
+            best = max(end_turn_text, key=lambda pair: _node_create_time(pair[1]))
+            return TurnTextResult(
+                "matched", text=_node_text(best[1]),
+                diagnostic={"user_node": user_nid, "assistant_node": best[0],
+                            "reason": "terminal_text_end_turn"},
+            )
+        # Text candidates exist but none end_turn yet.
+        return TurnTextResult("not_ready", diagnostic={
+            "reason": "text_not_end_turn", "user_node": user_nid,
+            "candidate_count": len(text_candidates),
+        })
+
+    # No text candidates — check for non-text assistant (image/tool-use).
+    non_text = [
+        (nid, node) for nid, node in descendants
+        if _node_content_type(node) != "text"
+    ]
+    if non_text:
+        return TurnTextResult("non_text", diagnostic={
+            "user_node": user_nid,
+            "content_types": [_node_content_type(n) for _, n in non_text],
+        })
+
+    return TurnTextResult("not_ready", diagnostic={
+        "reason": "descendants_exist_but_no_text", "user_node": user_nid,
+    })
+
+
+def select_end_turn_for_turn(
+    mapping: dict, anchor: TurnAnchor, *, had_non_text_content: bool
+) -> TurnEndResult:
+    """Resolve completion status for the submitted turn.
+
+    Returns a ``TurnEndResult`` with internal status. The caller (detector)
+    collapses to tri-state: ``complete`` / ``not_ready`` / ``fetch_failed``.
+
+    Completion rules (ChatGPT round 4):
+      - ``matched`` (complete): correlated assistant text node has end_turn=true
+        AND non-empty text.
+      - ``non_text`` complete only if ``had_non_text_content`` is True.
+      - ``not_ready`` / ``ambiguous`` / ``degraded_not_fresh`` → not_ready.
+    """
+    user_nid, reason = _resolve_user_node(mapping, anchor)
+    if user_nid is None:
+        if reason == "ambiguous":
+            return TurnEndResult("ambiguous", diagnostic={"reason": reason})
+        if reason == "degraded_not_fresh":
+            return TurnEndResult("degraded_not_fresh", diagnostic={"reason": reason})
+        return TurnEndResult("not_ready", diagnostic={"reason": reason})
+
+    descendants = _find_assistant_descendants(mapping, user_nid)
+    if not descendants:
+        return TurnEndResult("not_ready", diagnostic={
+            "reason": "no_assistant_descendant", "user_node": user_nid,
+        })
+
+    # Text completion: newest end_turn=true text descendant with non-empty text.
+    text_end_turn = [
+        (nid, node) for nid, node in descendants
+        if _node_content_type(node) == "text"
+        and _node_text(node).strip()
+        and _node_end_turn(node)
+    ]
+    if text_end_turn:
+        return TurnEndResult("matched", diagnostic={
+            "user_node": user_nid,
+            "assistant_node": text_end_turn[0][0],
+            "reason": "text_end_turn",
+        })
+
+    # Non-text completion: correlated non-text assistant with end_turn=true,
+    # gated by DOM had_non_text_content.
+    non_text_end_turn = [
+        (nid, node) for nid, node in descendants
+        if _node_content_type(node) != "text" and _node_end_turn(node)
+    ]
+    if non_text_end_turn and had_non_text_content:
+        return TurnEndResult("matched", diagnostic={
+            "user_node": user_nid,
+            "assistant_node": non_text_end_turn[0][0],
+            "reason": "non_text_end_turn_with_dom_guard",
+        })
+
+    # Correlated node exists but not done.
+    return TurnEndResult("not_ready", diagnostic={
+        "reason": "not_end_turn", "user_node": user_nid,
+        "descendant_count": len(descendants),
+    })
+
+
+def collapse_to_end_turn_status(result: TurnEndResult) -> EndTurnStatus:
+    """Collapse a rich ``TurnEndResult`` to the detector-facing tri-state.
+
+    Mapping (ChatGPT round 4):
+      matched → complete
+      not_ready, ambiguous, degraded_not_fresh, non_text → not_ready
+      fetch_failed → fetch_failed
+      auth_failed → propagates as exception upstream (never reaches here)
+    """
+    if result.status == "matched":
+        return "complete"
+    if result.status == "fetch_failed":
+        return "fetch_failed"
+    # not_ready, ambiguous, degraded_not_fresh, non_text → not_ready
+    return "not_ready"

--- a/src/chatgpt_web2api/turn_anchor.py
+++ b/src/chatgpt_web2api/turn_anchor.py
@@ -338,21 +338,23 @@ def _resolve_user_node(mapping: dict, anchor: TurnAnchor) -> tuple[str | None, s
         return fresh[0][0], "text_match_with_anchor"
 
     if anchor.mode == "degraded_existing":
-        # Wall-clock freshness floor. SKEW_TOLERANCE_SECONDS is a lower-bound
-        # guard — it rejects sufficiently-old nodes but NOT rapid same-text
-        # repeats (a previous turn sent up to ~13s prior can still pass).
+        # Degraded mode is logged, not guessed. Without a captured UUID, a
+        # text match + wall-clock freshness cannot distinguish "the new node
+        # propagated" from "the previous same-text turn is still within the
+        # freshness window." So degraded_existing NEVER resolves a user node —
+        # it only classifies what it sees for diagnostics and returns not_ready.
         #
-        # PR #39 review finding #3: a single degraded text match that passes
-        # the freshness floor could still be the PREVIOUS turn's user node
-        # (if the same text was sent twice rapidly). Without a captured UUID,
-        # we cannot distinguish "the new node propagated" from "the old node
-        # is still fresh enough." So: never silently accept a single degraded
-        # match — return not_ready and let the caller keep polling. When the
-        # new node propagates, either the ID path resolves it (if the UUID
-        # arrives late) or a second match appears (→ ambiguous → poll until
-        # one is clearly newer). This makes degraded_existing a pure "keep
-        # waiting" signal, not a "best guess" — matching the design intent
-        # ("never silently pick an ambiguous candidate").
+        # The caller keeps polling. When the new node propagates, either:
+        # - the ID path resolves it (if the UUID arrives late), or
+        # - a second match appears → the caller sees ≥2 candidates → ambiguous,
+        #   and the newer-create-time one wins once both fully propagate.
+        # If neither happens within the polling budget, the caller raises
+        # TurnReconciliationError — never silently returns stale text.
+        #
+        # (PR #39 review: the prior implementation accepted a single fresh
+        # match when no stale alternatives existed. That is the exact
+        # rapid-repeat case where the previous turn's node is still within
+        # the 8-second freshness tolerance and no new node has propagated yet.)
         fresh = []
         stale = []
         for nid, node in matching:
@@ -364,19 +366,18 @@ def _resolve_user_node(mapping: dict, anchor: TurnAnchor) -> tuple[str | None, s
                     stale.append((nid, node))
             else:
                 fresh.append((nid, node))  # no wall time; can't freshness-check
-        if fresh and len(fresh) > 1:
+
+        if len(fresh) > 1:
             return None, "ambiguous"
-        if fresh and len(fresh) == 1 and not stale:
-            # Single fresh match, no stale alternatives. This is the normal
-            # case when degraded mode fires on a conversation where the same
-            # text has NOT been sent before — the single match IS the new turn.
-            # Accept it.
-            return fresh[0][0], "degraded_text_match"
-        # Either: no fresh matches (all stale → degraded_not_fresh), or
-        # single fresh + stale alternatives (can't distinguish → keep polling).
-        if not fresh:
+        if fresh and stale:
+            return None, "degraded_ambiguous_with_stale"
+        if not fresh and stale:
             return None, "degraded_not_fresh"
-        return None, "degraded_ambiguous_with_stale"
+        # Single fresh match, no stale alternatives. We still do NOT accept —
+        # we cannot prove this is the new turn rather than the previous one
+        # that happens to be fresh. Return not_ready; the caller keeps polling
+        # and either the ID path resolves or TurnReconciliationError fires.
+        return None, "degraded_insufficient_evidence"
 
     if anchor.mode == "fresh_chat":
         # Text-only; first/only match expected on a fresh chat.

--- a/tests/fixtures/sample_conversation_mapping.json
+++ b/tests/fixtures/sample_conversation_mapping.json
@@ -1,0 +1,253 @@
+{
+  "nodes": {
+    "client-created-root": {
+      "id": "client-created-root",
+      "parent": null,
+      "children": [
+        "0b8575da-e38a-4fdb-b182-ccfb7f4f29ec"
+      ],
+      "role": "unknown",
+      "create_time": 0,
+      "end_turn": false,
+      "content_type": "unknown",
+      "text": ""
+    },
+    "0b8575da-e38a-4fdb-b182-ccfb7f4f29ec": {
+      "id": "0b8575da-e38a-4fdb-b182-ccfb7f4f29ec",
+      "parent": "client-created-root",
+      "children": [
+        "9a809728-0f2d-437e-986f-61a5ccd7e4d3"
+      ],
+      "role": "system",
+      "create_time": 0,
+      "end_turn": true,
+      "content_type": "text",
+      "text": ""
+    },
+    "9a809728-0f2d-437e-986f-61a5ccd7e4d3": {
+      "id": "9a809728-0f2d-437e-986f-61a5ccd7e4d3",
+      "parent": "0b8575da-e38a-4fdb-b182-ccfb7f4f29ec",
+      "children": [
+        "cbb5dd3f-e24b-47f8-96a2-5a7f0eff39fc"
+      ],
+      "role": "system",
+      "create_time": 0,
+      "end_turn": true,
+      "content_type": "text",
+      "text": ""
+    },
+    "cbb5dd3f-e24b-47f8-96a2-5a7f0eff39fc": {
+      "id": "cbb5dd3f-e24b-47f8-96a2-5a7f0eff39fc",
+      "parent": "9a809728-0f2d-437e-986f-61a5ccd7e4d3",
+      "children": [
+        "8a1718b6-d9b2-4eb1-bb18-a14c4711becf"
+      ],
+      "role": "system",
+      "create_time": 0,
+      "end_turn": false,
+      "content_type": "text",
+      "text": ""
+    },
+    "8a1718b6-d9b2-4eb1-bb18-a14c4711becf": {
+      "id": "8a1718b6-d9b2-4eb1-bb18-a14c4711becf",
+      "parent": "cbb5dd3f-e24b-47f8-96a2-5a7f0eff39fc",
+      "children": [
+        "ffa19648-10f4-42db-ad17-3ffc85215f1e"
+      ],
+      "role": "user",
+      "create_time": 0,
+      "end_turn": false,
+      "content_type": "user_editable_context",
+      "text": ""
+    },
+    "ffa19648-10f4-42db-ad17-3ffc85215f1e": {
+      "id": "ffa19648-10f4-42db-ad17-3ffc85215f1e",
+      "parent": "8a1718b6-d9b2-4eb1-bb18-a14c4711becf",
+      "children": [
+        "1919e19a-da54-4880-a385-9aef15d8811a"
+      ],
+      "role": "user",
+      "create_time": 1783140512.71,
+      "end_turn": false,
+      "content_type": "text",
+      "text": "[User]\nReply with exactly: TRUEFRESH-1"
+    },
+    "1919e19a-da54-4880-a385-9aef15d8811a": {
+      "id": "1919e19a-da54-4880-a385-9aef15d8811a",
+      "parent": "ffa19648-10f4-42db-ad17-3ffc85215f1e",
+      "children": [
+        "4f2b2cd3-4997-4256-8f4c-44334ca3ea73"
+      ],
+      "role": "system",
+      "create_time": 1783140514.5355382,
+      "end_turn": false,
+      "content_type": "text",
+      "text": ""
+    },
+    "4f2b2cd3-4997-4256-8f4c-44334ca3ea73": {
+      "id": "4f2b2cd3-4997-4256-8f4c-44334ca3ea73",
+      "parent": "1919e19a-da54-4880-a385-9aef15d8811a",
+      "children": [
+        "ef53abbc-8edc-4a06-8ef9-2eac62231a51"
+      ],
+      "role": "assistant",
+      "create_time": 1783140514.7041733,
+      "end_turn": false,
+      "content_type": "model_editable_context",
+      "text": ""
+    },
+    "ef53abbc-8edc-4a06-8ef9-2eac62231a51": {
+      "id": "ef53abbc-8edc-4a06-8ef9-2eac62231a51",
+      "parent": "4f2b2cd3-4997-4256-8f4c-44334ca3ea73",
+      "children": [
+        "ef4f1c98-5467-478d-8993-d49358b33f0e"
+      ],
+      "role": "assistant",
+      "create_time": 1783140515.942522,
+      "end_turn": false,
+      "content_type": "thoughts",
+      "text": ""
+    },
+    "ef4f1c98-5467-478d-8993-d49358b33f0e": {
+      "id": "ef4f1c98-5467-478d-8993-d49358b33f0e",
+      "parent": "ef53abbc-8edc-4a06-8ef9-2eac62231a51",
+      "children": [
+        "880df662-8fc0-412e-afff-8db7e163b065"
+      ],
+      "role": "assistant",
+      "create_time": 1783140516.123232,
+      "end_turn": false,
+      "content_type": "reasoning_recap",
+      "text": ""
+    },
+    "880df662-8fc0-412e-afff-8db7e163b065": {
+      "id": "880df662-8fc0-412e-afff-8db7e163b065",
+      "parent": "ef4f1c98-5467-478d-8993-d49358b33f0e",
+      "children": [
+        "67ad1f56-3035-4593-9d57-559cc20bdebf"
+      ],
+      "role": "assistant",
+      "create_time": 1783140514.591565,
+      "end_turn": true,
+      "content_type": "text",
+      "text": "TRUEFRESH-1"
+    },
+    "67ad1f56-3035-4593-9d57-559cc20bdebf": {
+      "id": "67ad1f56-3035-4593-9d57-559cc20bdebf",
+      "parent": "880df662-8fc0-412e-afff-8db7e163b065",
+      "children": [
+        "b4bd6940-fd41-4394-9e53-23d712ce0509"
+      ],
+      "role": "user",
+      "create_time": 1783140663.976,
+      "end_turn": false,
+      "content_type": "text",
+      "text": "[User]\nReply with exactly: POSTIDLE-1"
+    },
+    "b4bd6940-fd41-4394-9e53-23d712ce0509": {
+      "id": "b4bd6940-fd41-4394-9e53-23d712ce0509",
+      "parent": "67ad1f56-3035-4593-9d57-559cc20bdebf",
+      "children": [
+        "d1c66b0e-d371-417c-9610-6c0b1d7f5f87"
+      ],
+      "role": "assistant",
+      "create_time": 1783140667.174669,
+      "end_turn": false,
+      "content_type": "thoughts",
+      "text": ""
+    },
+    "d1c66b0e-d371-417c-9610-6c0b1d7f5f87": {
+      "id": "d1c66b0e-d371-417c-9610-6c0b1d7f5f87",
+      "parent": "b4bd6940-fd41-4394-9e53-23d712ce0509",
+      "children": [
+        "101f5265-a9e7-4fb7-9d11-1cfc2b311515"
+      ],
+      "role": "assistant",
+      "create_time": 1783140667.214854,
+      "end_turn": false,
+      "content_type": "reasoning_recap",
+      "text": ""
+    },
+    "101f5265-a9e7-4fb7-9d11-1cfc2b311515": {
+      "id": "101f5265-a9e7-4fb7-9d11-1cfc2b311515",
+      "parent": "d1c66b0e-d371-417c-9610-6c0b1d7f5f87",
+      "children": [
+        "35ea46d3-5237-4aeb-8c49-4d8ec7672ba8"
+      ],
+      "role": "assistant",
+      "create_time": 1783140666.325117,
+      "end_turn": true,
+      "content_type": "text",
+      "text": "POSTIDLE-1"
+    },
+    "35ea46d3-5237-4aeb-8c49-4d8ec7672ba8": {
+      "id": "35ea46d3-5237-4aeb-8c49-4d8ec7672ba8",
+      "parent": "101f5265-a9e7-4fb7-9d11-1cfc2b311515",
+      "children": [
+        "83346724-3733-489e-bf59-d6993f3e6fdc"
+      ],
+      "role": "user",
+      "create_time": 1783140731.069,
+      "end_turn": false,
+      "content_type": "text",
+      "text": "[User]\nThink step by step. What is 17 * 23? Show your reason...[truncated]"
+    },
+    "83346724-3733-489e-bf59-d6993f3e6fdc": {
+      "id": "83346724-3733-489e-bf59-d6993f3e6fdc",
+      "parent": "35ea46d3-5237-4aeb-8c49-4d8ec7672ba8",
+      "children": [
+        "29621773-cdad-4c45-931b-d965988b03bb"
+      ],
+      "role": "assistant",
+      "create_time": 1783140734.781526,
+      "end_turn": false,
+      "content_type": "thoughts",
+      "text": ""
+    },
+    "29621773-cdad-4c45-931b-d965988b03bb": {
+      "id": "29621773-cdad-4c45-931b-d965988b03bb",
+      "parent": "83346724-3733-489e-bf59-d6993f3e6fdc",
+      "children": [
+        "7cbf6743-199b-4bad-bb4a-310e86a99373"
+      ],
+      "role": "assistant",
+      "create_time": 1783140735.552245,
+      "end_turn": false,
+      "content_type": "reasoning_recap",
+      "text": ""
+    },
+    "7cbf6743-199b-4bad-bb4a-310e86a99373": {
+      "id": "7cbf6743-199b-4bad-bb4a-310e86a99373",
+      "parent": "29621773-cdad-4c45-931b-d965988b03bb",
+      "children": [],
+      "role": "assistant",
+      "create_time": 1783140733.290837,
+      "end_turn": true,
+      "content_type": "text",
+      "text": "17 \u00d7 23 = 17 \u00d7 (20 + 3)\n\n17 \u00d7 20 = 340  \n17 \u00d7 3 = 51  \n\n340 ...[truncated]"
+    }
+  },
+  "current_node": "7cbf6743-199b-4bad-bb4a-310e86a99373",
+  "_meta": {
+    "source": "real captured ChatGPT backend mapping",
+    "captured": "2026-07-04",
+    "conversation_id": "6a4890a0-584c-83eb-8429-becab7336e5f",
+    "node_count": 19,
+    "has_reasoning_recap": true,
+    "has_tool_use": false,
+    "roles": {
+      "?": 1,
+      "system": 4,
+      "user": 4,
+      "assistant": 10
+    },
+    "content_types": {
+      "?": 1,
+      "text": 10,
+      "user_editable_context": 1,
+      "model_editable_context": 1,
+      "thoughts": 3,
+      "reasoning_recap": 3
+    }
+  }
+}

--- a/tests/test_backend_client.py
+++ b/tests/test_backend_client.py
@@ -50,9 +50,10 @@ def test_backend_client_has_all_moved_methods():
         "_refresh_token",
         "ensure_token",
         "recover_auth",
-        # conversation fetch
-        "_fetch_text",
-        "_fetch_end_turn",
+        # conversation fetch (A2 anchored fetchers + id resolution)
+        "_fetch_recent_conversation_projection",
+        "_fetch_text_for_turn",
+        "_fetch_end_turn_for_turn",
         "_conversation_id_from_url",
         "_get_live_conversation_id_best_effort",
         "_check_auth_in_raw",
@@ -84,20 +85,6 @@ def test_token_ttl_seconds_moved():
 
 
 # ── 2. Transport seam: client reaches driver._js*, not a local copy ──
-
-
-@pytest.mark.asyncio
-async def test_fetch_text_reaches_driver_js_with_data_strict():
-    """_fetch_text must evaluate JS through the driver's strict evaluator."""
-    client, driver = _make_client()
-    driver._js_with_data_strict = AsyncMock(return_value="")
-    await client._fetch_text("conv-1")
-    driver._js_with_data_strict.assert_awaited_once()
-    # The data payload must carry the driver's token + the conversation id.
-    _, kwargs = driver._js_with_data_strict.call_args
-    args = driver._js_with_data_strict.call_args.args
-    # The template is the first positional arg; data dict is second.
-    assert args[1] == {"conv_id": "conv-1", "token": "tok"}
 
 
 @pytest.mark.asyncio
@@ -250,120 +237,3 @@ async def test_create_memory_success_false_when_get_memories_no_match():
     result = await client.create_memory("remember this please")
     assert result["success"] is False
     driver.get_memories.assert_awaited_once()
-
-
-# ── 8. _fetch_text bounded 404 retry (PR #23) ──────────────────────────
-#
-# The backend-api returns 404 immediately after a send while the just-created
-# conversation is still propagating server-side. _fetch_text treats 404 as a
-# transient race: bounded retry, NOT a breaker. 401 still raises immediately
-# (with breaker trip) and other non-OK statuses still raise RuntimeError
-# immediately — only 404 is retried.
-
-
-@pytest.mark.asyncio
-async def test_fetch_text_404_retries_then_succeeds():
-    """A transient 404 followed by a real body returns the body, not an error.
-    The fetch is retried until the conversation is persisted server-side."""
-    client, driver = _make_client()
-    client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0  # keep the test fast
-
-    responses = ['{"__status": 404}', '{"__status": 404}', "the assistant reply"]
-    calls = {"i": 0}
-
-    async def _fake(js_template, data, timeout=15):
-        r = responses[calls["i"]]
-        calls["i"] += 1
-        return r
-
-    driver._js_with_data_strict = _fake
-    result = await client._fetch_text("conv-1")
-    assert result == "the assistant reply"
-    assert calls["i"] == 3  # two 404s retried, third succeeded
-
-
-@pytest.mark.asyncio
-async def test_fetch_text_404_raises_after_bound():
-    """When 404 persists past the retry bound, it surfaces as RuntimeError
-    carrying the code, so callers see the same exception type as pre-retry."""
-    client, driver = _make_client()
-    client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0
-    calls = {"n": 0}
-
-    async def _fake(js_template, data, timeout=15):
-        calls["n"] += 1
-        return '{"__status": 404}'
-
-    driver._js_with_data_strict = _fake
-    with pytest.raises(RuntimeError) as ei:
-        await client._fetch_text("conv-1")
-    assert "404" in str(ei.value)
-    assert calls["n"] == client._FETCH_TEXT_404_MAX_ATTEMPTS
-
-
-@pytest.mark.asyncio
-async def test_fetch_text_401_not_retried_trips_breaker():
-    """401 is NOT a transient race: it must raise AuthExpiredError on the
-    first hit (no retry) and trip AUTH_EXPIRED. Guards against the 404 retry
-    accidentally swallowing auth failures."""
-    from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
-    from chatgpt_web2api.cdp_driver import AuthExpiredError
-
-    client, driver = _make_client()
-    driver._breakers = BreakerRegistry()
-    client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0
-    calls = {"n": 0}
-
-    async def _fake(js_template, data, timeout=15):
-        calls["n"] += 1
-        return '{"__status": 401}'
-
-    driver._js_with_data_strict = _fake
-    with pytest.raises(AuthExpiredError):
-        await client._fetch_text("conv-1")
-    # No retry: exactly one fetch attempt.
-    assert calls["n"] == 1
-    assert driver._breakers.is_open(BreakerKind.AUTH_EXPIRED)
-
-
-@pytest.mark.asyncio
-async def test_fetch_text_other_status_not_retried():
-    """Non-404 non-401 statuses (e.g. 500) raise RuntimeError immediately —
-    only the 404 propagation race is retried."""
-    client, driver = _make_client()
-    client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0
-    calls = {"n": 0}
-
-    async def _fake(js_template, data, timeout=15):
-        calls["n"] += 1
-        return '{"__status": 500}'
-
-    driver._js_with_data_strict = _fake
-    with pytest.raises(RuntimeError) as ei:
-        await client._fetch_text("conv-1")
-    assert "500" in str(ei.value)
-    assert calls["n"] == 1
-
-
-@pytest.mark.asyncio
-async def test_fetch_text_404_no_breaker_signal(monkeypatch):
-    """A transient 404 must NOT trip any breaker — it is a propagation race,
-    not an auth failure or persistent backend fault (follow-up C decides
-    breaker policy for backend errors separately)."""
-    from chatgpt_web2api.breakers import BreakerKind, BreakerRegistry
-
-    client, driver = _make_client()
-    reg = BreakerRegistry()
-    driver._breakers = reg
-    client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0
-
-    # Trip is the only mutation path; fail the test if anything tries it.
-    monkeypatch.setattr(reg, "trip", lambda *a, **k: pytest.fail("404 must not trip a breaker"))
-
-    async def _fake(js_template, data, timeout=15):
-        return '{"__status": 404}'
-
-    driver._js_with_data_strict = _fake
-    with pytest.raises(RuntimeError):
-        await client._fetch_text("conv-1")
-    assert not reg.is_open(BreakerKind.AUTH_EXPIRED)

--- a/tests/test_backend_projection_js.py
+++ b/tests/test_backend_projection_js.py
@@ -13,10 +13,6 @@ a real captured mapping via the CDP instrumentation scripts.
 """
 from __future__ import annotations
 
-import json
-
-import pytest
-
 from chatgpt_web2api.backend_projection import (
     CONVERSATION_PROJECTION_JS,
     PROJECTED_SCHEMA_FIELDS,
@@ -73,6 +69,7 @@ class TestProjectionLimit:
         # Re-import to pick up env. (The module reads os.getenv at import.)
         monkeypatch.setenv("W2A_TURN_PROJECTION_LIMIT", "100")
         import importlib
+
         import chatgpt_web2api.backend_projection as mod
         importlib.reload(mod)
         assert mod.TURN_PROJECTION_LIMIT == 100

--- a/tests/test_backend_projection_js.py
+++ b/tests/test_backend_projection_js.py
@@ -1,0 +1,190 @@
+"""Tests for the A2 backend projection JS (Step 5).
+
+Validates that ``CONVERSATION_PROJECTION_JS`` produces the expected compact
+schema when run against a backend mapping. Uses a synthetic mapping fixture
+now; the real captured thinking/tool-use fixture is a Step 10 hard prerequisite
+(no merge without it).
+
+The projection JS itself can't run in pure Python (it's JavaScript). These
+tests validate the *contract* — what the projected output must look like — by
+simulating the projection's behavior in Python and asserting the selectors
+work on the result. The actual JS execution is validated in Step 10 against
+a real captured mapping via the CDP instrumentation scripts.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from chatgpt_web2api.backend_projection import (
+    CONVERSATION_PROJECTION_JS,
+    PROJECTED_SCHEMA_FIELDS,
+    TURN_PROJECTION_LIMIT,
+)
+from chatgpt_web2api.turn_anchor import (
+    TurnAnchor,
+    select_end_turn_for_turn,
+    select_text_for_turn,
+)
+
+
+class TestProjectionConstant:
+    """Validate the JS constant is well-formed."""
+
+    def test_js_is_nonempty_string(self):
+        assert isinstance(CONVERSATION_PROJECTION_JS, str)
+        assert len(CONVERSATION_PROJECTION_JS) > 100
+
+    def test_js_fetches_correct_endpoint(self):
+        assert "/backend-api/conversation/" in CONVERSATION_PROJECTION_JS
+        assert "offset=0" in CONVERSATION_PROJECTION_JS
+        assert "limit=" in CONVERSATION_PROJECTION_JS
+
+    def test_js_threads_data_slots(self):
+        assert "__D.conv_id" in CONVERSATION_PROJECTION_JS
+        assert "__D.token" in CONVERSATION_PROJECTION_JS
+        assert "__D.limit" in CONVERSATION_PROJECTION_JS
+
+    def test_js_status_decode(self):
+        assert "__status" in CONVERSATION_PROJECTION_JS
+
+    def test_js_projects_to_compact_schema(self):
+        # The JS must output {nodes: {...}, current_node: ...}.
+        assert "nodes" in CONVERSATION_PROJECTION_JS
+        assert "current_node" in CONVERSATION_PROJECTION_JS
+
+    def test_js_preserves_graph_structure(self):
+        # Must keep parent, children, role — not just text.
+        assert "parent" in CONVERSATION_PROJECTION_JS
+        assert "children" in CONVERSATION_PROJECTION_JS
+        assert "role" in CONVERSATION_PROJECTION_JS
+
+    def test_js_drops_heavy_text_for_non_text(self):
+        # Non-text nodes should have empty text (heavy payload dropped).
+        assert "content_type" in CONVERSATION_PROJECTION_JS
+
+
+class TestProjectionLimit:
+    def test_default_limit_is_50(self):
+        assert TURN_PROJECTION_LIMIT == 50
+
+    def test_limit_env_overridable(self, monkeypatch):
+        # Re-import to pick up env. (The module reads os.getenv at import.)
+        monkeypatch.setenv("W2A_TURN_PROJECTION_LIMIT", "100")
+        import importlib
+        import chatgpt_web2api.backend_projection as mod
+        importlib.reload(mod)
+        assert mod.TURN_PROJECTION_LIMIT == 100
+        # Restore.
+        monkeypatch.delenv("W2A_TURN_PROJECTION_LIMIT", raising=False)
+        importlib.reload(mod)
+
+
+class TestSchemaFields:
+    def test_all_required_fields_documented(self):
+        required = {"id", "parent", "children", "role", "create_time",
+                    "end_turn", "content_type", "text"}
+        assert required == set(PROJECTED_SCHEMA_FIELDS.keys())
+
+
+class TestProjectedOutputSelectability:
+    """Verify the selectors work on the projected schema shape.
+
+    Simulates what the projection JS would produce for a typical mapping
+    (including intermediary reasoning nodes) and confirms the selectors
+    resolve correctly. This is the contract the JS must satisfy.
+    """
+
+    def _projected_mapping_with_reasoning(self) -> dict:
+        """Simulated projection output for: user → reasoning → draft → final."""
+        return {
+            "nodes": {
+                "u-1": {
+                    "id": "u-1", "parent": None, "children": ["r-1"],
+                    "role": "user", "create_time": 100.0, "end_turn": False,
+                    "content_type": "text", "text": "explain recursion",
+                },
+                "r-1": {
+                    "id": "r-1", "parent": "u-1", "children": ["a-draft"],
+                    "role": "assistant", "create_time": 100.5, "end_turn": False,
+                    "content_type": "reasoning_recap", "text": "",  # dropped
+                },
+                "a-draft": {
+                    "id": "a-draft", "parent": "r-1", "children": ["a-final"],
+                    "role": "assistant", "create_time": 101.0, "end_turn": False,
+                    "content_type": "text", "text": "Recursion is...",
+                },
+                "a-final": {
+                    "id": "a-final", "parent": "a-draft", "children": [],
+                    "role": "assistant", "create_time": 102.0, "end_turn": True,
+                    "content_type": "text", "text": "Recursion is a function that calls itself.",
+                },
+            },
+            "current_node": "a-final",
+        }
+
+    def test_selector_finds_terminal_through_intermediary(self):
+        mapping = self._projected_mapping_with_reasoning()
+        anchor = TurnAnchor(
+            sent_text="explain recursion", mode="captured_id",
+            captured_user_message_id="u-1",
+        )
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "matched"
+        assert result.text == "Recursion is a function that calls itself."
+        assert result.diagnostic["assistant_node"] == "a-final"
+
+    def test_selector_end_turn_through_intermediary(self):
+        mapping = self._projected_mapping_with_reasoning()
+        anchor = TurnAnchor(
+            sent_text="explain recursion", mode="captured_id",
+            captured_user_message_id="u-1",
+        )
+        result = select_end_turn_for_turn(mapping, anchor, had_non_text_content=False)
+        assert result.status == "matched"
+
+    def test_projected_mapping_has_all_required_fields(self):
+        mapping = self._projected_mapping_with_reasoning()
+        for nid, node in mapping["nodes"].items():
+            for field in PROJECTED_SCHEMA_FIELDS:
+                assert field in node, f"node {nid} missing field {field}"
+
+    def test_reasoning_node_text_is_empty_after_projection(self):
+        mapping = self._projected_mapping_with_reasoning()
+        reasoning = mapping["nodes"]["r-1"]
+        assert reasoning["content_type"] == "reasoning_recap"
+        assert reasoning["text"] == ""  # heavy payload dropped, node preserved
+
+
+class TestTargetOutsideOldLimit:
+    """Regression: a correlated pair at node 6-10 (outside old limit=5)."""
+
+    def test_selector_finds_pair_beyond_limit_5(self):
+        # Build a mapping with 8 user/assistant pairs; the target is pair 7.
+        # Each pair is a flat sequence: user-N → assistant-N, with the NEXT
+        # user as a sibling (not a child of the assistant). This matches
+        # ChatGPT's real graph shape.
+        nodes = {}
+        for i in range(1, 9):
+            u_id = f"u-{i}"
+            a_id = f"a-{i}"
+            nodes[u_id] = {
+                "id": u_id, "parent": None, "children": [a_id],
+                "role": "user", "create_time": float(100 + i * 2),
+                "end_turn": False, "content_type": "text", "text": f"prompt {i}",
+            }
+            nodes[a_id] = {
+                "id": a_id, "parent": u_id, "children": [],
+                "role": "assistant", "create_time": float(101 + i * 2),
+                "end_turn": True, "content_type": "text", "text": f"response {i}",
+            }
+        mapping = {"nodes": nodes, "current_node": "a-8"}
+        # Target pair 7 — well beyond the old limit=5.
+        anchor = TurnAnchor(
+            sent_text="prompt 7", mode="captured_id",
+            captured_user_message_id="u-7",
+        )
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "matched"
+        assert result.text == "response 7"

--- a/tests/test_cdp_event_dispatch.py
+++ b/tests/test_cdp_event_dispatch.py
@@ -1,0 +1,169 @@
+"""Tests for the CDP event dispatch table (A2 Step 1).
+
+Verifies that ``CDPTransport._reader_loop`` routes unsolicited CDP events
+(those without an ``id``) to registered handlers on
+``driver._cdp_event_handlers``, while continuing to route id-keyed responses
+to pending futures.
+
+The reader loop is the sole consumer of ``ws.recv()`` and resolves all
+pending command futures. Event handlers must be fast and non-blocking; this
+test verifies the dispatch mechanism, not handler performance (that is an
+implementation contract enforced by code review, not testable here).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.cdp_transport import CDPTransport
+
+
+def _make_driver():
+    """Minimal CDPDriver stub with the state the reader loop touches."""
+    d = MagicMock()
+    d._pending = {}
+    d._msg_id = 0
+    d._cdp_event_handlers = {}
+    d.reconnect = AsyncMock()
+    return d
+
+
+class _FakeWS:
+    """Yields a scripted sequence of CDP frames, then closes."""
+
+    def __init__(self, frames: list[str]):
+        self._frames = list(frames)
+        self._closed = False
+
+    async def recv(self):
+        if not self._frames:
+            # Keep the reader loop alive until cancelled by the test.
+            await asyncio.sleep(3600)
+        return self._frames.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_unsolicited_event_dispatched_to_registered_handler():
+    """An event with a method but no id is routed to the registered handler."""
+    received = []
+    driver = _make_driver()
+    driver._ws = _FakeWS([
+        json.dumps({"method": "Network.requestWillBeSent", "params": {"requestId": "abc"}}),
+    ])
+    driver._cdp_event_handlers["Network.requestWillBeSent"] = lambda msg: received.append(msg)
+
+    transport = CDPTransport(driver)
+    task = asyncio.create_task(transport._reader_loop())
+    # Give the loop a tick to process the frame.
+    await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert len(received) == 1
+    assert received[0]["method"] == "Network.requestWillBeSent"
+    assert received[0]["params"]["requestId"] == "abc"
+
+
+@pytest.mark.asyncio
+async def test_unsolicited_event_no_handler_is_debug_logged_not_crashed():
+    """An event with no registered handler is silently skipped (debug-logged)."""
+    driver = _make_driver()
+    driver._ws = _FakeWS([
+        json.dumps({"method": "Page.frameNavigated", "params": {}}),
+    ])
+    # No handler registered for Page.frameNavigated.
+
+    transport = CDPTransport(driver)
+    task = asyncio.create_task(transport._reader_loop())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    # If we got here without the loop raising, the test passes.
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_id_keyed_response_still_routes_to_pending_future():
+    """The event dispatch change must not break id-keyed response routing."""
+    driver = _make_driver()
+    driver._ws = _FakeWS([
+        json.dumps({"id": 42, "result": {"value": "hello"}}),
+    ])
+    fut: asyncio.Future = asyncio.get_event_loop().create_future()
+    driver._pending[42] = fut
+
+    transport = CDPTransport(driver)
+    task = asyncio.create_task(transport._reader_loop())
+    # Wait for the future to resolve.
+    result = await asyncio.wait_for(fut, timeout=1.0)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert result["result"]["value"] == "hello"
+    assert 42 not in driver._pending  # popped after resolution
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_does_not_kill_reader_loop():
+    """A handler that raises is logged and swallowed; the loop continues."""
+    driver = _make_driver()
+    good_events = []
+    driver._ws = _FakeWS([
+        # First event: handler raises.
+        json.dumps({"method": "Network.requestWillBeSent", "params": {"i": 1}}),
+        # Second event: handler succeeds (loop survived).
+        json.dumps({"method": "Network.requestWillBeSent", "params": {"i": 2}}),
+    ])
+
+    def flaky_handler(msg):
+        if msg["params"]["i"] == 1:
+            raise RuntimeError("boom")
+        good_events.append(msg)
+
+    driver._cdp_event_handlers["Network.requestWillBeSent"] = flaky_handler
+
+    transport = CDPTransport(driver)
+    task = asyncio.create_task(transport._reader_loop())
+    await asyncio.sleep(0.1)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    # The second event was processed despite the first handler raising.
+    assert len(good_events) == 1
+    assert good_events[0]["params"]["i"] == 2
+
+
+@pytest.mark.asyncio
+async def test_no_event_handlers_table_does_not_crash():
+    """If _cdp_event_handlers is missing entirely, loop still runs (back-compat)."""
+    driver = _make_driver()
+    del driver._cdp_event_handlers  # simulate a driver that never set it
+    driver._ws = _FakeWS([
+        json.dumps({"method": "Page.frameNavigated", "params": {}}),
+    ])
+
+    transport = CDPTransport(driver)
+    task = asyncio.create_task(transport._reader_loop())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    # Survived without AttributeError.
+    assert True

--- a/tests/test_completion_detector.py
+++ b/tests/test_completion_detector.py
@@ -31,6 +31,7 @@ from chatgpt_web2api.completion_detector import (
     PHASE_STALL_SECONDS,
     CompletionDetector,
 )
+from chatgpt_web2api.turn_anchor import TurnAnchor, TurnEndResult
 
 
 def _make_detector():
@@ -40,7 +41,7 @@ def _make_detector():
     driver = MagicMock()
     driver._current_conv_id = None
     driver._js_strict = AsyncMock(return_value="")
-    driver._fetch_end_turn = AsyncMock(return_value=False)
+    driver._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="not_ready"))
     driver._get_live_conversation_id_best_effort = AsyncMock(return_value="")
     return CompletionDetector(driver), driver
 
@@ -122,7 +123,7 @@ def test_per_call_results_reset_on_each_call():
         return "1"  # assistant-node count poll
 
     driver._js_strict = fake_js
-    driver._fetch_end_turn = AsyncMock(return_value=True)
+    driver._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))
     # Provide a conv_id so the backend end_turn primary signal is eligible
     # (guard requires conv_id_for_check); without it the loop has no
     # completion path and would run to the timeout.
@@ -131,7 +132,10 @@ def test_per_call_results_reset_on_each_call():
     import asyncio
 
     async def drain():
-        async for _ in detector.stream_until_complete(initial_count=0, timeout=5):
+        async for _ in detector.stream_until_complete(
+            initial_count=0, timeout=5,
+            turn_anchor=TurnAnchor(sent_text="test", mode="fresh_chat"),
+        ):
             pass
 
     asyncio.run(drain())
@@ -171,7 +175,7 @@ async def test_detector_routes_js_through_driver():
     """The detector must call self._driver._js_strict, NOT a local copy — so
     driver-side monkeypatches (used across the test suite) still intercept."""
     detector, driver = _make_detector()
-    driver._fetch_end_turn = AsyncMock(return_value=True)
+    driver._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))
     # Discriminate by JS expression: body scan -> JSON, count -> "1" (exceeds
     # initial_count=0 so Phase-1 breaks), poll -> completed payload WITH text so
     # the backend end_turn strict-content guard can fire and end the loop.
@@ -188,16 +192,19 @@ async def test_detector_routes_js_through_driver():
         return "1"
 
     driver._js_strict = fake_js
-    driver._fetch_end_turn = AsyncMock(return_value=True)
+    driver._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))
     # Provide conv_id so the backend end_turn primary signal is eligible and
     # the loop completes (otherwise no completion path → runs to timeout).
     driver._get_live_conversation_id_best_effort = AsyncMock(return_value="conv-1")
     seen = []
-    async for chunk in detector.stream_until_complete(initial_count=0, timeout=10000):
+    async for chunk in detector.stream_until_complete(
+        initial_count=0, timeout=10000,
+        turn_anchor=TurnAnchor(sent_text="test", mode="fresh_chat"),
+    ):
         seen.append(chunk)
     assert js_calls["n"] >= 1, "detector must reach transport via _driver._js_strict"
-    assert driver._fetch_end_turn.await_count >= 1, (
-        "detector must reach backend via _driver._fetch_end_turn"
+    assert driver._fetch_end_turn_for_turn.await_count >= 1, (
+        "detector must reach backend via _driver._fetch_end_turn_for_turn"
     )
 
 

--- a/tests/test_end_turn_primary.py
+++ b/tests/test_end_turn_primary.py
@@ -9,8 +9,8 @@ has_action is a fallback for the pre-conv_id window.
 These tests verify the Python-side completion POLICY (which signal wins),
 using the same mocking pattern as test_sse_end_turn_new_chat.py:
 monkeypatch time.monotonic + asyncio.sleep, fake _js_strict returning
-phase-appropriate JSON, AsyncMock for _fetch_end_turn / type_message /
-click_send / _fetch_text.
+phase-appropriate JSON, AsyncMock for _fetch_end_turn_for_turn /
+type_message / click_send / _fetch_text_for_turn.
 """
 
 import json
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from chatgpt_web2api.cdp_driver import CDPDriver
+from chatgpt_web2api.turn_anchor import TurnEndResult, TurnTextResult
 
 
 def _make_driver():
@@ -87,8 +88,13 @@ async def test_end_turn_wins_over_no_has_action(monkeypatch):
     d._js_strict = _phase1_then_phase2_js(state, phase2_factory=phase2)
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
-    d._fetch_end_turn = AsyncMock(return_value=True)
+    # A2: anchored final-text fetch. The DOM already streamed "The answer."
+    # (last_dom_text); return matched with the same text so the reconciliation
+    # loop breaks cleanly (len == last_dom_text → no spurious delta).
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="matched", text="The answer.")
+    )
+    d._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))
 
     chunks = []
     async for chunk in d.send_and_stream("hello", timeout=10000):
@@ -97,7 +103,7 @@ async def test_end_turn_wins_over_no_has_action(monkeypatch):
     deltas = [c.delta for c in chunks if c.delta]
     assert any("The answer" in c for c in deltas), f"deltas: {deltas}"
     assert chunks[-1].finish_reason == "stop"
-    assert d._fetch_end_turn.await_count >= 1
+    assert d._fetch_end_turn_for_turn.await_count >= 1
 
 
 # ── 2. end_turn=True wins even when is_thinking=True ───────────────────
@@ -125,8 +131,11 @@ async def test_end_turn_wins_over_is_thinking(monkeypatch):
     d._js_strict = _phase1_then_phase2_js(state, phase2_factory=phase2)
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
-    d._fetch_end_turn = AsyncMock(return_value=True)
+    # A2: DOM streamed "Done." (last_dom_text); return matched with same text.
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="matched", text="Done.")
+    )
+    d._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))
 
     chunks = []
     async for chunk in d.send_and_stream("hello", timeout=10000):
@@ -165,8 +174,13 @@ async def test_has_action_fallback_without_conv_id(monkeypatch):
     )
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
-    d._fetch_end_turn = AsyncMock(return_value=True)  # should NOT be called
+    # A2: conv_id never resolves (URL stays ?model=auto) so the reconciliation
+    # loop is skipped — this mock is never called. Mapped to not_ready for
+    # semantic fidelity with the old return_value="".
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="not_ready")
+    )
+    d._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))  # should NOT be called
 
     chunks = []
     async for chunk in d.send_and_stream("hello", timeout=10000):
@@ -177,7 +191,7 @@ async def test_has_action_fallback_without_conv_id(monkeypatch):
     assert any("Fallback answer" in c for c in deltas), f"deltas: {deltas}"
     assert chunks[-1].finish_reason == "stop"
     # end_turn was never consulted because conv_id_for_check was never set
-    assert d._fetch_end_turn.await_count == 0
+    assert d._fetch_end_turn_for_turn.await_count == 0
 
 
 # ── 4. JS selector walks to ancestor depth 8 (structural check) ────────
@@ -260,9 +274,13 @@ async def test_has_action_does_not_complete_when_backend_says_not_done(monkeypat
     d._js_strict = _phase1_then_phase2_js(state, phase2_factory=phase2)
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
+    # A2: loop never reaches reconciliation (GenerationStuckError fires in
+    # Phase-2 first). Mapped to not_ready (faithful to old "").
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="not_ready")
+    )
     # Backend is reachable but says NOT done — authoritative
-    d._fetch_end_turn = AsyncMock(return_value=False)
+    d._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="not_ready"))
 
     from chatgpt_web2api.cdp_driver import GenerationStuckError
 
@@ -274,4 +292,4 @@ async def test_has_action_does_not_complete_when_backend_says_not_done(monkeypat
     # The loop polled the backend (conv_id resolved after ~1s) and did NOT
     # break on has_action — it ran until the stall guard fired. Proves the DOM
     # signal cannot override a live backend.
-    assert d._fetch_end_turn.await_count >= 1, "backend must be consulted once conv_id is available"
+    assert d._fetch_end_turn_for_turn.await_count >= 1, "backend must be consulted once conv_id is available"

--- a/tests/test_identity_listener.py
+++ b/tests/test_identity_listener.py
@@ -1,0 +1,355 @@
+"""Tests for the A2 IdentityListener (Step 2).
+
+Exercises capture validation (failure-mode B), scope lifecycle (E), and the
+non-blocking handler contract. Uses synthetic ``Network.requestWillBeSent``
+events — no real CDP/Chrome required.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.identity_listener import (
+    CaptureResult,
+    CaptureScope,
+    IdentityListener,
+    hash_sent_text,
+)
+
+
+def _make_driver():
+    d = MagicMock()
+    d._cdp_event_handlers = {}
+    d._cdp = AsyncMock(return_value={"result": {}})
+    return d
+
+
+def _make_send_event(
+    *,
+    uuid: str = "11111111-1111-4111-8111-111111111111",
+    text: str = "hello",
+    conversation_id: str | None = "conv-1",
+    action: str = "next",
+    role: str = "user",
+    post_data: str | None = None,
+    request_id: str = "req-1",
+) -> dict:
+    """Build a synthetic Network.requestWillBeSent event."""
+    body = {
+        "action": action,
+        "messages": [{
+            "id": uuid,
+            "author": {"role": role},
+            "content": {"content_type": "text", "parts": [text]},
+        }],
+    }
+    if conversation_id is not None:
+        body["conversation_id"] = conversation_id
+    if post_data is None:
+        post_data = json.dumps(body)
+    return {
+        "method": "Network.requestWillBeSent",
+        "params": {
+            "requestId": request_id,
+            "request": {
+                "url": "https://chatgpt.com/backend-api/f/conversation",
+                "method": "POST",
+                "postData": post_data,
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_attach_registers_handler_and_enables_network():
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+    assert "Network.requestWillBeSent" in driver._cdp_event_handlers
+    assert driver._cdp.call_count == 1
+    args, kwargs = driver._cdp.call_args
+    assert args[0] == "Network.enable"
+    assert kwargs.get("params") == {"maxPostDataSize": 4 * 1024 * 1024} or args[1] == {"maxPostDataSize": 4 * 1024 * 1024}
+    assert listener.is_alive() is True
+
+
+@pytest.mark.asyncio
+async def test_successful_capture_resolves_uuid():
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+
+    text = "Reply with exactly: MARKER-1"
+    scope = listener.arm_capture_scope(
+        expected_text_hash=hash_sent_text(text),
+        conversation_id="conv-1",
+        target_id="tgt-1",
+    )
+    try:
+        # Fire the event directly through the handler.
+        await listener._process_send_post(
+            scope, _make_send_event(text=text, conversation_id="conv-1"),
+            "https://chatgpt.com/backend-api/f/conversation",
+        )
+        uuid = await listener.wait_for_captured_uuid(timeout=1.0)
+        assert uuid == "11111111-1111-4111-8111-111111111111"
+        assert listener.capture_success_count == 1
+    finally:
+        scope.close()
+
+
+@pytest.mark.asyncio
+async def test_wrong_text_hash_does_not_resolve():
+    """A POST whose text doesn't match our send is ignored (failure-mode D)."""
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+
+    scope = listener.arm_capture_scope(
+        expected_text_hash=hash_sent_text("our prompt"),
+        conversation_id="conv-1",
+        target_id="tgt-1",
+    )
+    try:
+        # POST carries different text.
+        await listener._process_send_post(
+            scope, _make_send_event(text="different prompt", conversation_id="conv-1"),
+            "https://chatgpt.com/backend-api/f/conversation",
+        )
+        # Should NOT resolve; scope stays open.
+        uuid = await listener.wait_for_captured_uuid(timeout=0.2)
+        assert uuid is None  # timeout
+    finally:
+        scope.close()
+
+
+@pytest.mark.asyncio
+async def test_wrong_conversation_id_does_not_resolve():
+    """A POST for a different conversation is ignored."""
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+
+    scope = listener.arm_capture_scope(
+        expected_text_hash=hash_sent_text("hello"),
+        conversation_id="conv-1",
+        target_id="tgt-1",
+    )
+    try:
+        await listener._process_send_post(
+            scope, _make_send_event(text="hello", conversation_id="conv-OTHER"),
+            "https://chatgpt.com/backend-api/f/conversation",
+        )
+        uuid = await listener.wait_for_captured_uuid(timeout=0.2)
+        assert uuid is None
+    finally:
+        scope.close()
+
+
+@pytest.mark.asyncio
+async def test_non_next_action_ignored():
+    """action != 'next' is not a user send (regenerate/edit/etc.)."""
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+
+    scope = listener.arm_capture_scope(
+        expected_text_hash=hash_sent_text("hello"),
+        conversation_id="conv-1",
+        target_id="tgt-1",
+    )
+    try:
+        await listener._process_send_post(
+            scope, _make_send_event(text="hello", conversation_id="conv-1", action="regenerate"),
+            "https://chatgpt.com/backend-api/f/conversation",
+        )
+        uuid = await listener.wait_for_captured_uuid(timeout=0.2)
+        assert uuid is None
+    finally:
+        scope.close()
+
+
+@pytest.mark.asyncio
+async def test_invalid_uuid_ignored():
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+
+    scope = listener.arm_capture_scope(
+        expected_text_hash=hash_sent_text("hello"),
+        conversation_id="conv-1",
+        target_id="tgt-1",
+    )
+    try:
+        await listener._process_send_post(
+            scope, _make_send_event(uuid="not-a-uuid", text="hello", conversation_id="conv-1"),
+            "https://chatgpt.com/backend-api/f/conversation",
+        )
+        uuid = await listener.wait_for_captured_uuid(timeout=0.2)
+        assert uuid is None
+    finally:
+        scope.close()
+
+
+@pytest.mark.asyncio
+async def test_scope_close_clears_active_state():
+    """Closing a scope clears the listener's active ref (failure-mode E)."""
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+
+    scope = listener.arm_capture_scope(
+        expected_text_hash=hash_sent_text("hello"),
+        conversation_id=None,
+        target_id="tgt-1",
+    )
+    assert listener._active_scope is scope
+    scope.close()
+    assert listener._active_scope is None
+    # Closing again is idempotent.
+    scope.close()
+
+
+@pytest.mark.asyncio
+async def test_scope_close_unblocks_waiter():
+    """If a scope is closed while wait_for_captured_uuid is awaiting, it returns None."""
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+
+    scope = listener.arm_capture_scope(
+        expected_text_hash=hash_sent_text("hello"),
+        conversation_id=None,
+        target_id="tgt-1",
+    )
+
+    async def closer():
+        await asyncio.sleep(0.1)
+        scope.close()
+
+    closer_task = asyncio.create_task(closer())
+    uuid = await listener.wait_for_captured_uuid(timeout=5.0)
+    await closer_task
+    assert uuid is None  # scope closed without capture
+
+
+@pytest.mark.asyncio
+async def test_handler_prefilter_rejects_non_post():
+    """The synchronous prefilter rejects non-POST events without scheduling."""
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+    scope = listener.arm_capture_scope(
+        expected_text_hash=hash_sent_text("hello"),
+        conversation_id=None,
+        target_id="tgt-1",
+    )
+    try:
+        # A GET request to the same endpoint — should be ignored by prefilter.
+        listener._on_request_will_be_sent({
+            "method": "Network.requestWillBeSent",
+            "params": {"requestId": "r1", "request": {
+                "url": "https://chatgpt.com/backend-api/f/conversation",
+                "method": "GET",
+            }},
+        })
+        # Give any (should-not-exist) task a tick.
+        await asyncio.sleep(0.05)
+        # No capture.
+        assert scope.future is not None and not scope.future.done()
+    finally:
+        scope.close()
+
+
+@pytest.mark.asyncio
+async def test_handler_no_active_scope_is_noop():
+    """Events with no armed scope are dropped silently."""
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+    # No scope armed.
+    listener._on_request_will_be_sent(_make_send_event(text="hello"))
+    await asyncio.sleep(0.05)
+    # No crash, no capture.
+
+
+@pytest.mark.asyncio
+async def test_reenable_if_stale_when_not_ready():
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    listener._ready = False  # simulate stale
+    ok = await listener.reenable_if_stale()
+    assert ok is True
+    assert listener.is_alive() is True
+    assert listener.reenabled_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reenable_if_stale_already_ready_is_noop():
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+    calls_before = driver._cdp.call_count
+    ok = await listener.reenable_if_stale()
+    assert ok is True
+    assert driver._cdp.call_count == calls_before  # no extra Network.enable
+
+
+@pytest.mark.asyncio
+async def test_postdata_missing_tries_getRequestPostData():
+    """Failure-mode C: if postData absent, try Network.getRequestPostData once."""
+    driver = _make_driver()
+    # First call: Network.enable. Second: getRequestPostData returns a body.
+    captured_uuid = "22222222-2222-4222-8222-222222222222"
+    body = json.dumps({
+        "action": "next",
+        "messages": [{"id": captured_uuid, "author": {"role": "user"},
+                      "content": {"content_type": "text", "parts": ["hello"]}}],
+        "conversation_id": "conv-1",
+    })
+    driver._cdp = AsyncMock(side_effect=[
+        {"result": {}},  # Network.enable
+        {"result": {"postData": body}},  # getRequestPostData
+    ])
+    listener = IdentityListener(driver)
+    await listener.attach()
+
+    scope = listener.arm_capture_scope(
+        expected_text_hash=hash_sent_text("hello"),
+        conversation_id="conv-1",
+        target_id="tgt-1",
+    )
+    try:
+        # Event with NO postData field.
+        event = {
+            "method": "Network.requestWillBeSent",
+            "params": {"requestId": "r1", "request": {
+                "url": "https://chatgpt.com/backend-api/f/conversation",
+                "method": "POST",
+                # no postData
+            }},
+        }
+        await listener._process_send_post(
+            scope, event, "https://chatgpt.com/backend-api/f/conversation",
+        )
+        uuid = await listener.wait_for_captured_uuid(timeout=1.0)
+        assert uuid == captured_uuid
+        assert listener.postdata_missing_count == 1
+    finally:
+        scope.close()
+
+
+@pytest.mark.asyncio
+async def test_sequential_send_sequence_increments():
+    driver = _make_driver()
+    listener = IdentityListener(driver)
+    await listener.attach()
+    s1 = listener.arm_capture_scope(expected_text_hash="a", conversation_id=None, target_id="t")
+    s2 = listener.arm_capture_scope(expected_text_hash="b", conversation_id=None, target_id="t")
+    assert s2.send_sequence_id == s1.send_sequence_id + 1
+    s1.close()
+    s2.close()

--- a/tests/test_identity_listener.py
+++ b/tests/test_identity_listener.py
@@ -7,15 +7,12 @@ events — no real CDP/Chrome required.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from chatgpt_web2api.identity_listener import (
-    CaptureResult,
-    CaptureScope,
     IdentityListener,
     hash_sent_text,
 )

--- a/tests/test_non_text_response.py
+++ b/tests/test_non_text_response.py
@@ -3,7 +3,7 @@
 Verifies that image/tool-use/non-text responses don't falsely trigger the
 stall detector, that text responses stream correctly (no regression), and
 that the placeholder message surfaces when non-text content is detected
-but _fetch_text returns empty.
+but _fetch_text_for_turn returns not_ready/empty.
 """
 
 import json
@@ -15,6 +15,7 @@ import pytest
 from chatgpt_web2api.cdp_driver import (
     CDPDriver,
 )
+from chatgpt_web2api.turn_anchor import TurnEndResult, TurnTextResult
 
 
 def _make_driver():
@@ -70,7 +71,11 @@ async def test_image_response_does_not_stall(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")  # no text from API
+    # A2: image turn — selector reports non_text so the reconciliation loop
+    # breaks to the placeholder path (last_dom_text empty + had_non_text_content).
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="non_text")
+    )
 
     chunks = []
     async for chunk in d.send_and_stream("generate an image", timeout=10000):
@@ -124,7 +129,11 @@ async def test_text_response_streams_delta_unchanged(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
+    # A2: _fake_js has no location.href handler → conv_id never resolves →
+    # reconciliation skipped. Mapped to not_ready (faithful to old "").
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="not_ready")
+    )
 
     chunks = []
     async for chunk in d.send_and_stream("hello", timeout=10000):
@@ -138,13 +147,14 @@ async def test_text_response_streams_delta_unchanged(monkeypatch):
     assert chunks[-1].finish_reason == "stop"
 
 
-# ── 3. _fetch_text empty + non-text content → placeholder ────────────
+# ── 3. _fetch_text_for_turn not_ready + non-text content → placeholder ─
 
 
 @pytest.mark.asyncio
 async def test_placeholder_on_empty_fetch_with_non_text_content(monkeypatch):
-    """When Phase-2 detects non-text content (html_len > 50) but _fetch_text
-    returns empty, the reconcile should yield a placeholder message."""
+    """When Phase-2 detects non-text content (html_len > 50) but
+    _fetch_text_for_turn returns not_ready, the reconcile should yield a
+    placeholder message."""
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
@@ -180,11 +190,15 @@ async def test_placeholder_on_empty_fetch_with_non_text_content(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")  # API returns no text
+    # A2: non-text turn (html_len=200>50 → had_non_text_content). Selector
+    # reports non_text → reconciliation breaks to the placeholder path.
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="non_text")
+    )
     # Updated for #12: backend end_turn is primary when conv_id is available.
     # This test's URL resolves to /c/test-conv-123, so the backend is consulted.
     # end_turn confirms completion once the non-text content is present.
-    d._fetch_end_turn = AsyncMock(return_value=True)
+    d._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))
 
     chunks = []
     async for chunk in d.send_and_stream("generate image", timeout=10000):

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -17,6 +17,7 @@ from chatgpt_web2api.cdp_driver import (
     CDPDriver,
     GenerationStuckError,
 )
+from chatgpt_web2api.turn_anchor import TurnEndResult, TurnTextResult
 
 # ── Helpers ────────────────────────────────────────────────────
 
@@ -32,7 +33,8 @@ def _make_driver():
 
 def _mock_js_with_payload(d, payload_map):
     """Make d._js_with_data return values based on a lookup of (conv_id/token)
-    → response string. For _fetch_text the payload carries conv_id+token."""
+    → response string. For backend conversation fetches the payload carries
+    conv_id+token."""
 
     async def _fake(js_template, data, timeout=15):
         return payload_map.get(data.get("conv_id"), "")
@@ -104,56 +106,12 @@ async def test_read_methods_call_ensure_token_first():
     assert call_order == ["ensure_token", "fetch"], f"order: {call_order}"
 
 
-# ── 3. _fetch_text 401 raises AuthExpiredError ─────────────────
-
-
-@pytest.mark.asyncio
-async def test_fetch_text_401_raises_auth_expired():
-    d = _make_driver()
-
-    async def _fake(js_template, data, timeout=15):
-        return '{"__status": 401}'
-
-    d._js_with_data_strict = _fake
-    d.ensure_token = AsyncMock(return_value="tok")
-    with pytest.raises(AuthExpiredError):
-        await d._fetch_text("conv-1")
-
-
-@pytest.mark.asyncio
-async def test_fetch_text_404_raises_runtime_error():
-    """A persistent 404 (bound exhausted) surfaces as RuntimeError with the
-    code. The bounded retry in backend_client._fetch_text is exercised, but
-    backoff is zeroed here to keep the test fast."""
-    d = _make_driver()
-    calls = {"n": 0}
-
-    async def _fake(js_template, data, timeout=15):
-        calls["n"] += 1
-        return '{"__status": 404}'
-
-    d._js_with_data_strict = _fake
-    d.ensure_token = AsyncMock(return_value="tok")
-    # Zero the backoff so the bound is exhausted without real sleeping.
-    d._backend_client._FETCH_TEXT_404_BACKOFF_SECONDS = 0.0
-    with pytest.raises(RuntimeError) as ei:
-        await d._fetch_text("conv-1")
-    assert "404" in str(ei.value)
-    # Bound exhausted → one fetch per attempt.
-    assert calls["n"] == d._backend_client._FETCH_TEXT_404_MAX_ATTEMPTS
-
-
-@pytest.mark.asyncio
-async def test_fetch_text_valid_body_returns_text():
-    d = _make_driver()
-
-    async def _fake(js_template, data, timeout=15):
-        return "the assistant reply text"
-
-    d._js_with_data_strict = _fake
-    d.ensure_token = AsyncMock(return_value="tok")
-    result = await d._fetch_text("conv-1")
-    assert result == "the assistant reply text"
+# ── 3. (removed) legacy _fetch_text status-decode tests ─────────
+#
+# The uncorrelated ``_fetch_text`` / ``_fetch_end_turn`` methods were deleted
+# in the A2 Step 9/10 cleanup; the same status-decode + breaker behavior now
+# lives in ``_fetch_recent_conversation_projection`` and is exercised via the
+# A2 anchored fetchers (``_fetch_text_for_turn`` / ``_fetch_end_turn_for_turn``).
 
 
 # ── 4. Phase-1 stall (node count never changes) ────────────────
@@ -238,7 +196,7 @@ async def test_phase2_stall_raises_generation_stuck(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
+    d._fetch_text_for_turn = AsyncMock(return_value=TurnTextResult(status="not_ready"))
 
     with pytest.raises(GenerationStuckError) as ei:
         async for _ in d.send_and_stream("hi", timeout=10000):
@@ -283,7 +241,9 @@ async def test_slow_appear_succeeds_without_cap(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="done")
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="matched", text="done")
+    )
 
     chunks = []
     async for chunk in d.send_and_stream("hi", timeout=10000):
@@ -325,7 +285,9 @@ async def test_progressing_generation_does_not_raise(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value=state["text"])
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="matched", text=state["text"])
+    )
 
     chunks = []
     async for chunk in d.send_and_stream("hi", timeout=100000):
@@ -344,13 +306,14 @@ async def test_thinking_model_streams_during_answer_phase(monkeypatch):
     The old `if is_thinking / elif text-changed` structure meant
     is_thinking=true suppressed ALL delta emission — freezing
     last_dom_text="" and producing an empty response whenever the
-    _fetch_text fallback lagged (the common case for thinking models,
-    whose conversation-API text commits late).
+    backend final-text fetch lagged (the common case for thinking
+    models, whose conversation-API text commits late).
 
     Simulates the post-reasoning gap: is_thinking=true throughout
     (.result-thinking lingers after reasoning ends), answer text grows
-    each poll, has_action fires at the end. With _fetch_text mocked
-    empty (fallback lag), the answer MUST still arrive via deltas."""
+    each poll, has_action fires at the end. With _fetch_text_for_turn
+    mocked not_ready (fallback lag), the answer MUST still arrive via
+    deltas."""
     d = _make_driver()
     t = [0.0]
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.time.monotonic", lambda: t[0])
@@ -386,7 +349,9 @@ async def test_thinking_model_streams_during_answer_phase(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")  # fallback lag → empty
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="not_ready")
+    )  # fallback lag → empty
 
     chunks = []
     async for chunk in d.send_and_stream("think then answer", timeout=10000):
@@ -436,16 +401,18 @@ async def test_phase2_end_turn_fallback_completes_when_dom_action_missing(monkey
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="the full answer")
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="matched", text="the full answer")
+    )
     # Backend says end_turn is true on first check → completes.
-    d._fetch_end_turn = AsyncMock(return_value=True)
+    d._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))
     end_turn_calls["n"] = 0
 
-    async def _counting_end_turn(cid):
+    async def _counting_end_turn(cid, anchor, *, had_non_text_content=False):
         end_turn_calls["n"] += 1
-        return True
+        return TurnEndResult(status="matched")
 
-    d._fetch_end_turn = _counting_end_turn
+    d._fetch_end_turn_for_turn = _counting_end_turn
 
     chunks = []
     async for chunk in d.send_and_stream("hi", timeout=10000):
@@ -484,13 +451,13 @@ async def test_phase2_end_turn_fallback_ignored_on_fetch_failure(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
+    d._fetch_text_for_turn = AsyncMock(return_value=TurnTextResult(status="not_ready"))
 
     # Backend fetch raises — must be swallowed, not propagated.
-    async def _raising_end_turn(cid):
+    async def _raising_end_turn(cid, anchor, *, had_non_text_content=False):
         raise RuntimeError("backend blew up")
 
-    d._fetch_end_turn = _raising_end_turn
+    d._fetch_end_turn_for_turn = _raising_end_turn
 
     # Should still raise GenerationStuckError (stall), NOT the backend error.
     with pytest.raises(GenerationStuckError) as ei:
@@ -530,13 +497,13 @@ async def test_phase2_end_turn_fallback_skipped_when_no_text(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
+    d._fetch_text_for_turn = AsyncMock(return_value=TurnTextResult(status="not_ready"))
 
-    async def _counting_end_turn(cid):
+    async def _counting_end_turn(cid, anchor, *, had_non_text_content=False):
         end_turn_calls["n"] += 1
-        return True
+        return TurnEndResult(status="matched")
 
-    d._fetch_end_turn = _counting_end_turn
+    d._fetch_end_turn_for_turn = _counting_end_turn
 
     with pytest.raises(GenerationStuckError):
         async for _ in d.send_and_stream("hi", timeout=10000):
@@ -586,13 +553,15 @@ async def test_phase2_backend_end_turn_is_primary_over_dom(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="answer")
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="matched", text="answer")
+    )
 
-    async def _counting_end_turn(cid):
+    async def _counting_end_turn(cid, anchor, *, had_non_text_content=False):
         end_turn_calls["n"] += 1
-        return True
+        return TurnEndResult(status="matched")
 
-    d._fetch_end_turn = _counting_end_turn
+    d._fetch_end_turn_for_turn = _counting_end_turn
 
     async for _ in d.send_and_stream("hi", timeout=10000):
         pass
@@ -658,14 +627,18 @@ async def test_thinking_placeholder_does_not_stall_past_90s(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="the answer")
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="matched", text="the answer")
+    )
 
     # Backend says not-done during thinking, then done once the answer appears.
-    async def _end_turn(cid):
+    async def _end_turn(cid, anchor, *, had_non_text_content=False):
         state["end_turn_calls"] += 1
-        return state["phase2_polls"] > 10
+        return TurnEndResult(
+            status="matched" if state["phase2_polls"] > 10 else "not_ready"
+        )
 
-    d._fetch_end_turn = _end_turn
+    d._fetch_end_turn_for_turn = _end_turn
 
     chunks = []
     async for chunk in d.send_and_stream("think hard", timeout=10000):
@@ -710,8 +683,8 @@ async def test_saw_thinking_unlocks_fallback_but_empty_end_turn_does_not_finish(
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
-    d._fetch_end_turn = AsyncMock(return_value=True)
+    d._fetch_text_for_turn = AsyncMock(return_value=TurnTextResult(status="not_ready"))
+    d._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))
 
     # is_thinking keeps resetting the stall clock, and the strict content
     # guard prevents completing on empty. The loop runs to the deadline and
@@ -762,8 +735,10 @@ async def test_saw_thinking_with_end_turn_and_content_finishes(monkeypatch):
     d._js_strict = _fake_js
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="the full answer")
-    d._fetch_end_turn = AsyncMock(return_value=True)
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="matched", text="the full answer")
+    )
+    d._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))
 
     chunks = []
     async for chunk in d.send_and_stream("think then answer", timeout=10000):

--- a/tests/test_sse_end_turn_new_chat.py
+++ b/tests/test_sse_end_turn_new_chat.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from chatgpt_web2api.cdp_driver import CDPDriver
+from chatgpt_web2api.turn_anchor import TurnEndResult, TurnTextResult
 
 
 def _make_driver():
@@ -149,16 +150,20 @@ async def test_loop_resolves_conv_id_mid_loop(monkeypatch):
     d._js_strict = _phase1_then_phase2_js(state, phase2_factory=phase2)
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
+    # A2: DOM streamed "Hello world. " (last_dom_text); return matched with the
+    # same text so reconciliation breaks cleanly (len == last_dom_text → no delta).
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="matched", text="Hello world. ")
+    )
 
-    # end_turn becomes True once polled. Mocked to record the conv_id it saw.
+    # end_turn becomes matched once polled. Mocked to record the conv_id it saw.
     seen_conv_ids = []
 
-    async def _fake_end_turn(conv_id):
+    async def _fake_end_turn(conv_id, anchor, *, had_non_text_content=False):
         seen_conv_ids.append(conv_id)
-        return True
+        return TurnEndResult(status="matched")
 
-    d._fetch_end_turn = _fake_end_turn
+    d._fetch_end_turn_for_turn = _fake_end_turn
 
     chunks = []
     async for chunk in d.send_and_stream("hello", timeout=10000):
@@ -197,8 +202,12 @@ async def test_backend_end_turn_completes_with_text(monkeypatch):
     d._js_strict = _phase1_then_phase2_js(state, phase2_factory=phase2)
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
-    d._fetch_end_turn = AsyncMock(return_value=True)
+    # A2: DOM streamed "Final answer." (last_dom_text); return matched with
+    # same text so reconciliation breaks cleanly (no spurious delta).
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="matched", text="Final answer.")
+    )
+    d._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))
 
     chunks = []
     async for chunk in d.send_and_stream("hello", timeout=10000):
@@ -207,7 +216,7 @@ async def test_backend_end_turn_completes_with_text(monkeypatch):
     deltas = [c.delta for c in chunks if c.delta]
     assert any("Final answer" in c for c in deltas), f"deltas: {deltas}"
     assert chunks[-1].finish_reason == "stop"
-    assert d._fetch_end_turn.await_count >= 1
+    assert d._fetch_end_turn_for_turn.await_count >= 1
 
 
 # ── 5. is_thinking=True does not prevent backend completion ────────────
@@ -241,8 +250,11 @@ async def test_is_thinking_does_not_block_backend_completion(monkeypatch):
     d._js_strict = _phase1_then_phase2_js(state, phase2_factory=phase2)
     d.type_message = AsyncMock()
     d.click_send = AsyncMock()
-    d._fetch_text = AsyncMock(return_value="")
-    d._fetch_end_turn = AsyncMock(return_value=True)
+    # A2: DOM streamed "Answer." (last_dom_text); return matched with same text.
+    d._fetch_text_for_turn = AsyncMock(
+        return_value=TurnTextResult(status="matched", text="Answer.")
+    )
+    d._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="matched"))
 
     chunks = []
     async for chunk in d.send_and_stream("hello", timeout=10000):

--- a/tests/test_turn_anchor.py
+++ b/tests/test_turn_anchor.py
@@ -221,6 +221,27 @@ class TestDegradedExisting:
         result = select_text_for_turn(mapping, anchor)
         assert result.status == "ambiguous"
 
+    def test_degraded_same_text_repeat_does_not_silently_match(self):
+        """PR #39 review finding #3: degraded mode with one fresh + one stale
+        same-text match must NOT silently pick the fresh one — we can't
+        distinguish 'new node propagated' from 'old node still fresh enough.'
+        Must return not_ready (keep polling) until disambiguated."""
+        # Previous turn's user node — stale (below freshness floor).
+        u_old = _user_node("u-old", "continue", 82.0, children=["a-old"])
+        # New turn's user node — fresh (within the TOL=8 window).
+        u_new = _user_node("u-new", "continue", 100.0, children=["a-new"])
+        mapping = _mapping(("u-old", u_old), ("u-new", u_new))
+        anchor = TurnAnchor(
+            sent_text="continue", mode="degraded_existing",
+            pre_send_wall_time=95.0,
+        )
+        result = select_text_for_turn(mapping, anchor)
+        # Must NOT be "matched" — the stale alternative means we can't be
+        # certain u-new is the new turn (it might be u-old's text still
+        # propagating). Keep polling.
+        assert result.status != "matched"
+        assert result.status in ("not_ready", "degraded_ambiguous_with_stale")
+
 
 # ── Selector: fresh_chat ──────────────────────────────────────────────────
 

--- a/tests/test_turn_anchor.py
+++ b/tests/test_turn_anchor.py
@@ -184,9 +184,11 @@ class TestExistingConversationFallback:
 # ── Selector: degraded_existing ───────────────────────────────────────────
 
 class TestDegradedExisting:
-    def test_degraded_fresh_match_accepted(self):
-        # Backend create_time is ~5s ahead of local; pre_send_wall_time=95.0.
-        # New user at 100.0 → 100.0 >= 95.0 - 8.0 = 87.0 → fresh.
+    def test_degraded_never_matches_single_fresh(self):
+        """Degraded mode never accepts a match — it only polls or times out.
+        Even a single fresh node with no stale alternatives is not sufficient
+        evidence, because we can't prove it's the NEW turn vs the previous
+        same-text turn still within the freshness window."""
         user = _user_node("u-1", "hello", 100.0, children=["a-1"])
         asst = _assistant_node("a-1", "Reply", 101.0, end_turn=True, parent="u-1")
         mapping = _mapping(("u-1", user), ("a-1", asst))
@@ -195,8 +197,8 @@ class TestDegradedExisting:
             pre_send_wall_time=95.0,
         )
         result = select_text_for_turn(mapping, anchor)
-        assert result.status == "matched"
-        assert result.text == "Reply"
+        assert result.status != "matched"
+        assert result.status == "not_ready"
 
     def test_degraded_stale_single_match_rejected(self):
         # Old user node from 80.0; pre_send_wall_time=95.0.
@@ -236,11 +238,30 @@ class TestDegradedExisting:
             pre_send_wall_time=95.0,
         )
         result = select_text_for_turn(mapping, anchor)
-        # Must NOT be "matched" — the stale alternative means we can't be
-        # certain u-new is the new turn (it might be u-old's text still
-        # propagating). Keep polling.
         assert result.status != "matched"
         assert result.status in ("not_ready", "degraded_ambiguous_with_stale")
+
+    def test_degraded_single_fresh_previous_turn_not_accepted(self):
+        """The narrowest rapid-repeat case: only ONE matching user node exists,
+        it passes the freshness floor, but it's actually the PREVIOUS turn's
+        node (the new node hasn't propagated yet). Degraded mode must NOT
+        accept this — it has insufficient evidence to prove this is the new
+        turn rather than the old one.
+        (PR #39 review — the prior implementation accepted this case.)"""
+        # Previous "continue" sent ~3s ago; backend create_time is ~5s ahead
+        # of local, so this node's create_time=100.0 is within the freshness
+        # floor of pre_send_wall_time=95.0 (100.0 >= 95.0 - 8.0 = 87.0).
+        # But the NEW "continue" send's node hasn't propagated to the backend
+        # mapping yet — there's only one match, and it's the OLD one.
+        user = _user_node("u-prev", "continue", 100.0, children=["a-prev"])
+        mapping = _mapping(("u-prev", user))
+        anchor = TurnAnchor(
+            sent_text="continue", mode="degraded_existing",
+            pre_send_wall_time=95.0,
+        )
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status != "matched"
+        assert result.status == "not_ready"
 
 
 # ── Selector: fresh_chat ──────────────────────────────────────────────────

--- a/tests/test_turn_anchor.py
+++ b/tests/test_turn_anchor.py
@@ -1,0 +1,350 @@
+"""Tests for the A2 turn-anchor module (Step 4).
+
+Pure-Python tests for the matcher, selectors, and tri-state collapse. No CDP,
+no real browser — operates on synthetic projected mappings.
+"""
+from __future__ import annotations
+
+import pytest
+
+from chatgpt_web2api.turn_anchor import (
+    EndTurnStatus,
+    SKEW_TOLERANCE_SECONDS,
+    TurnAnchor,
+    TurnEndResult,
+    TurnTextResult,
+    collapse_to_end_turn_status,
+    normalize_text,
+    select_end_turn_for_turn,
+    select_text_for_turn,
+    user_text_matches_sent,
+)
+
+
+# ── Test fixtures ─────────────────────────────────────────────────────────
+
+def _user_node(node_id: str, text: str, create_time: float, *, children=None) -> dict:
+    return {
+        "id": node_id,
+        "message": {
+            "id": node_id,
+            "author": {"role": "user"},
+            "create_time": create_time,
+            "content": {"content_type": "text", "parts": [text]},
+        },
+        "children": children or [],
+    }
+
+
+def _assistant_node(node_id: str, text: str, create_time: float, *,
+                    end_turn: bool = False, content_type: str = "text",
+                    parent: str | None = None, children=None) -> dict:
+    return {
+        "id": node_id,
+        "parent": parent,
+        "message": {
+            "id": node_id,
+            "author": {"role": "assistant"},
+            "create_time": create_time,
+            "end_turn": end_turn,
+            "content": {"content_type": content_type,
+                        "parts": [text] if text else []},
+        },
+        "children": children or [],
+    }
+
+
+def _mapping(*nodes) -> dict:
+    """Build a projected mapping from a list of (id, node_dict)."""
+    return {"nodes": {n[0]: n[1] for n in nodes}}
+
+
+# ── Matcher tests ─────────────────────────────────────────────────────────
+
+class TestMatcher:
+    def test_full_equality_short(self):
+        assert user_text_matches_sent("hello", "hello")
+
+    def test_full_equality_with_whitespace_normalization(self):
+        assert user_text_matches_sent("  hello  ", "hello")
+        assert user_text_matches_sent("hello\r\nworld", "hello\nworld")
+
+    def test_full_equality_case_sensitive(self):
+        # Matcher is case-sensitive after normalization (no lowercasing).
+        assert not user_text_matches_sent("Hello", "hello")
+
+    def test_truncated_prefix_long_accepted(self):
+        parent = "A" * 1024
+        sent = "A" * 1024 + "B" * 100  # sent is longer; parent is a prefix
+        assert user_text_matches_sent(parent, sent)
+
+    def test_short_prefix_rejected(self):
+        # 64-char shared prefix — below threshold.
+        parent = "X" * 64
+        sent = "X" * 64 + "Y"
+        assert not user_text_matches_sent(parent, sent)
+
+    def test_below_threshold_must_match_exactly(self):
+        parent = "A" * 500
+        sent = "A" * 500 + "B"
+        assert not user_text_matches_sent(parent, sent)
+
+    def test_empty_strings(self):
+        assert not user_text_matches_sent("", "")
+        assert not user_text_matches_sent("hello", "")
+
+
+# ── Selector: primary ID path ─────────────────────────────────────────────
+
+class TestPrimaryIdPath:
+    def test_captured_id_exact_match(self):
+        user = _user_node("u-1", "hello", 100.0, children=["a-1"])
+        asst = _assistant_node("a-1", "Hi there", 101.0, end_turn=True, parent="u-1")
+        mapping = _mapping(("u-1", user), ("a-1", asst))
+        anchor = TurnAnchor(
+            sent_text="hello", mode="captured_id",
+            captured_user_message_id="u-1",
+        )
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "matched"
+        assert result.text == "Hi there"
+
+    def test_captured_id_not_yet_in_mapping(self):
+        anchor = TurnAnchor(
+            sent_text="hello", mode="captured_id",
+            captured_user_message_id="u-MISSING",
+        )
+        mapping = _mapping(("u-1", _user_node("u-1", "hello", 100.0)))
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "not_ready"
+        assert "id_not_yet_in_mapping" in result.diagnostic.get("reason", "")
+
+
+# ── Selector: fallback existing_conversation ──────────────────────────────
+
+class TestExistingConversationFallback:
+    def test_text_match_with_anchor_newer(self):
+        old_user = _user_node("u-old", "hello", 90.0, children=["a-old"])
+        new_user = _user_node("u-new", "hello", 100.0, children=["a-new"])
+        asst = _assistant_node("a-new", "Fresh reply", 101.0, end_turn=True, parent="u-new")
+        mapping = _mapping(("u-old", old_user), ("u-new", new_user), ("a-new", asst))
+        anchor = TurnAnchor(
+            sent_text="hello", mode="existing_conversation",
+            latest_user_node_id="u-old", latest_user_create_time=90.0,
+        )
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "matched"
+        assert result.text == "Fresh reply"
+
+    def test_timestamp_tie_node_id_disambiguates(self):
+        # Two user nodes with same text and same create_time; different ids.
+        u1 = _user_node("u-1", "hello", 100.0, children=["a-1"])
+        u2 = _user_node("u-2", "hello", 100.0, children=["a-2"])
+        a1 = _assistant_node("a-1", "Reply 1", 101.0, end_turn=True, parent="u-1")
+        a2 = _assistant_node("a-2", "Reply 2", 102.0, end_turn=True, parent="u-2")
+        mapping = _mapping(("u-1", u1), ("u-2", u2), ("a-1", a1), ("a-2", a2))
+        anchor = TurnAnchor(
+            sent_text="hello", mode="existing_conversation",
+            latest_user_node_id="u-PREVIOUS", latest_user_create_time=100.0,
+        )
+        # Both u-1 and u-2 are different from u-PREVIOUS and >= 100.0 → ambiguous.
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "ambiguous"
+
+    def test_identical_answer_text_still_matches_newest(self):
+        # Same text sent twice; both responses identical. Selector must still
+        # find the NEWER end_turn=true descendant.
+        old_user = _user_node("u-old", "ping", 90.0, children=["a-old"])
+        new_user = _user_node("u-new", "ping", 100.0, children=["a-new"])
+        a_old = _assistant_node("a-old", "pong", 91.0, end_turn=True, parent="u-old")
+        a_new = _assistant_node("a-new", "pong", 101.0, end_turn=True, parent="u-new")
+        mapping = _mapping(("u-old", old_user), ("u-new", new_user),
+                           ("a-old", a_old), ("a-new", a_new))
+        anchor = TurnAnchor(
+            sent_text="ping", mode="existing_conversation",
+            latest_user_node_id="u-old", latest_user_create_time=90.0,
+        )
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "matched"
+        # Should return the newer assistant's text (both "pong" but from a-new).
+        assert result.diagnostic.get("assistant_node") == "a-new"
+
+    def test_no_fresh_text_match(self):
+        # Only the previous user node matches; it's not newer.
+        old_user = _user_node("u-old", "hello", 90.0, children=["a-old"])
+        mapping = _mapping(("u-old", old_user))
+        anchor = TurnAnchor(
+            sent_text="hello", mode="existing_conversation",
+            latest_user_node_id="u-old", latest_user_create_time=90.0,
+        )
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "not_ready"
+
+
+# ── Selector: degraded_existing ───────────────────────────────────────────
+
+class TestDegradedExisting:
+    def test_degraded_fresh_match_accepted(self):
+        # Backend create_time is ~5s ahead of local; pre_send_wall_time=95.0.
+        # New user at 100.0 → 100.0 >= 95.0 - 8.0 = 87.0 → fresh.
+        user = _user_node("u-1", "hello", 100.0, children=["a-1"])
+        asst = _assistant_node("a-1", "Reply", 101.0, end_turn=True, parent="u-1")
+        mapping = _mapping(("u-1", user), ("a-1", asst))
+        anchor = TurnAnchor(
+            sent_text="hello", mode="degraded_existing",
+            pre_send_wall_time=95.0,
+        )
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "matched"
+        assert result.text == "Reply"
+
+    def test_degraded_stale_single_match_rejected(self):
+        # Old user node from 80.0; pre_send_wall_time=95.0.
+        # 80.0 >= 95.0 - 8.0 = 87.0? No → stale.
+        user = _user_node("u-old", "hello", 80.0, children=["a-old"])
+        mapping = _mapping(("u-old", user))
+        anchor = TurnAnchor(
+            sent_text="hello", mode="degraded_existing",
+            pre_send_wall_time=95.0,
+        )
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "degraded_not_fresh"
+
+    def test_degraded_ambiguous_two_fresh(self):
+        u1 = _user_node("u-1", "hello", 100.0, children=["a-1"])
+        u2 = _user_node("u-2", "hello", 101.0, children=["a-2"])
+        mapping = _mapping(("u-1", u1), ("u-2", u2))
+        anchor = TurnAnchor(
+            sent_text="hello", mode="degraded_existing",
+            pre_send_wall_time=95.0,
+        )
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "ambiguous"
+
+
+# ── Selector: fresh_chat ──────────────────────────────────────────────────
+
+class TestFreshChat:
+    def test_fresh_chat_single_match(self):
+        user = _user_node("u-1", "hello", 100.0, children=["a-1"])
+        asst = _assistant_node("a-1", "Hi!", 101.0, end_turn=True, parent="u-1")
+        mapping = _mapping(("u-1", user), ("a-1", asst))
+        anchor = TurnAnchor(sent_text="hello", mode="fresh_chat")
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "matched"
+        assert result.text == "Hi!"
+
+    def test_fresh_chat_no_match_returns_not_ready(self):
+        mapping = _mapping(("u-1", _user_node("u-1", "different", 100.0)))
+        anchor = TurnAnchor(sent_text="hello", mode="fresh_chat")
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "not_ready"
+
+
+# ── Selector: terminal selection (newest end_turn, not first) ─────────────
+
+class TestTerminalSelection:
+    def test_picks_newest_end_turn_not_first_text_descendant(self):
+        # Graph: user → reasoning → draft_text → final_text(end_turn)
+        # The draft has text but no end_turn; the final has end_turn=true.
+        user = _user_node("u-1", "hello", 100.0, children=["r-1"])
+        reasoning = {
+            "id": "r-1", "parent": "u-1",
+            "message": {"id": "r-1", "author": {"role": "assistant"},
+                        "create_time": 100.5, "content": {"content_type": "reasoning_recap", "parts": []}},
+            "children": ["a-draft"],
+        }
+        draft = _assistant_node("a-draft", "Draft text", 101.0, parent="r-1", children=["a-final"])
+        final = _assistant_node("a-final", "Final text", 102.0, end_turn=True, parent="a-draft")
+        mapping = _mapping(("u-1", user), ("r-1", reasoning),
+                           ("a-draft", draft), ("a-final", final))
+        anchor = TurnAnchor(sent_text="hello", mode="captured_id",
+                            captured_user_message_id="u-1")
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "matched"
+        assert result.text == "Final text"  # NOT "Draft text"
+        assert result.diagnostic.get("assistant_node") == "a-final"
+
+
+# ── Selector: non-text completion ─────────────────────────────────────────
+
+class TestNonTextCompletion:
+    def test_non_text_assistant_no_text_match(self):
+        user = _user_node("u-1", "gen image", 100.0, children=["a-img"])
+        img = _assistant_node("a-img", "", 101.0, end_turn=True,
+                              content_type="multimodal_text", parent="u-1")
+        mapping = _mapping(("u-1", user), ("a-img", img))
+        anchor = TurnAnchor(sent_text="gen image", mode="captured_id",
+                            captured_user_message_id="u-1")
+        result = select_text_for_turn(mapping, anchor)
+        assert result.status == "non_text"
+
+    def test_end_turn_non_text_completes_only_with_dom_guard(self):
+        user = _user_node("u-1", "gen image", 100.0, children=["a-img"])
+        img = _assistant_node("a-img", "", 101.0, end_turn=True,
+                              content_type="multimodal_text", parent="u-1")
+        mapping = _mapping(("u-1", user), ("a-img", img))
+        anchor = TurnAnchor(sent_text="gen image", mode="captured_id",
+                            captured_user_message_id="u-1")
+
+        # Without DOM guard → not_ready.
+        r1 = select_end_turn_for_turn(mapping, anchor, had_non_text_content=False)
+        assert r1.status == "not_ready"
+
+        # With DOM guard → matched (complete).
+        r2 = select_end_turn_for_turn(mapping, anchor, had_non_text_content=True)
+        assert r2.status == "matched"
+
+
+# ── Tri-state collapse ────────────────────────────────────────────────────
+
+class TestTriStateCollapse:
+    @pytest.mark.parametrize("internal,expected", [
+        ("matched", "complete"),
+        ("not_ready", "not_ready"),
+        ("ambiguous", "not_ready"),
+        ("degraded_not_fresh", "not_ready"),
+        ("fetch_failed", "fetch_failed"),
+    ])
+    def test_collapse(self, internal, expected):
+        result = TurnEndResult(status=internal)
+        assert collapse_to_end_turn_status(result) == expected
+
+    def test_non_text_without_dom_guard_collapses_to_not_ready(self):
+        # non_text status (text selector) isn't an end_turn status, but verify
+        # that if it leaks through, it collapses to not_ready (safe default).
+        result = TurnEndResult(status="non_text")
+        assert collapse_to_end_turn_status(result) == "not_ready"
+
+
+# ── with_captured_id ─────────────────────────────────────────────────────
+
+class TestWithCapturedId:
+    def test_with_uuid_returns_new_anchor_with_id(self):
+        base = TurnAnchor(sent_text="hello", mode="existing_conversation")
+        updated = base.with_captured_id("uuid-123")
+        assert updated.captured_user_message_id == "uuid-123"
+        assert updated.sent_text == "hello"
+        # Original is unchanged (immutable).
+        assert base.captured_user_message_id is None
+
+    def test_with_none_returns_same_anchor(self):
+        base = TurnAnchor(sent_text="hello", mode="existing_conversation")
+        updated = base.with_captured_id(None)
+        assert updated is base
+
+
+# ── Normalization ─────────────────────────────────────────────────────────
+
+class TestNormalize:
+    def test_nfc_normalization(self):
+        # é can be composed (NFC) or decomposed (NFD).
+        composed = "caf\u00e9"  # é as one char
+        decomposed = "cafe\u0301"  # e + combining accent
+        assert normalize_text(composed) == normalize_text(decomposed)
+
+    def test_zero_width_stripped(self):
+        assert normalize_text("hello\u200bworld") == "helloworld"
+
+    def test_crlf_to_lf(self):
+        assert normalize_text("a\r\nb\rc") == "a\nb\nc"

--- a/tests/test_turn_anchor.py
+++ b/tests/test_turn_anchor.py
@@ -8,18 +8,14 @@ from __future__ import annotations
 import pytest
 
 from chatgpt_web2api.turn_anchor import (
-    EndTurnStatus,
-    SKEW_TOLERANCE_SECONDS,
     TurnAnchor,
     TurnEndResult,
-    TurnTextResult,
     collapse_to_end_turn_status,
     normalize_text,
     select_end_turn_for_turn,
     select_text_for_turn,
     user_text_matches_sent,
 )
-
 
 # ── Test fixtures ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
A2 replaces uncorrelated backend response selection with turn-anchored reconciliation.

**Before:** the bridge selected the newest assistant text by `create_time`, which allowed stale/off-by-one returns when the new assistant node existed but backend text had not propagated.

**After:** the bridge captures the client-generated user message UUID from the ChatGPT send POST, verifies that UUID in the backend mapping, and resolves the assistant response through the conversation graph. If UUID capture is unavailable, it falls back to bounded dual-anchor reconciliation rather than legacy newest-by-time selection.

## Validation

- 601 unit tests passing
- ruff clean
- live canary: 20/20 fresh responses
- prior repro: 12/12 stale on master+A1 (`eca62a5`)
- stress tests: tool-use shape, postData size, post-idle listener, skew stability
- release blockers passed: true fresh-chat, post-idle listener survival, real thinking/tool-use fixture projection

## Scope of the fix

Stale-return is eliminated in the reproduced stale-return scenario and structurally prevented for correlated sends. The fix is proven against the bug; broader bridge topology issues like shared-SSE tab isolation remain separate workstreams.

## Post-merge status: opt-in / canary accepted

This PR is **canary accepted** (validated against the reproduced bug + stress tests), not globally operationally accepted. Broader multi-session operational acceptance should follow after it survives normal multi-session use.

## Peer review

Design and implementation peer-reviewed with ChatGPT across 7 rounds (conv `6a482cfd`), including investigation Phases 0–13 (reproduction, identity spike, skew measurement, serialization audit, a11y oracle), 4 stress tests, and a final implementation-plan review that caught a sequencing bug before code was written.

## PR review fixes (3 commits)

1. Projection `__error` now decoded as `fetch_failed` (was silently `not_ready`).
2. `AuthExpiredError` re-raised in detector before broad except (was swallowed).
3. `degraded_existing` never produces `matched` — logged, not guessed. The prior fix closed the "fresh + stale" case but left the "single fresh only" case open (the exact rapid-repeat scenario). Now degraded mode only polls or raises `TurnReconciliationError`, never silently returns stale text.

## Investigation artifacts

The `scripts/a2_*.py` files are reproducible evidence tools used during the investigation (Phase 0 reproduction, Phase 1 identity spike, stress tests 1–4, fixture capture). They are not part of the production code path.