### PR TITLE
Reliability session: stall detector, navigation diagnostics, tab isolation, recovery hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ sentinel_flow.json
 .rest-proxy.log
 .sse-server.log
 
+
+# ChatGPT collaboration binding (local only)
+.chatgpt-collaboration.json

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -287,8 +287,49 @@ W2A_PARALLEL_TABS=1 chatgpt-web2api --port 8082 --cdp-port 9222
 
 > **Rollout warning:** do not mix old (port-lock-only) workers and new
 > (`parallel_tabs=true`) workers on the **same CDP port** during a rolling
-> upgrade — their lock files don't exclude each other. Finish the rollout on a
-> port before enabling parallel mode on it.
+> upgrade — their lock files don't exclude each other. Finish the rollout on
+> a port before enabling parallel mode on it.
+
+### Other CDP clients on the same Chrome (Super-Browser, Playwright, etc.)
+
+The bridge creates **owned tabs** (`tab_mode="owned"`, the default) — each
+driver gets its own dedicated tab via `Target.createTarget` and its own
+websocket. A `Page.navigate` issued by one CDP client goes over that client's
+websocket to that client's tab; it **cannot** navigate another client's tab.
+CDP targets are independent.
+
+However, running multiple CDP clients (e.g., 4 Super-Browser MCP servers + the
+bridge + the MCP server = 6+ clients) on one Chrome instance can still
+**degrade reliability** through resource contention:
+
+- **CPU/memory saturation** — each CDP client drives React hydration, DOM
+  polling, and JS evaluation. Under load, the Chrome renderer can slow
+  enough that ChatGPT's SPA fails to hydrate the composer within the
+  bridge's readiness window (see P2 staged readiness diagnostics).
+- **CDP HTTP endpoint queuing** — the `/json/list` and `/json/version`
+  endpoints are served by Chrome's DevTools HTTP server, which is
+  single-threaded. Many clients polling concurrently can introduce latency.
+- **Profile-level state** — all tabs share one Chrome profile (one account,
+  one cookie jar, one service worker). A service-worker update or auth
+  redirect on one tab can briefly affect the others.
+
+**What this means in practice:** the bridge's write path (navigate + send)
+is more sensitive to these effects than the read path (list/get
+conversations via `/backend-api/*`), because the write path requires
+DOM-level readiness (composer hydrated, send button enabled) while the read
+path is a pure HTTP fetch. If you observe "navigation timeout" or "no send
+button" errors that worsen as more clients connect, consider:
+
+1. Running the bridge on a **dedicated Chrome instance** (separate
+   `--user-data-dir` and `--cdp-port`).
+2. Reducing the number of concurrent CDP clients on the shared Chrome.
+3. Enabling `parallel_tabs: true` so the bridge and MCP server each get
+  their own tab (they do by default with `tab_mode="owned"`, but
+  `parallel_tabs` adds per-target locking and fail-closed semantics).
+
+The bridge's error messages now include staged diagnostics (P2) that name
+the failing readiness stage, making this degradation diagnosable rather
+than opaque.
 
 ---
 

--- a/scripts/ensure_hook.py
+++ b/scripts/ensure_hook.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""ZCode SessionStart hook wrapper for `chatgpt-web2api ensure`.
+
+Runs `chatgpt-web2api ensure` to reconcile the bridge (start REST + SSE if
+missing, verify health). ALWAYS exits 0 so a bridge failure never blocks the
+ZCode session — the bridge being down is an infrastructure problem, not a
+reason to prevent the user from working. Failures are logged to stderr where
+ZCode captures them in its hook execution log.
+
+Usage (from ZCode hooks.json):
+  command: python.exe
+  args: [path/to/ensure_hook.py, --rest-port, 8080, --mcp-sse-port, 8090]
+
+Exit codes:
+  0 — always (hook passes regardless of bridge state)
+  The bridge's actual state is logged to stderr for diagnosis.
+"""
+import subprocess
+import sys
+
+
+def main() -> None:
+    # Forward our args (minus the script name) to `chatgpt-web2api ensure`.
+    # The first arg is this script's path; the rest are ensure's flags.
+    ensure_args = sys.argv[1:]
+    cmd = [sys.executable, "-m", "chatgpt_web2api", "ensure"] + ensure_args
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=90,  # Chrome cold-start can take 10-15s; 90s is generous
+        )
+        # Log the output for ZCode's hook execution log.
+        if result.stdout:
+            print(result.stdout, file=sys.stderr)
+        if result.stderr:
+            print(result.stderr, file=sys.stderr)
+        if result.returncode != 0:
+            print(
+                f"ensure exited {result.returncode} — bridge may need manual "
+                f"attention (auth=2, failure=1). This does not block the session.",
+                file=sys.stderr,
+            )
+    except subprocess.TimeoutExpired:
+        print(
+            "ensure timed out after 90s — bridge may be slow to start. "
+            "This does not block the session.",
+            file=sys.stderr,
+        )
+    except Exception as e:
+        print(f"ensure hook error: {e}", file=sys.stderr)
+
+    # ALWAYS exit 0 — never block the ZCode session.
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/chatgpt_web2api/api_server.py
+++ b/src/chatgpt_web2api/api_server.py
@@ -530,10 +530,16 @@ class APIServer:
         transparently — the client only sees it (as a 429) if the limit
         persists across all retries.
         """
+        # P1: resolve model-aware detector budgets from config.
+        from .completion_detector import DetectorBudgets
+
+        budgets = DetectorBudgets.from_config(self._config.chatgpt, model)
 
         async def _send_and_collect() -> str:
             collected = ""
-            async for chunk in self._driver.send_and_stream(text, timeout=timeout):
+            async for chunk in self._driver.send_and_stream(
+                text, timeout=timeout, budgets=budgets, model=model,
+            ):
                 collected += chunk.delta
             return collected
 
@@ -577,6 +583,10 @@ class APIServer:
           cleared it), but if one occurs it falls back to the inline
           ``[Error: ...]`` SSE chunk — documented as a known limitation.
         """
+        # P1: resolve model-aware detector budgets from config.
+        from .completion_detector import DetectorBudgets
+
+        budgets = DetectorBudgets.from_config(self._config.chatgpt, model)
 
         async def _preflight() -> None:
             """Raise RateLimitError if the pop-up is present right now."""
@@ -638,7 +648,9 @@ class APIServer:
         )
 
         try:
-            async for chunk in self._driver.send_and_stream(text, timeout=timeout):
+            async for chunk in self._driver.send_and_stream(
+                text, timeout=timeout, budgets=budgets, model=model,
+            ):
                 if chunk.delta:
                     await self._send_sse(
                         resp,

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -1284,14 +1284,20 @@ class CDPDriver:
         )
 
         last_probe: NavigationReadinessProbe | None = None
+        last_js_error: str | None = None
         url_was_correct = False  # track if URL was ever correct (for displacement)
+        displacement_count = 0  # P2 review: debounce — require 2 consecutive wrong polls
 
         for _ in range(30):
             try:
                 result = await self._js_strict(probe_js)
                 data = json.loads(result)
+                last_js_error = None  # successful probe clears the error
             except Exception as e:
                 # P2: log transient JS failures instead of silently swallowing.
+                # Distinguish "probe execution failed" from "stage failed" per
+                # ChatGPT review finding C.
+                last_js_error = str(e)
                 logger.debug("Navigation probe JS failed (will retry): %s", e)
                 await asyncio.sleep(0.5)
                 continue
@@ -1305,18 +1311,23 @@ class CDPDriver:
             last_probe = probe
             url_correct = self._is_url_at_conversation(probe.url, conversation_id)
 
-            # P2: fast-fail on URL displacement. If the URL was correct on a
-            # prior poll but is now wrong, the page navigated away (SPA redirect,
-            # access denied, conversation deleted). Don't burn the full 15s.
+            # P2: fast-fail on URL displacement with debounce (review finding B).
+            # If the URL was correct on a prior poll but is now wrong, the page
+            # may have navigated away (SPA redirect, access denied, conversation
+            # deleted). Require 2 CONSECUTIVE wrong-URL polls to avoid
+            # false-positive on SPA route normalization / param stripping.
             if url_correct:
                 url_was_correct = True
+                displacement_count = 0
             elif url_was_correct:
-                if self._current_conv_id == conversation_id:
-                    self._current_conv_id = None
-                raise RuntimeError(
-                    f"Navigation to {conversation_id} displaced — URL moved "
-                    f"to {probe.url[:80]} after initially loading (nav_displaced)"
-                )
+                displacement_count += 1
+                if displacement_count >= 2:
+                    if self._current_conv_id == conversation_id:
+                        self._current_conv_id = None
+                    raise RuntimeError(
+                        f"Navigation to {conversation_id} displaced — URL moved "
+                        f"to {probe.url[:80]} after initially loading (nav_displaced)"
+                    )
 
             if probe.is_ready(url_correct):
                 logger.info("Conversation ready: %s", probe.url)
@@ -1336,7 +1347,7 @@ class CDPDriver:
                 )
             raise RuntimeError(
                 f"Navigation to {conversation_id} failed — all probes errored "
-                f"(no readiness data obtained)"
+                f"(no readiness data obtained, last_js_error={last_js_error})"
             )
 
         await asyncio.sleep(1)

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -561,6 +561,17 @@ class CDPDriver:
                         f"Owned-tab creation failed in parallel mode; refusing "
                         f"shared-tab fallback: {e}"
                     ) from e
+                if self.tab_mode == "owned":
+                    # Owned mode: never adopt an arbitrary tab. The adopt
+                    # fallback (_find_page_ws) picks ANY chatgpt.com tab,
+                    # which could belong to another process — causing two
+                    # drivers to race on the same tab. Fail closed instead;
+                    # the caller (ensure/connect) will retry or surface the
+                    # error. (ChatGPT design review, conv 6a507b4c.)
+                    raise RuntimeError(
+                        f"Owned-tab creation failed and shared-tab fallback "
+                        f"is disabled in owned mode: {e}"
+                    ) from e
                 logger.warning("Tab isolation failed (%s) — falling back to shared tab", e)
                 self._target_id = None
                 self._owns_target = False
@@ -747,6 +758,16 @@ class CDPDriver:
                                 f"Reconnect owned-tab creation failed in "
                                 f"parallel mode; refusing fallback: {create_err}"
                             ) from create_err
+                        if self.tab_mode == "owned":
+                            # Owned mode: tab creation failed and we must not
+                            # fall back to adopting an arbitrary tab. Raise
+                            # OwnedTabRequiredError so the reconnect retry
+                            # loop doesn't swallow it.
+                            raise OwnedTabRequiredError(
+                                f"Reconnect owned-tab creation failed and "
+                                f"shared-tab fallback is disabled in owned "
+                                f"mode: {create_err}"
+                            ) from create_err
                         raise
                 if not ws_url:
                     if self._parallel_tabs:
@@ -754,6 +775,17 @@ class CDPDriver:
                         raise OwnedTabRequiredError(
                             "Reconnect could not obtain an owned tab; refusing "
                             "shared-tab fallback in parallel mode"
+                        )
+                    if self.tab_mode == "owned":
+                        # Owned mode: never adopt an arbitrary tab on reconnect.
+                        # The adopt fallback could steal another process's tab,
+                        # causing two drivers to race on the same DOM. Fail
+                        # closed — raise OwnedTabRequiredError so the reconnect
+                        # retry loop doesn't swallow it (it's in the immediate-
+                        # raise list at line 802).
+                        raise OwnedTabRequiredError(
+                            "Reconnect could not obtain an owned tab and "
+                            "shared-tab fallback is disabled in owned mode"
                         )
                     ws_url = await self._find_page_ws()
                 self._ws = await websockets.connect(

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -84,7 +84,6 @@ from .chatgpt_dom import (  # noqa: E402,F401
     SEND_BUTTON_SELECTOR,
 )
 
-
 # ── P2: Navigation readiness probe ────────────────────────────────────────
 #
 # Co-designed with ChatGPT (vision-alignment cycle, conversation 6a4ebb2a).

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -1372,13 +1372,15 @@ class CDPDriver:
         if "chatgpt.com" not in (parsed.netloc or "").lower():
             return False
         parts = [p for p in parsed.path.split("/") if p]
-        # Find the "c" segment — it's the conversation-route marker in both
-        # non-project (["c", "{id}"]) and project-scoped
-        # (["g", "{gizmo}", "c", "{id}"]) URL shapes.
-        for i, part in enumerate(parts):
-            if part == "c" and i + 1 < len(parts):
-                return parts[i + 1] == conversation_id
-        return False
+        # Find the ("c", conversation_id) adjacent pair — the conversation
+        # route marker in both non-project (["c", "{id}"]) and project-scoped
+        # (["g", "{gizmo}", "c", "{id}"]) URL shapes. Using the adjacent pair
+        # (rather than just finding the first "c") avoids false-positives if
+        # a "c" segment appears earlier in a different context.
+        return any(
+            parts[i] == "c" and parts[i + 1] == conversation_id
+            for i in range(len(parts) - 1)
+        )
 
     async def _is_live_conversation_url(self, conversation_id: str) -> bool:
         """Read ``location.href`` and check it is at *conversation_id*.

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -1545,6 +1545,8 @@ class CDPDriver:
                     elapsed_ms,
                     self._current_conv_id or "(none)",
                 )
+                # Store for send-acknowledgment baseline (ChatGPT review A).
+                self._pre_send_user_count = user_count
                 return count
 
             # Retry or fail-closed.
@@ -1574,26 +1576,35 @@ class CDPDriver:
         # Unreachable (the loop either returns or raises).
         raise SendReadinessError("send_baseline: exhausted retries unexpectedly")
 
-    async def _verify_send_acknowledged(self) -> bool:
+    async def _verify_send_acknowledged(self) -> bool | None:
         """P0 send acknowledgment (ChatGPT review, conv 6a52f0f3).
 
         After click_send dispatches synthetic mouse events, verify the message
         was actually accepted by React — not just that the JS event loop ran.
 
-        Checks two signals (either is sufficient):
-          1. User-message DOM count increased (a new [data-message-author-role=
-             "user"] node appeared), AND
-          2. Composer cleared (the prompt-textarea is empty).
+        Composite condition: user-message count increased AND composer cleared.
+        Uses the pre-send user count baseline (self._pre_send_user_count) to
+        detect the delta, not just "userCount > 0" (which is always true on
+        existing conversations).
 
-        Polls briefly (3s at 0.5s intervals) to allow React to process the
-        submission. Returns True if acknowledged, False if no signal appears.
+        Tri-state return:
+          - True: acknowledged (count increased AND composer cleared)
+          - False: conclusively NOT acknowledged (valid probes showed no delta)
+          - None: probe inconclusive (CDP errors, no valid probe obtained,
+            missing composer, or no pre-send baseline) — non-blocking
 
-        Never raises — the caller decides what to do with a False result.
+        Polls briefly (3s at 0.5s intervals). Never raises.
         """
         import time as _time
         from .chatgpt_dom import COMPOSER_SELECTOR, COMPOSER_FALLBACK_SELECTOR
 
+        pre_send_count = getattr(self, "_pre_send_user_count", None)
+        if pre_send_count is None:
+            # No baseline — can't verify a delta. Non-blocking.
+            return None
+
         deadline = _time.monotonic() + 3.0
+        valid_probe_seen = False
         while _time.monotonic() < deadline:
             try:
                 result = await self._js_strict(
@@ -1602,23 +1613,31 @@ class CDPDriver:
                     "    '[data-message-author-role=\"user\"]').length;"
                     f"  var composer = document.querySelector('{COMPOSER_SELECTOR}')"
                     f"       || document.querySelector('{COMPOSER_FALLBACK_SELECTOR}');"
-                    "  var composerEmpty = composer ? !(composer.innerText || composer.value || '').trim() : true;"
-                    "  return JSON.stringify({userCount: userMsgs, composerEmpty: composerEmpty});"
+                    "  var composerPresent = !!composer;"
+                    "  var composerEmpty = composer ? !(composer.innerText || composer.value || '').trim() : false;"
+                    "  return JSON.stringify({userCount: userMsgs, composerPresent: composerPresent, composerEmpty: composerEmpty});"
                     "})()"
                 )
                 if not result or not result.strip().startswith("{"):
-                    # Not a JSON object (empty, number, string, mock returning
-                    # detector data). Return None to signal "probe inconclusive".
-                    return None
+                    return None  # inconclusive — not a JSON object
                 state = json.loads(result)
                 if not isinstance(state, dict) or "userCount" not in state:
-                    return None
-                if state.get("userCount", 0) > 0 and state.get("composerEmpty"):
+                    return None  # inconclusive — unexpected shape
+                valid_probe_seen = True
+                # Composite: count increased AND composer present AND cleared.
+                # Missing composer (composerPresent=False) is inconclusive, not
+                # acknowledged — could be navigation, selector drift, wrong page.
+                if not state.get("composerPresent"):
+                    continue  # wait for next poll — might be transient
+                current_count = state.get("userCount", 0)
+                if current_count > pre_send_count and state.get("composerEmpty"):
                     return True
             except Exception:
                 pass
             await asyncio.sleep(0.5)
-        return False
+        # If we got valid probes but none showed acknowledgment, return False.
+        # If no valid probe was ever obtained (all CDP errors), return None.
+        return False if valid_probe_seen else None
 
     async def _capture_pre_send_fallback_anchor(self, text: str):
         """A2: build the pre-send fallback TurnAnchor (NO captured UUID yet).

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -142,13 +142,51 @@ class GenerationStuckError(RuntimeError):
 
     - ``phase == "phase_1_appear"``: assistant message node never appeared.
     - ``phase == "phase_2_stream"``: streaming started but text stopped changing.
+
+    P1 (2026-07-08): phase-2 stalls now carry richer structured fields for
+    observability and caller-side reconciliation decisions:
+
+    - ``stall_kind``: ``"first_content_timeout"`` (no text appeared within the
+      first-content budget — common for reasoning models in the thinking phase)
+      or ``"stream_idle_timeout"`` (text appeared then stopped progressing) or
+      ``"hard_timeout"`` (absolute wall-clock cap exceeded).
+    - ``model_class``: ``"reasoning"`` or ``"default"`` (from classify_model).
+    - ``elapsed_seconds``: total time spent in phase-2 observation.
+    - ``generation_active_signal``: whether a DOM thinking/generating indicator
+      was present at the moment of the stall (advisory — a liveness hint).
+    - ``turn_id``: the turn anchor's captured UUID if available, for caller-side
+      reconciliation/retry of OBSERVATION (never retry the send).
+
+    The structured fields are optional (keyword-only) so existing phase-1
+    construction sites remain compatible. Callers should NEVER auto-retry the
+    SEND on a phase-2 stall (the generation may still be running and would
+    duplicate the message). Safe retry is observation-only: re-read the
+    conversation and reconcile against the same turn.
     """
 
-    def __init__(self, phase: str, stalled_for_s: float) -> None:
+    def __init__(
+        self,
+        phase: str,
+        stalled_for_s: float,
+        *,
+        stall_kind: str | None = None,
+        model_class: str | None = None,
+        elapsed_seconds: float | None = None,
+        generation_active_signal: bool | None = None,
+        turn_id: str | None = None,
+    ) -> None:
         self.phase = phase
         self.stalled_for_s = float(stalled_for_s)
+        # P1 structured fields (optional for back-compat with phase-1 sites).
+        self.stall_kind = stall_kind
+        self.model_class = model_class
+        self.elapsed_seconds = float(elapsed_seconds) if elapsed_seconds is not None else None
+        self.generation_active_signal = generation_active_signal
+        self.turn_id = turn_id
+        # Human-readable message includes the stall kind if available.
+        kind_str = f" ({stall_kind})" if stall_kind else ""
         super().__init__(
-            f"Generation stalled in {phase} for {stalled_for_s:.0f}s — no DOM progress"
+            f"Generation stalled in {phase}{kind_str} for {stalled_for_s:.0f}s — no DOM progress"
         )
 
 
@@ -1459,7 +1497,14 @@ class CDPDriver:
                 conversation_id_at_capture=conv_id,
             )
 
-    async def send_and_stream(self, text: str, timeout: float = 120) -> AsyncIterator[StreamChunk]:
+    async def send_and_stream(
+        self,
+        text: str,
+        timeout: float = 120,
+        *,
+        budgets=None,
+        model: str | None = None,
+    ) -> AsyncIterator[StreamChunk]:
         """Send a message and yield streaming response chunks.
 
         A2 turn-correlation sequence (peer-reviewed, conv ``6a482cfd``):
@@ -1514,10 +1559,15 @@ class CDPDriver:
             turn_anchor = fallback_anchor.with_captured_id(captured_uuid)
 
             # A2 Step 8: stream + completion with the anchored turn.
+            # P1: pass budgets + model for the model-aware two-state phase-2
+            # machine. When None (no config available), the detector uses the
+            # legacy single PHASE_STALL_SECONDS behavior.
             async for chunk in self._completion.stream_until_complete(
                 initial_count=initial_count,
                 timeout=timeout,
                 turn_anchor=turn_anchor,
+                budgets=budgets,
+                model=model,
             ):
                 yield chunk
 

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -565,10 +565,11 @@ class CDPDriver:
                     # Owned mode: never adopt an arbitrary tab. The adopt
                     # fallback (_find_page_ws) picks ANY chatgpt.com tab,
                     # which could belong to another process — causing two
-                    # drivers to race on the same tab. Fail closed instead;
-                    # the caller (ensure/connect) will retry or surface the
-                    # error. (ChatGPT design review, conv 6a507b4c.)
-                    raise RuntimeError(
+                    # drivers to race on the same tab. Fail closed with
+                    # OwnedTabRequiredError (consistent with reconnect path)
+                    # so callers have one stable failure contract.
+                    # (ChatGPT design review, conv 6a507b4c + 6a526e19.)
+                    raise OwnedTabRequiredError(
                         f"Owned-tab creation failed and shared-tab fallback "
                         f"is disabled in owned mode: {e}"
                     ) from e

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -85,6 +85,64 @@ from .chatgpt_dom import (  # noqa: E402,F401
 )
 
 
+# ── P2: Navigation readiness probe ────────────────────────────────────────
+#
+# Co-designed with ChatGPT (vision-alignment cycle, conversation 6a4ebb2a).
+# Replaces the opaque "ready composer" poll with a staged probe that captures
+# WHICH readiness stage passed and which failed. When the poll fails, the
+# error message names the stage (e.g. "url correct but composer not present")
+# instead of the old "did not reach a ready composer within the timeout".
+#
+# Stages (each must pass for the next to matter):
+#   url_correct → document_ready → app_shell_present → composer_present
+
+@dataclass
+class NavigationReadinessProbe:
+    """Results of a single navigation-readiness probe poll.
+
+    Captured each poll iteration so the caller can build a diagnostic error
+    message naming the stage that failed. The JS probe evaluates all stages
+    in one ``Runtime.evaluate`` call (no extra round-trips).
+    """
+    url: str
+    ready_state: str
+    app_shell_present: bool
+    composer_present: bool
+
+    @property
+    def document_ready(self) -> bool:
+        return self.ready_state == "complete"
+
+    def is_ready(self, url_correct: bool) -> bool:
+        """All stages passed — page loaded AND composer ready AND URL matches.
+
+        ``url_correct`` is passed by the caller (it knows the target
+        conversation_id; the probe doesn't).
+        """
+        return (
+            url_correct
+            and self.document_ready
+            and self.app_shell_present
+            and self.composer_present
+        )
+
+    def diagnostic_summary(self, url_correct: bool) -> str:
+        """Human-readable description of which stage failed.
+
+        Names the first failing stage so the error message points at the
+        real problem instead of an opaque 'timeout'.
+        """
+        if not url_correct:
+            return f"url displaced (got {self.url[:80]})"
+        if not self.document_ready:
+            return f"document still loading (readyState={self.ready_state})"
+        if not self.app_shell_present:
+            return "app shell not present (ChatGPT nav/sidebar missing)"
+        if not self.composer_present:
+            return "composer not present (selector did not match after page loaded)"
+        return "all stages passed"
+
+
 class RateLimitError(RuntimeError):
     """Raised when ChatGPT shows its 'Too many requests' rate-limit pop-up.
 
@@ -1198,43 +1256,87 @@ class CDPDriver:
         raises — never admits an unverified conversation as current. This
         is the invariant the auto-continue paths depend on: ``_current_conv_id``
         means "the live tab is here", not "we attempted to go here".
+
+        P2 (2026-07-09): the readiness poll is now staged — it probes
+        url → document.readyState → app shell → composer in one JS call
+        and captures which stage failed. The error message names the stage
+        instead of the old opaque "did not reach a ready composer." Also
+        fast-fails with ``nav_displaced`` if the URL moves away from the
+        target mid-poll (detects SPA redirects / access-denied states).
         """
         url = f"https://chatgpt.com/c/{conversation_id}"
         logger.info("Navigate to conversation: %s", url)
         await self._cdp("Page.navigate", {"url": url})
         await asyncio.sleep(3)
 
-        # Wait for composer (new ProseMirror div, or legacy textarea) AND a
-        # verified landing. A for/else means: if the loop completes without
-        # `break` (never became ready at the right URL), the else runs and we
-        # fail rather than falling through to admit an unverified conversation.
+        # P2: staged readiness probe. Evaluates all stages in one JS call
+        # (no extra round-trips). Uses _js_strict so transient JS failures
+        # are visible (logged) rather than silently burning poll iterations.
+        probe_js = (
+            "(function() {"
+            "  return JSON.stringify({"
+            "    url: location.href,"
+            "    ready_state: document.readyState,"
+            f"    app_shell: !!document.querySelector('nav') || !!document.querySelector('[class*=\"sidebar\"]'),"
+            f"    composer: !!document.querySelector('{COMPOSER_SELECTOR}') || !!document.querySelector('{COMPOSER_FALLBACK_SELECTOR}')"
+            "  });"
+            "})()"
+        )
+
+        last_probe: NavigationReadinessProbe | None = None
+        url_was_correct = False  # track if URL was ever correct (for displacement)
+
         for _ in range(30):
-            result = await self._js(
-                "(function() {"
-                "  return JSON.stringify({"
-                f"    ready: !!document.querySelector('{COMPOSER_SELECTOR}') || !!document.querySelector('{COMPOSER_FALLBACK_SELECTOR}'),"
-                "    url: location.href"
-                "  });"
-                "})()"
-            )
             try:
-                state = json.loads(result)
-            except (json.JSONDecodeError, TypeError):
-                state = {}
-            if state.get("ready") and self._is_url_at_conversation(
-                state.get("url", ""), conversation_id
-            ):
-                logger.info("Conversation ready: %s", state.get("url", ""))
+                result = await self._js_strict(probe_js)
+                data = json.loads(result)
+            except Exception as e:
+                # P2: log transient JS failures instead of silently swallowing.
+                logger.debug("Navigation probe JS failed (will retry): %s", e)
+                await asyncio.sleep(0.5)
+                continue
+
+            probe = NavigationReadinessProbe(
+                url=data.get("url", ""),
+                ready_state=data.get("ready_state", ""),
+                app_shell_present=bool(data.get("app_shell")),
+                composer_present=bool(data.get("composer")),
+            )
+            last_probe = probe
+            url_correct = self._is_url_at_conversation(probe.url, conversation_id)
+
+            # P2: fast-fail on URL displacement. If the URL was correct on a
+            # prior poll but is now wrong, the page navigated away (SPA redirect,
+            # access denied, conversation deleted). Don't burn the full 15s.
+            if url_correct:
+                url_was_correct = True
+            elif url_was_correct:
+                if self._current_conv_id == conversation_id:
+                    self._current_conv_id = None
+                raise RuntimeError(
+                    f"Navigation to {conversation_id} displaced — URL moved "
+                    f"to {probe.url[:80]} after initially loading (nav_displaced)"
+                )
+
+            if probe.is_ready(url_correct):
+                logger.info("Conversation ready: %s", probe.url)
                 break
             await asyncio.sleep(0.5)
         else:
             # Loop exhausted without a verified landing. Clear any stale
-            # state that might point here so a later auto-continue can't
-            # reuse a known-unverified id, then surface the failure.
+            # state and raise with P2 staged diagnostics.
             if self._current_conv_id == conversation_id:
                 self._current_conv_id = None
+            if last_probe is not None:
+                url_correct = self._is_url_at_conversation(last_probe.url, conversation_id)
+                stage = last_probe.diagnostic_summary(url_correct)
+                raise RuntimeError(
+                    f"Navigation to {conversation_id} failed after 15s — "
+                    f"stage: {stage}"
+                )
             raise RuntimeError(
-                f"Navigation to {conversation_id} did not reach a ready composer within the timeout"
+                f"Navigation to {conversation_id} failed — all probes errored "
+                f"(no readiness data obtained)"
             )
 
         await asyncio.sleep(1)

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -1716,23 +1716,37 @@ class CDPDriver:
                             last_dom_text = result.text
                         break
                     if result.status == "non_text":
-                        break  # placeholder path below
+                        # P2.5 RCA fix: non_text is NOT terminal here. The backend
+                        # propagates intermediary nodes (reasoning_recap, thoughts,
+                        # model_editable_context) BEFORE the final text node.
+                        # Treating non_text as terminal caused an intermittent
+                        # race: the reconciliation saw the intermediaries,
+                        # concluded "non-text", and yielded the placeholder even
+                        # though the text node would appear within seconds.
+                        # Now: keep polling (like not_ready) — the text node may
+                        # still be propagating. Only after the loop exhausts do we
+                        # yield the placeholder.
+                        pass
                     if result.status in ("ambiguous", "degraded_not_fresh", "fetch_failed"):
                         # Keep polling — these may resolve as the backend settles.
                         pass
                     # not_ready → keep polling.
                     await asyncio.sleep(0.5)
                 else:
-                    # Loop exhausted without match — raise typed error.
-                    raise TurnReconciliationError(
-                        conversation_id=conv_id,
-                        anchor_mode=turn_anchor.mode,
-                        last_status=last_status,
-                        diagnostic={
-                            "captured_id": turn_anchor.captured_user_message_id,
-                            "had_non_text_content": had_non_text_content,
-                        },
-                    )
+                    # Loop exhausted without a text match.
+                    # If the last status was non_text (genuinely non-text
+                    # response after full polling), fall through to the
+                    # placeholder below. Otherwise raise a typed error.
+                    if last_status != "non_text":
+                        raise TurnReconciliationError(
+                            conversation_id=conv_id,
+                            anchor_mode=turn_anchor.mode,
+                            last_status=last_status,
+                            diagnostic={
+                                "captured_id": turn_anchor.captured_user_message_id,
+                                "had_non_text_content": had_non_text_content,
+                            },
+                        )
                 # Non-text placeholder (unchanged from pre-A2).
                 if not last_dom_text and had_non_text_content:
                     placeholder = (

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -1623,12 +1623,14 @@ class CDPDriver:
                 state = json.loads(result)
                 if not isinstance(state, dict) or "userCount" not in state:
                     return None  # inconclusive — unexpected shape
-                valid_probe_seen = True
-                # Composite: count increased AND composer present AND cleared.
-                # Missing composer (composerPresent=False) is inconclusive, not
-                # acknowledged — could be navigation, selector drift, wrong page.
+                # Missing composer (composerPresent=False) is inconclusive —
+                # could be navigation, selector drift, wrong page. Don't count
+                # it as a valid probe; continue polling. (ChatGPT review C.)
                 if not state.get("composerPresent"):
                     continue  # wait for next poll — might be transient
+                # Only count as a valid probe when the composer is present
+                # and we can actually evaluate the acknowledgment condition.
+                valid_probe_seen = True
                 current_count = state.get("userCount", 0)
                 if current_count > pre_send_count and state.get("composerEmpty"):
                     return True

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -1357,9 +1357,10 @@ class CDPDriver:
     def _is_url_at_conversation(url: str, conversation_id: str) -> bool:
         """Exact path-segment match: is *url* at ``/c/{conversation_id}``?
 
-        Uses urllib to parse the path and compare the second segment, so a
-        high-entropy id can't accidentally match as a substring of another
-        path. Query strings and trailing slashes are tolerated; a different
+        Handles both non-project URLs (``/c/{id}``) and project-scoped URLs
+        (``/g/{gizmo_id}/c/{id}``). Finds the ``c`` path segment and checks
+        if the segment immediately after it matches the conversation ID.
+        Query strings and trailing slashes are tolerated; a different
         conversation id or a non-conversation URL returns False.
         """
         if not url or not conversation_id:
@@ -1371,8 +1372,13 @@ class CDPDriver:
         if "chatgpt.com" not in (parsed.netloc or "").lower():
             return False
         parts = [p for p in parsed.path.split("/") if p]
-        # Expected shape: ["c", "<conversation_id>"]
-        return len(parts) >= 2 and parts[0] == "c" and parts[1] == conversation_id
+        # Find the "c" segment — it's the conversation-route marker in both
+        # non-project (["c", "{id}"]) and project-scoped
+        # (["g", "{gizmo}", "c", "{id}"]) URL shapes.
+        for i, part in enumerate(parts):
+            if part == "c" and i + 1 < len(parts):
+                return parts[i + 1] == conversation_id
+        return False
 
     async def _is_live_conversation_url(self, conversation_id: str) -> bool:
         """Read ``location.href`` and check it is at *conversation_id*.

--- a/src/chatgpt_web2api/cdp_driver.py
+++ b/src/chatgpt_web2api/cdp_driver.py
@@ -1574,6 +1574,52 @@ class CDPDriver:
         # Unreachable (the loop either returns or raises).
         raise SendReadinessError("send_baseline: exhausted retries unexpectedly")
 
+    async def _verify_send_acknowledged(self) -> bool:
+        """P0 send acknowledgment (ChatGPT review, conv 6a52f0f3).
+
+        After click_send dispatches synthetic mouse events, verify the message
+        was actually accepted by React — not just that the JS event loop ran.
+
+        Checks two signals (either is sufficient):
+          1. User-message DOM count increased (a new [data-message-author-role=
+             "user"] node appeared), AND
+          2. Composer cleared (the prompt-textarea is empty).
+
+        Polls briefly (3s at 0.5s intervals) to allow React to process the
+        submission. Returns True if acknowledged, False if no signal appears.
+
+        Never raises — the caller decides what to do with a False result.
+        """
+        import time as _time
+        from .chatgpt_dom import COMPOSER_SELECTOR, COMPOSER_FALLBACK_SELECTOR
+
+        deadline = _time.monotonic() + 3.0
+        while _time.monotonic() < deadline:
+            try:
+                result = await self._js_strict(
+                    "(function() {"
+                    "  var userMsgs = document.querySelectorAll("
+                    "    '[data-message-author-role=\"user\"]').length;"
+                    f"  var composer = document.querySelector('{COMPOSER_SELECTOR}')"
+                    f"       || document.querySelector('{COMPOSER_FALLBACK_SELECTOR}');"
+                    "  var composerEmpty = composer ? !(composer.innerText || composer.value || '').trim() : true;"
+                    "  return JSON.stringify({userCount: userMsgs, composerEmpty: composerEmpty});"
+                    "})()"
+                )
+                if not result or not result.strip().startswith("{"):
+                    # Not a JSON object (empty, number, string, mock returning
+                    # detector data). Return None to signal "probe inconclusive".
+                    return None
+                state = json.loads(result)
+                if not isinstance(state, dict) or "userCount" not in state:
+                    return None
+                if state.get("userCount", 0) > 0 and state.get("composerEmpty"):
+                    return True
+            except Exception:
+                pass
+            await asyncio.sleep(0.5)
+        return False
+
     async def _capture_pre_send_fallback_anchor(self, text: str):
         """A2: build the pre-send fallback TurnAnchor (NO captured UUID yet).
 
@@ -1708,6 +1754,38 @@ class CDPDriver:
             if capture_scope is not None:
                 captured_uuid = await self._identity_listener.wait_for_captured_uuid(timeout=5.0)
 
+            # P0 send acknowledgment (ChatGPT review, conv 6a52f0f3):
+            # click_send dispatches synthetic mouse events — that proves the
+            # JS ran, not that React accepted the submission. Under load, the
+            # click can fire without producing a user message. Before entering
+            # completion detection, verify at least one acknowledgment signal:
+            #   1. UUID was captured, OR
+            #   2. user-message count increased AND composer cleared
+            # If none → raise before entering completion detection (which would
+            # waste time polling for a response that will never come).
+            #
+            # Graceful: if the acknowledgment probe fails (JS error, mock
+            # environment, unusual DOM), DON'T block the send. The check is a
+            # safety net for the overloaded-page case, not a hard gate that
+            # could prevent sends in edge cases we haven't seen.
+            if not captured_uuid:
+                try:
+                    acknowledged = await self._verify_send_acknowledged()
+                    if acknowledged is False:  # explicitly False, not None
+                        raise SendReadinessError(
+                            "Send not acknowledged — click dispatched but no user "
+                            "message appeared (no UUID captured, user count unchanged, "
+                            "composer not cleared). The page may be overloaded or the "
+                            "send was rejected. Do NOT retry automatically."
+                        )
+                except SendReadinessError:
+                    raise
+                except Exception as ack_err:
+                    # Probe failed (JS error, mock, unusual DOM). Don't block
+                    # the send — let completion detection proceed. Log so the
+                    # failure is traceable.
+                    logger.debug("Send acknowledgment probe failed (non-blocking): %s", ack_err)
+
             # A2 Step 7: build the final anchor (fallback + captured UUID).
             turn_anchor = fallback_anchor.with_captured_id(captured_uuid)
 
@@ -1747,9 +1825,11 @@ class CDPDriver:
                 # or dual-anchor fallback); stale text from a prior turn is
                 # never accepted.
                 last_status = "not_ready"
+                last_diagnostic = {}
                 for _ in range(60):
                     result = await self._fetch_text_for_turn(conv_id, turn_anchor)
                     last_status = result.status
+                    last_diagnostic = result.diagnostic or {}
                     if result.status == "matched" and result.text:
                         if len(result.text) > len(last_dom_text):
                             yield StreamChunk(delta=result.text[len(last_dom_text):])
@@ -1785,6 +1865,7 @@ class CDPDriver:
                             diagnostic={
                                 "captured_id": turn_anchor.captured_user_message_id,
                                 "had_non_text_content": had_non_text_content,
+                                "last_fetch_diagnostic": last_diagnostic,
                             },
                         )
                 # Non-text placeholder (unchanged from pre-A2).

--- a/src/chatgpt_web2api/chatgpt_dom.py
+++ b/src/chatgpt_web2api/chatgpt_dom.py
@@ -360,9 +360,23 @@ class ChatGPTDom:
                 "  if (!el) return '';"
                 "  if (el.tagName === 'TEXTAREA') return el.value;"
                 # Recursive DOM extractor: walks all descendant nodes,
-                # emitting \n for <br> elements and block boundaries.
-                # This correctly handles <p>line1<br>line2</p> which
-                # textContent would render as "line1line2".
+                # emitting \n for <br> elements. Correctly handles
+                # <p>line1<br>line2</p> which textContent renders as
+                # "line1line2". (ChatGPT review, conv 6a52f0f3.)
+                #
+                # Scope: handles root-level <p>/<div> blocks with inline
+                # descendants (what Input.insertText produces). Does NOT
+                # reconstruct nested block boundaries (blockquote, lists) —
+                # if ChatGPT changes its composer to nest blocks, this needs
+                # a block-aware recursion update.
+                "  function isPlaceholderBreakBlock(node) {"
+                "    return ("
+                "      node.nodeType === 1 &&"
+                "      node.childNodes.length === 1 &&"
+                "      node.firstChild.nodeType === 1 &&"
+                "      node.firstChild.tagName === 'BR'"
+                "    );"
+                "  }"
                 "  function extractText(node) {"
                 "    if (node.nodeType === 3) return (node.nodeValue || '').replace(/\\u00a0/g, ' ');"
                 "    if (node.nodeType !== 1) return '';"
@@ -374,8 +388,10 @@ class ChatGPTDom:
                 "    return text;"
                 "  }"
                 # Walk immediate children of the composer element.
-                # Each block-level child (<p>, <div>) contributes its text.
-                # Join blocks with \n to reconstruct paragraph boundaries.
+                # Each block-level child contributes its extracted text.
+                # A placeholder <br>-only block (<p><br></p>) is treated as
+                # an empty string so the join produces the correct number of
+                # newlines (one from the join, not one from the <br> too).
                 "  var parts = [];"
                 "  for (var i = 0; i < el.childNodes.length; i++) {"
                 "    var child = el.childNodes[i];"
@@ -383,7 +399,7 @@ class ChatGPTDom:
                 "      var t = (child.nodeValue || '').replace(/\\u00a0/g, ' ');"
                 "      if (t) parts.push(t);"
                 "    } else if (child.nodeType === 1) {"
-                "      parts.push(extractText(child));"
+                "      parts.push(isPlaceholderBreakBlock(child) ? '' : extractText(child));"
                 "    }"
                 "  }"
                 "  return parts.join('\\n');"

--- a/src/chatgpt_web2api/chatgpt_dom.py
+++ b/src/chatgpt_web2api/chatgpt_dom.py
@@ -52,6 +52,7 @@ import asyncio
 import json
 import logging
 import time
+import unicodedata
 
 from .breakers import BreakerKind
 
@@ -328,24 +329,25 @@ class ChatGPTDom:
     async def _verify_composer_text(self, selector: str, expected: str) -> bool:
         """Canonical-equality check: does the composer hold *expected*?
 
-        Compares editor-visible text with canonical normalization (CRLF→LF,
-        NBSP→space, tolerate a trailing block newline ProseMirror adds) — but
-        does NOT broadly collapse internal whitespace, since that would hide
-        real corruption of code/YAML/Markdown indentation.
+        Compares editor-visible text with canonical normalization (NFC, CRLF→LF,
+        NBSP→space) and tolerates at most one editor-added trailing newline.
 
         For a contenteditable ProseMirror div, neither ``innerText`` nor
-        ``textContent`` reconstructs what the user typed across line breaks:
-        ``\\n`` in the input becomes a new ``<p>`` block, and ProseMirror
-        renders blank-line paragraphs as ``<p><br></p>``. ``innerText`` then
-        emits *several* newlines per block boundary (measured: a 2-newline
-        input read back as 5), while ``textContent`` joins blocks with
-        *nothing* (0 newlines). Both fail canonical equality for any
-        multi-line prompt. The fix is a block-aware extractor: join each
-        top-level block child's text with a single ``\\n``, and treat an
-        empty block (the ``<br>``-only paragraph from a blank line) as one
-        newline. This reconstructs the typed text faithfully for both
-        single-line and multi-line input. Legacy ``<textarea>`` still reads
-        ``.value``, which is already exact.
+        ``textContent`` reconstructs what the user typed across line breaks.
+        The fix is a recursive DOM extractor that:
+        - Walks all descendant nodes (not just immediate children)
+        - Emits ``\\n`` for ``<br>`` elements
+        - Joins top-level block children with ``\\n``
+        - Does NOT strip the user's trailing newline (the Python-side
+          tolerance handles editor-added trailing newlines)
+
+        Legacy ``<textarea>`` still reads ``.value``, which is already exact.
+
+        P0 (2026-07-12): ChatGPT code review (conv 6a52f0f3) found 4 defects:
+        1. <br> inside <p> was invisible to textContent (lost newlines)
+        2. Missing NFC normalization (combining accents failed)
+        3. Unconditional trailing-newline strip corrupted user's trailing \\n
+        4. Fixed 500ms delay instead of bounded polling
         """
         # Imported lazily to avoid a module-load circular dependency.
         from .cdp_driver import CDPJSError
@@ -357,41 +359,49 @@ class ChatGPTDom:
                 f"  var el = document.querySelector('{selector}');"
                 "  if (!el) return '';"
                 "  if (el.tagName === 'TEXTAREA') return el.value;"
-                # Block-aware read for contenteditable. Walk the immediate
-                # child nodes; each element block contributes its text plus
-                # one trailing newline, each text node contributes itself.
-                # An empty block (the <br>-only paragraph from a blank line)
-                # collapses to a single blank line, matching a typed "\n\n".
-                # This yields exactly the number of newlines the user typed.
-                "  var parts = [];"
-                "  function blockText(node) {"
-                "    return (node.textContent || '').replace(/\\u00a0/g, ' ');"
+                # Recursive DOM extractor: walks all descendant nodes,
+                # emitting \n for <br> elements and block boundaries.
+                # This correctly handles <p>line1<br>line2</p> which
+                # textContent would render as "line1line2".
+                "  function extractText(node) {"
+                "    if (node.nodeType === 3) return (node.nodeValue || '').replace(/\\u00a0/g, ' ');"
+                "    if (node.nodeType !== 1) return '';"
+                "    if (node.tagName === 'BR') return '\\n';"
+                "    var text = '';"
+                "    for (var i = 0; i < node.childNodes.length; i++) {"
+                "      text += extractText(node.childNodes[i]);"
+                "    }"
+                "    return text;"
                 "  }"
+                # Walk immediate children of the composer element.
+                # Each block-level child (<p>, <div>) contributes its text.
+                # Join blocks with \n to reconstruct paragraph boundaries.
+                "  var parts = [];"
                 "  for (var i = 0; i < el.childNodes.length; i++) {"
                 "    var child = el.childNodes[i];"
-                "    if (child.nodeType === 3) { parts.push(child.nodeValue || ''); }"
-                "    else if (child.nodeType === 1) {"
-                "      parts.push(blockText(child));"
+                "    if (child.nodeType === 3) {"
+                "      var t = (child.nodeValue || '').replace(/\\u00a0/g, ' ');"
+                "      if (t) parts.push(t);"
+                "    } else if (child.nodeType === 1) {"
+                "      parts.push(extractText(child));"
                 "    }"
                 "  }"
-                "  var joined = parts.join('\\n');"
-                # ProseMirror may append a trailing empty <p>/<br> block that
-                # adds a stray trailing newline; strip at most one to mirror
-                # the single-trailing-newline tolerance below.
-                "  return joined.replace(/\\n$/, '');"
+                "  return parts.join('\\n');"
                 "})()"
             )
         except CDPJSError:
             return False
-        if not actual:
+        if not actual and expected:
             return False
-        canon_actual = actual.replace("\r\n", "\n").replace("\r", "\n").replace("\u00a0", " ")
-        canon_expected = expected.replace("\r\n", "\n").replace("\r", "\n").replace("\u00a0", " ")
+        # NFC normalization: handles composed/decomposed Unicode sequences
+        # (e.g., é as 'e'+U+0301 vs U+00E9). The turn-anchor matcher already
+        # uses NFC; this brings the verifier to parity.
+        canon_actual = unicodedata.normalize("NFC", actual.replace("\r\n", "\n").replace("\r", "\n").replace("\u00a0", " "))
+        canon_expected = unicodedata.normalize("NFC", expected.replace("\r\n", "\n").replace("\r", "\n").replace("\u00a0", " "))
         # ProseMirror wraps input in a <p> and may append a trailing block
         # newline. Tolerate AT MOST ONE editor-added trailing newline — but
         # never strip a user-intended trailing newline. So accept an exact
-        # match, OR actual == expected + one editor newline. (Stripping
-        # unconditionally would corrupt prompts that legitimately end in \n.)
+        # match, OR actual == expected + one editor newline.
         return canon_actual == canon_expected or canon_actual == canon_expected + "\n"
 
     async def click_send(self) -> None:

--- a/src/chatgpt_web2api/chatgpt_dom.py
+++ b/src/chatgpt_web2api/chatgpt_dom.py
@@ -83,6 +83,10 @@ COMPOSER_FALLBACK_SELECTOR = "textarea#prompt-textarea"
 # the legacy testid for older deployments.
 SEND_BUTTON_SELECTOR = 'button[aria-label*="Send" i]:not([data-testid="stop-button"])'
 SEND_BUTTON_FALLBACK_SELECTOR = 'button[data-testid="send-button"]'
+# P2.5: broader fallback — a submit-type button inside the composer form.
+# If ChatGPT changes the aria-label (selector drift), a type=submit button
+# inside the form is still the send affordance. This is the LAST resort.
+SEND_BUTTON_BROAD_SELECTOR = 'form button[type="submit"]'
 
 # Send-button readiness poll. After a prior send completes (or under parallel
 # mode, where the MutationLock releases the instant a send finishes), ChatGPT's
@@ -406,7 +410,8 @@ class ChatGPTDom:
             has_btn = await d._js(
                 "(function() {"
                 f"  var btn = document.querySelector('{SEND_BUTTON_SELECTOR}')"
-                f"       || document.querySelector('{SEND_BUTTON_FALLBACK_SELECTOR}');"
+                f"       || document.querySelector('{SEND_BUTTON_FALLBACK_SELECTOR}')"
+                f"       || document.querySelector('{SEND_BUTTON_BROAD_SELECTOR}');"
                 "  return btn && !btn.disabled ? 'yes' : 'no';"
                 "})()"
             )
@@ -417,7 +422,8 @@ class ChatGPTDom:
         result = await d._js(
             "(function() {"
             f"  var btn = document.querySelector('{SEND_BUTTON_SELECTOR}')"
-            f"       || document.querySelector('{SEND_BUTTON_FALLBACK_SELECTOR}');"
+            f"       || document.querySelector('{SEND_BUTTON_FALLBACK_SELECTOR}')"
+            f"       || document.querySelector('{SEND_BUTTON_BROAD_SELECTOR}');"
             "  if (!btn) return 'no send button';"
             "  if (btn.disabled) return 'button disabled';"
             "  var evts = ['pointerdown','mousedown','pointerup','mouseup','click'];"
@@ -507,23 +513,44 @@ class ChatGPTDom:
     # ── Diagnostics ───────────────────────────────────────────
 
     async def _capture_selector_diagnostic(self, selector_name: str) -> None:
-        """#5: Capture DOM state when a selector fails to match.
+        """#5 / P2.5: Capture DOM state when a selector fails to match.
 
-        Logs a diagnostic snapshot (URL, title, body text preview, button count)
-        so selector drift is diagnosable without W2A_DIAGNOSE=1. Called at the
-        point of selector failure (e.g. 'no send button', 'No textarea').
-        Best-effort — never raises.
+        Logs a rich diagnostic snapshot so selector drift and send-readiness
+        failures are diagnosable without W2A_DIAGNOSE=1. Called at the point of
+        selector failure (e.g. 'no send button', 'No textarea'). Best-effort —
+        never raises.
+
+        P2.5 (2026-07-09): expanded from url/title/body/button_count to include
+        send-readiness-specific fields (ChatGPT's proposed readiness snapshot):
+        - composer_found / composer_text_length / composer_enabled: distinguishes
+          "text didn't land" (injection failed) from "selector drifted"
+        - send_candidates_count / enabled_send_candidates_count: how many buttons
+          match a broad send heuristic, and how many are enabled
+        - stop_button_present / generating_indicator_present: is a generation
+          in progress (the send button is replaced by stop during generation)
         """
         d = self._driver
         try:
             snapshot = await d._js_strict(
                 "(function(){"
+                "  var composer = document.querySelector('" + COMPOSER_SELECTOR + "')"
+                "       || document.querySelector('" + COMPOSER_FALLBACK_SELECTOR + "');"
+                "  var sendCandidates = document.querySelectorAll('button[type=\"submit\"], button[aria-label*=\"Send\" i], button[data-testid=\"send-button\"]');"
+                "  var enabledSend = Array.prototype.filter.call(sendCandidates, function(b){ return !b.disabled; });"
+                "  var stopBtn = document.querySelector('[data-testid=\"stop-button\"], button[aria-label*=\"Stop\" i]');"
                 "  return JSON.stringify({"
                 "    url: location.href,"
                 "    title: document.title,"
                 "    body_preview: (document.body && document.body.innerText || '').slice(0, 300),"
                 "    button_count: document.querySelectorAll('button').length,"
-                "    textarea_count: document.querySelectorAll('textarea').length"
+                "    textarea_count: document.querySelectorAll('textarea').length,"
+                "    composer_found: !!composer,"
+                "    composer_text_length: composer ? (composer.innerText || composer.value || '').length : 0,"
+                "    composer_enabled: composer ? !composer.disabled : false,"
+                "    send_candidates_count: sendCandidates.length,"
+                "    enabled_send_candidates_count: enabledSend.length,"
+                "    stop_button_present: !!stopBtn,"
+                "    generating_indicator_present: !!document.querySelector('[class*=\"result-thinking\"], [class*=\"generating\"]')"
                 "  });"
                 "})()",
                 timeout=5,

--- a/src/chatgpt_web2api/chatgpt_dom.py
+++ b/src/chatgpt_web2api/chatgpt_dom.py
@@ -83,10 +83,15 @@ COMPOSER_FALLBACK_SELECTOR = "textarea#prompt-textarea"
 # the legacy testid for older deployments.
 SEND_BUTTON_SELECTOR = 'button[aria-label*="Send" i]:not([data-testid="stop-button"])'
 SEND_BUTTON_FALLBACK_SELECTOR = 'button[data-testid="send-button"]'
-# P2.5: broader fallback — a submit-type button inside the composer form.
-# If ChatGPT changes the aria-label (selector drift), a type=submit button
-# inside the form is still the send affordance. This is the LAST resort.
-SEND_BUTTON_BROAD_SELECTOR = 'form button[type="submit"]'
+# P2.5: broader fallback — a submit-type button inside the COMPOSER FORM
+# (scoped to the form containing #prompt-textarea, not page-global, to avoid
+# hitting login/search/feedback forms if the page is displaced). If ChatGPT
+# changes the aria-label (selector drift), a submit-type button inside the
+# composer form is still the send affordance. This is the LAST resort.
+SEND_BUTTON_BROAD_SELECTOR = (
+    'form:has(#prompt-textarea) button[type="submit"],'
+    'form:has(.ProseMirror) button[type="submit"]'
+)
 
 # Send-button readiness poll. After a prior send completes (or under parallel
 # mode, where the MutationLock releases the instant a send finishes), ChatGPT's

--- a/src/chatgpt_web2api/completion_detector.py
+++ b/src/chatgpt_web2api/completion_detector.py
@@ -116,9 +116,12 @@ PHASE_STALL_SECONDS = 90
 # silent "thinking" phase before the first answer token renders, which the
 # old uniform 90s stall window falsely aborted. Matched case-insensitively
 # against the slug via substring. "thinking" covers gpt-5-*-thinking and
-# gpt-5-*-t-mini (Thinking Mini); "o3" and "research" are the other
-# reasoning-class families.
-_REASONING_MARKERS = ("thinking", "-t-mini", "o3", "research")
+# gpt-5-*-t-mini (Thinking Mini); "o1"/"o3"/"o4" are the o-series reasoning
+# families; "research" is Deep Research; "reasoning" is a catch-all in case
+# OpenAI introduces slugs that name it directly. Inclusive on purpose — a
+# false negative (reasoning model gets the shorter default budget) is worse
+# than a false positive (non-reasoning model gets the longer budget).
+_REASONING_MARKERS = ("thinking", "-t-mini", "o1", "o3", "o4", "research", "reasoning")
 
 
 def classify_model(model: str | None) -> str:
@@ -256,8 +259,11 @@ class CompletionDetector:
         turn-anchoring work to correlate against the correct turn.
 
         On any fetch failure or exception, returns False (let the stall raise)
-        rather than degrading to a silent success.
+        rather than degrading to a silent success. EXCEPT auth expiry: that
+        must surface as auth expiry, not degrade to a generic stall (PR #39
+        review finding #2 invariant — auth failure never degrades).
         """
+        from .cdp_driver import AuthExpiredError
         from .turn_anchor import collapse_to_end_turn_status
 
         if not conv_id:
@@ -269,6 +275,8 @@ class CompletionDetector:
             )
             status = collapse_to_end_turn_status(end_result)
             return status == "complete"
+        except AuthExpiredError:
+            raise  # never swallow auth expiry — it must surface as auth expiry
         except Exception as e:
             logger.debug("Final reconciliation fetch failed: %s", e)
             return False
@@ -589,18 +597,22 @@ class CompletionDetector:
                 if not conv_id_for_check:
                     last_change_time = time.monotonic()
             # P1: track advisory liveness signal for structured error reporting.
-            # True when the DOM shows active generation (thinking indicator or
-            # a generating/stop-button state). This is advisory only — it
-            # informs the structured error and logging, but does NOT pause the
-            # stall clock (a stuck indicator must not create an infinite hang).
+            # True when the DOM shows active generation (thinking indicator).
+            # This is advisory only — it informs the structured error and
+            # logging, but does NOT pause the stall clock (a stuck indicator
+            # must not create an infinite hang).
             generation_active_signal = bool(is_thinking)
             if current != last_dom_text:
                 last_change_time = time.monotonic()
                 # P1: first text content transitions us from awaiting_first_content
                 # to streaming_after_first_content. The stall budget changes with
-                # the state (see the stall check below).
+                # the state (see the stall check below). When the state flips,
+                # reset the stream-idle clock so a long reasoning wait followed
+                # by first text doesn't immediately fail under the shorter
+                # stream-idle budget (review finding A).
                 if current and not first_content_seen:
                     first_content_seen = True
+                    last_change_time = time.monotonic()  # reset stream-idle clock
                 if len(current) > len(last_dom_text):
                     delta = current[len(last_dom_text) :]
                     yield StreamChunk(delta=delta)
@@ -613,9 +625,15 @@ class CompletionDetector:
                 if html_len > 50:
                     had_non_text_content = True
                     self.had_non_text_content = True
-                # P1: non-text content also counts as first-content (images/tool-use).
-                if not first_content_seen:
+                # P1: meaningful non-text content (html_len > 50, the existing
+                # threshold that excludes the bare message wrapper) also counts
+                # as first-content. Do NOT transition on the first poll's
+                # wrapper creation alone — that would prematurely move a
+                # reasoning model from the 300s first-content budget to the
+                # 120s stream-idle budget while still thinking (review finding A).
+                if html_len > 50 and not first_content_seen:
                     first_content_seen = True
+                    last_change_time = time.monotonic()  # reset stream-idle clock
             last_html_len = html_len
             last_child_count = child_count
 

--- a/src/chatgpt_web2api/completion_detector.py
+++ b/src/chatgpt_web2api/completion_detector.py
@@ -64,12 +64,14 @@ import asyncio
 import json
 import logging
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
     from .cdp_driver import StreamChunk
+    from .config import ChatGPTConfig
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +86,117 @@ logger = logging.getLogger(__name__)
 # while the model reasons before the first answer token renders; the
 # is_thinking reset covers the labeled phase, but there is an unlabeled gap
 # between thinking-end and answer-start that also needs this headroom.
+#
+# P1 (2026-07-08): this constant is now the FALLBACK for phase_1_appear
+# (unchanged behavior) and the default-class phase-2 budgets when no
+# DetectorBudgets is resolved. Phase-2 detection has been refactored into a
+# model-aware two-state machine (awaiting_first_content →
+# streaming_after_first_content) with budgets from DetectorBudgets. See
+# classify_model / DetectorBudgets below. Kept for back-compat (re-exported
+# from cdp_driver; referenced by phase_1_appear which is deliberately
+# unchanged).
 PHASE_STALL_SECONDS = 90
+
+
+# ── P1: model-aware detector budgets ─────────────────────────────────────
+#
+# Co-designed with ChatGPT (conversation 6a4ebc1e, 2026-07-08). The single
+# PHASE_STALL_SECONDS=90 conflated two different states: "model hasn't
+# produced visible text yet" (reasoning models think silently for 30-60s+)
+# and "model was streaming text and then stopped" (a genuine hang). These
+# should NOT share a stall budget. Reasoning models stress case 1; real
+# network/UI hangs stress case 2.
+#
+# The fix: split phase-2 into first-content-wait vs stream-idle, with
+# model-aware budgets on first-content specifically. DOM "thinking" signals
+# are advisory liveness hints (generation_active_signal) within the hard
+# cap — never authoritative clock-pauses.
+
+# Slugs that indicate a reasoning-capable model. These models have a long
+# silent "thinking" phase before the first answer token renders, which the
+# old uniform 90s stall window falsely aborted. Matched case-insensitively
+# against the slug via substring. "thinking" covers gpt-5-*-thinking and
+# gpt-5-*-t-mini (Thinking Mini); "o3" and "research" are the other
+# reasoning-class families.
+_REASONING_MARKERS = ("thinking", "-t-mini", "o3", "research")
+
+
+def classify_model(model: str | None) -> str:
+    """Classify a ChatGPT web model slug as ``"reasoning"`` or ``"default"``.
+
+    Reasoning models (gpt-5-*-thinking, o3, research, Thinking Mini variants)
+    have a long silent thinking phase before streaming text and need a longer
+    first-content stall budget. An unknown or empty model is conservatively
+    classified ``"default"`` — the shorter budget — so a possibly-dead
+    generation fails fast rather than being held too long.
+
+    The classification is intentionally coarse (two buckets), not per-model.
+    Per-model tuning can wait until field data proves the buckets insufficient.
+    """
+    if not model:
+        return "default"
+    lowered = model.lower()
+    if any(marker in lowered for marker in _REASONING_MARKERS):
+        return "reasoning"
+    return "default"
+
+
+@dataclass(frozen=True)
+class DetectorBudgets:
+    """Per-call detector timeout budgets, resolved from config + model class.
+
+    - ``first_content_timeout_seconds``: how long to wait for the FIRST text
+      content after the assistant node appears. Longer for reasoning models
+      (they think silently before streaming).
+    - ``stream_idle_timeout_seconds``: how long to wait for PROGRESS once text
+      has already appeared and then stopped. Shorter than first-content — once
+      streaming started, a long idle is suspicious.
+    - ``hard_timeout_seconds``: absolute wall-clock cap on phase-2 observation,
+      regardless of DOM liveness signals. Prevents infinite waits even if the
+      UI claims it is still thinking.
+    """
+
+    first_content_timeout_seconds: float
+    stream_idle_timeout_seconds: float
+    hard_timeout_seconds: float
+
+    @classmethod
+    def default(cls) -> DetectorBudgets:
+        """Default (non-reasoning) budgets — reproduces the legacy 90s behavior."""
+        return cls(
+            first_content_timeout_seconds=90,
+            stream_idle_timeout_seconds=90,
+            hard_timeout_seconds=900,
+        )
+
+    @classmethod
+    def reasoning(cls) -> DetectorBudgets:
+        """Reasoning-model budgets — longer first-content, shorter stream-idle."""
+        return cls(
+            first_content_timeout_seconds=300,
+            stream_idle_timeout_seconds=120,
+            hard_timeout_seconds=900,
+        )
+
+    @classmethod
+    def from_config(cls, config: ChatGPTConfig, model: str | None) -> DetectorBudgets:
+        """Resolve budgets from ChatGPTConfig + the classified model.
+
+        Reads the 5 detector config keys. If the model classifies as reasoning,
+        uses the reasoning first-content/stream-idle budgets; otherwise default.
+        The hard cap is shared across both classes.
+        """
+        if classify_model(model) == "reasoning":
+            return cls(
+                first_content_timeout_seconds=config.detector_reasoning_first_content_timeout_seconds,
+                stream_idle_timeout_seconds=config.detector_reasoning_stream_idle_timeout_seconds,
+                hard_timeout_seconds=config.detector_hard_timeout_seconds,
+            )
+        return cls(
+            first_content_timeout_seconds=config.detector_default_first_content_timeout_seconds,
+            stream_idle_timeout_seconds=config.detector_default_stream_idle_timeout_seconds,
+            hard_timeout_seconds=config.detector_hard_timeout_seconds,
+        )
 
 # Phrases ChatGPT uses in its rate-limit pop-up. Matched case-insensitively
 # against scanned DOM text. Kept narrow to avoid false positives on normal
@@ -127,12 +239,48 @@ class CompletionDetector:
         self.last_dom_text: str = ""
         self.had_non_text_content: bool = False
 
+    async def _reconcile_before_stall(
+        self, d, conv_id: str, turn_anchor, had_non_text_content: bool,
+    ) -> bool:
+        """P1: final reconciliation before raising a phase-2 stall.
+
+        Field evidence shows the generation often completes after the detector
+        would have given up (the stall kills the *observation*, not the
+        generation). Before raising, check the backend one more time: if the
+        turn completed, the detector should return normally rather than
+        surfacing a false failure.
+
+        Returns True if the turn completed (caller returns normally), False if
+        not (caller raises). Safe by design — this is an OBSERVATION read, not
+        a re-send; it cannot duplicate the user message. Leverages the A2
+        turn-anchoring work to correlate against the correct turn.
+
+        On any fetch failure or exception, returns False (let the stall raise)
+        rather than degrading to a silent success.
+        """
+        from .turn_anchor import collapse_to_end_turn_status
+
+        if not conv_id:
+            return False
+        try:
+            end_result = await d._fetch_end_turn_for_turn(
+                conv_id, turn_anchor,
+                had_non_text_content=had_non_text_content,
+            )
+            status = collapse_to_end_turn_status(end_result)
+            return status == "complete"
+        except Exception as e:
+            logger.debug("Final reconciliation fetch failed: %s", e)
+            return False
+
     async def stream_until_complete(
         self,
         *,
         initial_count: int,
         timeout: float,
         turn_anchor,
+        budgets: DetectorBudgets | None = None,
+        model: str | None = None,
     ) -> AsyncIterator[StreamChunk]:
         """Run Phase-1 (appear) + Phase-2 (stream) and yield delta chunks.
 
@@ -150,6 +298,19 @@ class CompletionDetector:
         set ONLY on ``fetch_failed`` (true transport failure), NOT on
         ``not_ready``/``ambiguous``/``degraded_not_fresh`` (which collapse to
         ``not_ready`` and must NOT unlock the DOM fallback).
+
+        P1 (2026-07-08): ``budgets`` and ``model`` enable the model-aware
+        two-state phase-2 machine. When ``budgets`` is None, the legacy
+        behavior (single PHASE_STALL_SECONDS=90 for both phases) is preserved
+        for back-compat. When provided, phase-2 splits into
+        awaiting_first_content (first_content_timeout_seconds budget) and
+        streaming_after_first_content (stream_idle_timeout_seconds budget),
+        with a hard_timeout_seconds absolute cap. DOM thinking/generating
+        signals are advisory liveness hints (generation_active_signal) within
+        the hard cap — never authoritative clock-pauses. On phase-2 stall, a
+        final reconciliation is attempted before raising: if the backend
+        reports the turn completed, the detector returns normally instead of
+        raising (the generation actually finished).
         """
         # Imported lazily to avoid a module-load circular dependency: cdp_driver
         # top-level re-exports PHASE_STALL_SECONDS / is_rate_limited_text from
@@ -164,6 +325,11 @@ class CompletionDetector:
         from .turn_anchor import collapse_to_end_turn_status
 
         d = self._driver
+
+        # P1: resolve the model class for structured error reporting.
+        model_class = classify_model(model) if model else "default"
+        # P1: budgets default to legacy behavior when not provided (back-compat).
+        use_two_state = budgets is not None
 
         # Reset per-call results surfaced to the driver tail.
         self.last_dom_text = ""
@@ -271,6 +437,15 @@ class CompletionDetector:
         # streaming) rather than .markdown textContent (which lags).
         last_change_time = time.monotonic()
         deadline = time.monotonic() + timeout
+        # P1: two-state phase-2 machine. phase_2_start tracks total observation
+        # time for the hard cap; first_content_seen tracks whether we've
+        # transitioned from awaiting_first_content to streaming_after_first_content.
+        # The active stall budget depends on this state: first-content uses
+        # budgets.first_content_timeout_seconds (longer for reasoning models that
+        # think silently); stream-idle uses budgets.stream_idle_timeout_seconds.
+        phase_2_start = time.monotonic()
+        first_content_seen = False
+        generation_active_signal = False  # advisory liveness (DOM thinking/generating)
         # Backend end_turn fallback throttle (R4): if the DOM action-button
         # selector drifts again, the conversation API's end_turn flag is a
         # secondary completion signal. Throttled to once per 3s to respect the
@@ -413,8 +588,19 @@ class CompletionDetector:
                 saw_thinking = True
                 if not conv_id_for_check:
                     last_change_time = time.monotonic()
+            # P1: track advisory liveness signal for structured error reporting.
+            # True when the DOM shows active generation (thinking indicator or
+            # a generating/stop-button state). This is advisory only — it
+            # informs the structured error and logging, but does NOT pause the
+            # stall clock (a stuck indicator must not create an infinite hang).
+            generation_active_signal = bool(is_thinking)
             if current != last_dom_text:
                 last_change_time = time.monotonic()
+                # P1: first text content transitions us from awaiting_first_content
+                # to streaming_after_first_content. The stall budget changes with
+                # the state (see the stall check below).
+                if current and not first_content_seen:
+                    first_content_seen = True
                 if len(current) > len(last_dom_text):
                     delta = current[len(last_dom_text) :]
                     yield StreamChunk(delta=delta)
@@ -427,6 +613,9 @@ class CompletionDetector:
                 if html_len > 50:
                     had_non_text_content = True
                     self.had_non_text_content = True
+                # P1: non-text content also counts as first-content (images/tool-use).
+                if not first_content_seen:
+                    first_content_seen = True
             last_html_len = html_len
             last_child_count = child_count
 
@@ -529,8 +718,78 @@ class CompletionDetector:
                 logger.info("DOM has_action (fallback completion) — no backend signal")
                 break
 
-            if time.monotonic() - last_change_time > PHASE_STALL_SECONDS:
-                raise GenerationStuckError("phase_2_stream", time.monotonic() - last_change_time)
+            # ── P1: model-aware two-state stall detection ───────────────────
+            # Replaces the single PHASE_STALL_SECONDS check. When budgets are
+            # provided, phase-2 splits into two states with separate budgets:
+            #   - awaiting_first_content: no text yet. Uses
+            #     first_content_timeout_seconds (longer for reasoning models).
+            #   - streaming_after_first_content: text appeared then stopped.
+            #     Uses stream_idle_timeout_seconds (shorter — once streaming
+            #     started, a long idle is suspicious).
+            # A hard_timeout_seconds absolute cap applies regardless of state
+            # or DOM liveness. DOM thinking/generating signals are advisory
+            # (generation_active_signal) — they inform logging but do NOT pause
+            # the stall clock (a stuck thinking indicator must not create an
+            # infinite hang).
+            #
+            # On stall: attempt ONE final reconciliation read before raising.
+            # If the backend reports the turn completed, return normally — the
+            # generation actually finished (field-verified case). Only if
+            # reconciliation finds no completion do we raise a structured
+            # GenerationStuckError.
+            if use_two_state:
+                elapsed_since_progress = time.monotonic() - last_change_time
+                elapsed_total = time.monotonic() - phase_2_start
+
+                # Determine which budget applies based on the current state.
+                stall_budget = (
+                    budgets.stream_idle_timeout_seconds
+                    if first_content_seen
+                    else budgets.first_content_timeout_seconds
+                )
+                stall_kind = (
+                    "stream_idle_timeout"
+                    if first_content_seen
+                    else "first_content_timeout"
+                )
+
+                # Hard cap: absolute wall-clock limit regardless of DOM signals.
+                hard_cap_hit = elapsed_total > budgets.hard_timeout_seconds
+                budget_hit = elapsed_since_progress > stall_budget
+
+                if hard_cap_hit or budget_hit:
+                    # Final reconciliation: did the turn actually complete?
+                    # Field evidence: the generation often completes after the
+                    # detector would have given up. Before raising, check the
+                    # backend one more time.
+                    turn_id = getattr(turn_anchor, "captured_id", None)
+                    reconciled = await self._reconcile_before_stall(
+                        d, conv_id_for_check, turn_anchor,
+                        had_non_text_content,
+                    )
+                    if reconciled:
+                        logger.info(
+                            "Phase-2 %s reconciled after stall — generation "
+                            "had completed (elapsed=%.0fs, kind=%s, "
+                            "model_class=%s, active=%s)",
+                            stall_kind, elapsed_total, stall_kind,
+                            model_class, generation_active_signal,
+                        )
+                        return  # generation completed — return normally
+                    # Reconciliation found no completion — raise structured error.
+                    raise GenerationStuckError(
+                        "phase_2_stream",
+                        elapsed_since_progress,
+                        stall_kind=("hard_timeout" if hard_cap_hit else stall_kind),
+                        model_class=model_class,
+                        elapsed_seconds=elapsed_total,
+                        generation_active_signal=generation_active_signal,
+                        turn_id=turn_id,
+                    )
+            else:
+                # Legacy path (no budgets provided): single PHASE_STALL_SECONDS.
+                if time.monotonic() - last_change_time > PHASE_STALL_SECONDS:
+                    raise GenerationStuckError("phase_2_stream", time.monotonic() - last_change_time)
 
             await asyncio.sleep(0.5)
 

--- a/src/chatgpt_web2api/config.py
+++ b/src/chatgpt_web2api/config.py
@@ -97,6 +97,18 @@ class ChatGPTConfig:
     # Account-level throttle breaker: pauses mutations pool-wide if ChatGPT
     # signals excessive consumption from simultaneous multi-tab use.
     mcp_account_throttle_cooldown_seconds: int = 300
+    # P1: model-aware detector budgets. Phase-2 stall detection splits into
+    # first-content-wait (no text yet) vs stream-idle (text appeared then
+    # stopped), with model-aware budgets. See classify_model /
+    # DetectorBudgets in completion_detector.py. Defaults reproduce the
+    # legacy 90s behavior for non-reasoning models and give reasoning models
+    # a longer first-content window (300s) so their silent thinking phase
+    # isn't falsely aborted.
+    detector_reasoning_first_content_timeout_seconds: float = 300
+    detector_reasoning_stream_idle_timeout_seconds: float = 120
+    detector_default_first_content_timeout_seconds: float = 90
+    detector_default_stream_idle_timeout_seconds: float = 90
+    detector_hard_timeout_seconds: float = 900
 
 
 @dataclass
@@ -262,6 +274,22 @@ class Config:
         c = data.get("mcp_account_throttle_cooldown_seconds")
         if c is not None:
             self.chatgpt.mcp_account_throttle_cooldown_seconds = int(c)
+        # P1 detector budgets
+        c = data.get("detector_reasoning_first_content_timeout_seconds")
+        if c is not None:
+            self.chatgpt.detector_reasoning_first_content_timeout_seconds = float(c)
+        c = data.get("detector_reasoning_stream_idle_timeout_seconds")
+        if c is not None:
+            self.chatgpt.detector_reasoning_stream_idle_timeout_seconds = float(c)
+        c = data.get("detector_default_first_content_timeout_seconds")
+        if c is not None:
+            self.chatgpt.detector_default_first_content_timeout_seconds = float(c)
+        c = data.get("detector_default_stream_idle_timeout_seconds")
+        if c is not None:
+            self.chatgpt.detector_default_stream_idle_timeout_seconds = float(c)
+        c = data.get("detector_hard_timeout_seconds")
+        if c is not None:
+            self.chatgpt.detector_hard_timeout_seconds = float(c)
         c = data.get("request_timeout")
         if c is not None:
             self.server.request_timeout = int(c)
@@ -316,6 +344,17 @@ class Config:
             self.chatgpt.mcp_session_pool_create_concurrency = int(v)
         if v := _env("W2A_MCP_ACCOUNT_THROTTLE_COOLDOWN_SECONDS"):
             self.chatgpt.mcp_account_throttle_cooldown_seconds = int(v)
+        # P1 detector budgets
+        if v := _env("W2A_DETECTOR_REASONING_FIRST_CONTENT_TIMEOUT_SECONDS"):
+            self.chatgpt.detector_reasoning_first_content_timeout_seconds = float(v)
+        if v := _env("W2A_DETECTOR_REASONING_STREAM_IDLE_TIMEOUT_SECONDS"):
+            self.chatgpt.detector_reasoning_stream_idle_timeout_seconds = float(v)
+        if v := _env("W2A_DETECTOR_DEFAULT_FIRST_CONTENT_TIMEOUT_SECONDS"):
+            self.chatgpt.detector_default_first_content_timeout_seconds = float(v)
+        if v := _env("W2A_DETECTOR_DEFAULT_STREAM_IDLE_TIMEOUT_SECONDS"):
+            self.chatgpt.detector_default_stream_idle_timeout_seconds = float(v)
+        if v := _env("W2A_DETECTOR_HARD_TIMEOUT_SECONDS"):
+            self.chatgpt.detector_hard_timeout_seconds = float(v)
         if v := _env("W2A_HEADLESS"):
             self.chrome.headless = v.lower() in ("true", "1", "yes")
         if v := _env("W2A_LOG_LEVEL"):
@@ -347,6 +386,11 @@ class Config:
             "mcp_session_pool_sweep_interval_seconds": self.chatgpt.mcp_session_pool_sweep_interval_seconds,
             "mcp_session_pool_create_concurrency": self.chatgpt.mcp_session_pool_create_concurrency,
             "mcp_account_throttle_cooldown_seconds": self.chatgpt.mcp_account_throttle_cooldown_seconds,
+            "detector_reasoning_first_content_timeout_seconds": self.chatgpt.detector_reasoning_first_content_timeout_seconds,
+            "detector_reasoning_stream_idle_timeout_seconds": self.chatgpt.detector_reasoning_stream_idle_timeout_seconds,
+            "detector_default_first_content_timeout_seconds": self.chatgpt.detector_default_first_content_timeout_seconds,
+            "detector_default_stream_idle_timeout_seconds": self.chatgpt.detector_default_stream_idle_timeout_seconds,
+            "detector_hard_timeout_seconds": self.chatgpt.detector_hard_timeout_seconds,
             "request_timeout": self.server.request_timeout,
             "log_level": self.log.level,
             "ensure_degraded_poll_interval_s": self.ensure.degraded_poll_interval_s,

--- a/src/chatgpt_web2api/mcp_driver_pool.py
+++ b/src/chatgpt_web2api/mcp_driver_pool.py
@@ -28,6 +28,9 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# P1.5: cap for lease history records (prevents unbounded growth).
+_LEASE_HISTORY_LIMIT = 100
+
 
 # ── Errors ────────────────────────────────────────────────────────────────
 
@@ -231,7 +234,6 @@ class McpSessionDriverPool:
         # completed records. Pure diagnostics — no behavioral influence.
         self._active_leases: dict[str, LeaseRecord] = {}
         self._lease_history: list[LeaseRecord] = []
-        self._history_cap = 100  # prevent unbounded growth
 
     @property
     def active_leases(self) -> dict[str, LeaseRecord]:
@@ -513,8 +515,13 @@ class McpSessionDriverPool:
         detects double-releases (a correctness bug where the same lease is
         released twice). Double-release logs a warning but does NOT re-decrement
         in_flight (that would undercount).
+
+        Legacy callers without a ``lease_id`` (``lease_id=""``) skip tracking
+        but still get the correct in_flight decrement (review finding A).
         """
-        # P1.5: complete the lease record if we have its ID.
+        # P1.5: lease tracking. For tracked leases (lease_id non-empty),
+        # complete the record or detect double-release.
+        skip_decrement = False
         if lease_id:
             record = self._active_leases.pop(lease_id, None)
             if record is not None:
@@ -523,17 +530,25 @@ class McpSessionDriverPool:
                 record.release_reason = release_reason
                 self._lease_history.append(record)
                 # Cap history to prevent unbounded growth.
-                if len(self._lease_history) > self._history_cap:
-                    self._lease_history = self._lease_history[-self._history_cap:]
+                if len(self._lease_history) > _LEASE_HISTORY_LIMIT:
+                    self._lease_history = self._lease_history[-_LEASE_HISTORY_LIMIT:]
             else:
+                # Confirmed double-release: lease_id was provided but is not in
+                # active_leases. Log and do NOT re-decrement in_flight (review
+                # finding A — re-decrementing would undercount).
                 logger.warning(
                     "Double-release detected: lease_id=%s not in active_leases "
-                    "(session=%s) — lease was already released or never tracked",
+                    "(session=%s) — lease was already released; skipping "
+                    "in_flight decrement to avoid undercount",
                     lease_id, slot.session_key,
                 )
-        async with slot.meta_lock:
-            slot.in_flight = max(0, slot.in_flight - 1)
-            slot.last_used_at = time.monotonic()
+                skip_decrement = True
+        # For untracked releases (lease_id="" — legacy/direct callers) and
+        # normal tracked releases, decrement in_flight. Double-releases skip.
+        if not skip_decrement:
+            async with slot.meta_lock:
+                slot.in_flight = max(0, slot.in_flight - 1)
+                slot.last_used_at = time.monotonic()
 
     async def _sweep_idle(self) -> None:
         """Background loop: close idle slots past TTL.

--- a/src/chatgpt_web2api/mcp_driver_pool.py
+++ b/src/chatgpt_web2api/mcp_driver_pool.py
@@ -23,7 +23,7 @@ import logging
 import time
 import uuid
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)

--- a/src/chatgpt_web2api/mcp_driver_pool.py
+++ b/src/chatgpt_web2api/mcp_driver_pool.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import uuid
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -39,11 +40,16 @@ class PoolExhaustedError(RuntimeError):
     sites below now render as
     ``"PoolExhaustedError: no driver slot available within acquire_timeout.
     Retry later."`` rather than ``": . Retry later."``.
+
+    P1.5: carries an optional ``active_leases`` dump so the error message
+    names the sessions holding slots at exhaustion time.
     """
 
-    def __init__(self, message: str | None = None) -> None:
+    def __init__(self, message: str | None = None, active_leases: list[str] | None = None) -> None:
         if message is None:
             message = "no driver slot available within acquire_timeout"
+        if active_leases:
+            message = f"{message} (active: {', '.join(active_leases)})"
         super().__init__(message)
 
 
@@ -118,6 +124,26 @@ class DriverSlot:
     closing: bool = False
 
 
+# ── P1.5: Lease accounting records ────────────────────────────────────────
+
+@dataclass
+class LeaseRecord:
+    """P1.5: per-lease lifecycle record for diagnostics.
+
+    Created at acquire time, completed at release time with hold duration
+    and release reason. Stored in the pool's ``_lease_history`` (capped)
+    for post-hoc RCA. This is pure instrumentation — it does NOT influence
+    pool behavior (capacity, eviction, blocking).
+    """
+    lease_id: str
+    session_key: str
+    acquired_at: float
+    released_at: float | None = None
+    hold_duration_s: float | None = None
+    release_reason: str | None = None  # "normal" | "exception" | "cancellation"
+
+
+
 # ── Lease ─────────────────────────────────────────────────────────────────
 
 @dataclass(frozen=True)
@@ -127,6 +153,7 @@ class DriverLease:
     driver: Any  # CDPDriver
     breakers: Any  # BreakerRegistry
     call_lock: asyncio.Lock
+    lease_id: str = ""  # P1.5: correlates to a LeaseRecord for diagnostics
 
 
 class _LeaseContext:
@@ -148,7 +175,14 @@ class _LeaseContext:
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         if self._lease is None:
             return
-        await self._pool._release(self._lease.slot)
+        # P1.5: classify the release reason for lease accounting.
+        if exc_type is None:
+            reason = "normal"
+        elif issubclass(exc_type, asyncio.CancelledError):
+            reason = "cancellation"
+        else:
+            reason = "exception"
+        await self._pool._release(self._lease.slot, lease_id=self._lease.lease_id, release_reason=reason)
         self._lease = None
 
 
@@ -192,6 +226,22 @@ class McpSessionDriverPool:
             cfg.mcp_account_throttle_cooldown_seconds
         )
         self._sweep_task: asyncio.Task | None = None
+        # P1.5: lease accounting. _active_leases maps lease_id → LeaseRecord
+        # for currently-held leases; _lease_history is a capped list of
+        # completed records. Pure diagnostics — no behavioral influence.
+        self._active_leases: dict[str, LeaseRecord] = {}
+        self._lease_history: list[LeaseRecord] = []
+        self._history_cap = 100  # prevent unbounded growth
+
+    @property
+    def active_leases(self) -> dict[str, LeaseRecord]:
+        """Currently-held leases (lease_id → LeaseRecord)."""
+        return self._active_leases
+
+    @property
+    def lease_history(self) -> list[LeaseRecord]:
+        """Completed lease records (most recent last, capped at _history_cap)."""
+        return self._lease_history
 
     @property
     def account_breaker(self) -> AccountThrottleBreaker:
@@ -311,12 +361,7 @@ class McpSessionDriverPool:
                             else:
                                 slot.in_flight += 1
                                 slot.last_used_at = time.monotonic()
-                                return DriverLease(
-                                    slot=slot,
-                                    driver=slot.driver,
-                                    breakers=slot.breakers,
-                                    call_lock=slot.call_lock,
-                                )
+                                return self._make_lease(slot)
 
                 # Need a new slot.
                 if pending_slot is None and (
@@ -343,7 +388,7 @@ class McpSessionDriverPool:
 
                     remaining = deadline - time.monotonic()
                     if remaining <= 0:
-                        raise PoolExhaustedError()
+                        raise PoolExhaustedError(active_leases=self._active_session_keys())
 
                     try:
                         await asyncio.wait_for(
@@ -356,7 +401,7 @@ class McpSessionDriverPool:
                             timeout=remaining,
                         )
                     except TimeoutError:
-                        raise PoolExhaustedError()
+                        raise PoolExhaustedError(active_leases=self._active_session_keys())
 
                     if self._shutting_down:
                         raise PoolShuttingDownError()
@@ -366,13 +411,13 @@ class McpSessionDriverPool:
             if pending_slot is not None:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
-                    raise PoolExhaustedError()
+                    raise PoolExhaustedError(active_leases=self._active_session_keys())
                 try:
                     await asyncio.wait_for(
                         pending_slot.ready_event.wait(), timeout=remaining
                     )
                 except TimeoutError:
-                    raise PoolExhaustedError()
+                    raise PoolExhaustedError(active_leases=self._active_session_keys())
                 continue
 
         assert materialize_slot is not None
@@ -383,7 +428,7 @@ class McpSessionDriverPool:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 await self._abandon_pending_slot(materialize_slot)
-                raise PoolExhaustedError()
+                raise PoolExhaustedError(active_leases=self._active_session_keys())
 
             try:
                 await asyncio.wait_for(
@@ -392,7 +437,7 @@ class McpSessionDriverPool:
                 sem_acquired = True
             except TimeoutError:
                 await self._abandon_pending_slot(materialize_slot)
-                raise PoolExhaustedError()
+                raise PoolExhaustedError(active_leases=self._active_session_keys())
 
             await self._materialize_slot(materialize_slot)
 
@@ -432,20 +477,60 @@ class McpSessionDriverPool:
         async with materialize_slot.meta_lock:
             if materialize_slot.driver is None:
                 raise PoolSlotUnavailableError()
-            return DriverLease(
-                slot=materialize_slot,
-                driver=materialize_slot.driver,
-                breakers=materialize_slot.breakers,
-                call_lock=materialize_slot.call_lock,
-            )
+            return self._make_lease(materialize_slot)
 
     def _make_breakers(self):
         """Create a fresh BreakerRegistry for a slot."""
         from .breakers import BreakerRegistry
         return BreakerRegistry()
 
-    async def _release(self, slot: DriverSlot) -> None:
-        """Release a lease: decrement in_flight, update last_used_at."""
+    def _make_lease(self, slot: DriverSlot) -> DriverLease:
+        """P1.5: create a DriverLease + its LeaseRecord. Instruments the lease
+        lifecycle for diagnostics (hold duration, release reason)."""
+        lease_id = uuid.uuid4().hex[:12]
+        record = LeaseRecord(
+            lease_id=lease_id,
+            session_key=slot.session_key,
+            acquired_at=time.monotonic(),
+        )
+        self._active_leases[lease_id] = record
+        return DriverLease(
+            slot=slot,
+            driver=slot.driver,
+            breakers=slot.breakers,
+            call_lock=slot.call_lock,
+            lease_id=lease_id,
+        )
+
+    def _active_session_keys(self) -> list[str]:
+        """P1.5: session keys of currently-held leases (for exhaustion dumps)."""
+        return sorted({r.session_key for r in self._active_leases.values()})
+
+    async def _release(self, slot: DriverSlot, *, lease_id: str = "", release_reason: str = "normal") -> None:
+        """Release a lease: decrement in_flight, update last_used_at.
+
+        P1.5: also completes the LeaseRecord (hold duration + reason) and
+        detects double-releases (a correctness bug where the same lease is
+        released twice). Double-release logs a warning but does NOT re-decrement
+        in_flight (that would undercount).
+        """
+        # P1.5: complete the lease record if we have its ID.
+        if lease_id:
+            record = self._active_leases.pop(lease_id, None)
+            if record is not None:
+                record.released_at = time.monotonic()
+                record.hold_duration_s = record.released_at - record.acquired_at
+                record.release_reason = release_reason
+                self._lease_history.append(record)
+                # Cap history to prevent unbounded growth.
+                if len(self._lease_history) > self._history_cap:
+                    self._lease_history = self._lease_history[-self._history_cap:]
+            else:
+                logger.warning(
+                    "Double-release detected: lease_id=%s not in active_leases "
+                    "(session=%s) — lease was already released or never tracked",
+                    lease_id, slot.session_key,
+                )
         async with slot.meta_lock:
             slot.in_flight = max(0, slot.in_flight - 1)
             slot.last_used_at = time.monotonic()
@@ -593,4 +678,20 @@ class McpSessionDriverPool:
             },
             "account_breaker_tripped": self._account_breaker.is_tripped(),
             "shutting_down": self._shutting_down,
+            # P1.5: lease accounting summary for RCA / diagnostics.
+            "leases": {
+                "active_count": len(self._active_leases),
+                "history_count": len(self._lease_history),
+                "active": [
+                    {"lease_id": r.lease_id, "session_key": r.session_key,
+                     "acquired_at": r.acquired_at}
+                    for r in self._active_leases.values()
+                ],
+                "recent": [
+                    {"lease_id": r.lease_id, "session_key": r.session_key,
+                     "hold_duration_s": r.hold_duration_s,
+                     "release_reason": r.release_reason}
+                    for r in self._lease_history[-10:]
+                ],
+            },
         }

--- a/src/chatgpt_web2api/mcp_driver_pool.py
+++ b/src/chatgpt_web2api/mcp_driver_pool.py
@@ -31,11 +31,29 @@ logger = logging.getLogger(__name__)
 # ── Errors ────────────────────────────────────────────────────────────────
 
 class PoolExhaustedError(RuntimeError):
-    """Pool is full after acquire_timeout."""
+    """Pool is full after acquire_timeout.
+
+    Carries a default human-readable message (mirroring RateLimitError /
+    AuthExpiredError in cdp_driver.py) so the MCP error-formatter can't
+    surface an empty diagnostic. The bare ``raise PoolExhaustedError()``
+    sites below now render as
+    ``"PoolExhaustedError: no driver slot available within acquire_timeout.
+    Retry later."`` rather than ``": . Retry later."``.
+    """
+
+    def __init__(self, message: str | None = None) -> None:
+        if message is None:
+            message = "no driver slot available within acquire_timeout"
+        super().__init__(message)
 
 
 class PoolShuttingDownError(RuntimeError):
     """Pool is shutting down; no new slots can be created."""
+
+    def __init__(self, message: str | None = None) -> None:
+        if message is None:
+            message = "driver pool is shutting down; no new slots can be created"
+        super().__init__(message)
 
 
 class PoolSlotUnavailableError(RuntimeError):

--- a/src/chatgpt_web2api/mcp_driver_pool.py
+++ b/src/chatgpt_web2api/mcp_driver_pool.py
@@ -597,9 +597,15 @@ class McpSessionDriverPool:
                     async with slot.meta_lock:
                         slot.in_flight = 0
                         slot.closing = True
+                    # Only delete the mapping and discard the active key if
+                    # this slot is STILL the current mapping for its session.
+                    # If a replacement was created while we were closing, the
+                    # identity check prevents us from deleting the replacement
+                    # OR discarding the key the replacement needs.
+                    # (ChatGPT review, conv 6a52a623 — closing-slot race.)
                     if self._slots.get(slot.session_key) is slot:
                         del self._slots[slot.session_key]
-                    self._active_keys.discard(slot.session_key)
+                        self._active_keys.discard(slot.session_key)
                     self._capacity_available.notify_all()
 
     async def close_all(self) -> None:

--- a/src/chatgpt_web2api/mcp_server.py
+++ b/src/chatgpt_web2api/mcp_server.py
@@ -1664,8 +1664,13 @@ def create_server() -> Server:
                     # Shared result formatting (singleton parity, PR #42 fix #1).
                     return _format_tool_result(name, result)
         except (PoolExhaustedError, PoolShuttingDownError) as e:
+            # Defensive: never let an empty-message exception surface as
+            # ". Retry later." Fall back to the type name so the caller always
+            # gets a diagnosable signal. (The exception classes now carry a
+            # default message, but this guards against future bare raises.)
+            detail = str(e) or type(e).__name__
             return mcp_types.CallToolResult(
-                content=[mcp_types.TextContent(type="text", text=f"{e}. Retry later.")],
+                content=[mcp_types.TextContent(type="text", text=f"{detail}. Retry later.")],
                 isError=True,
             )
         except Exception as exc:

--- a/src/chatgpt_web2api/mcp_server.py
+++ b/src/chatgpt_web2api/mcp_server.py
@@ -778,7 +778,18 @@ async def do_chat_completion(
     full_response = ""
     conv_id = ""
     chunk_count = 0
-    async for chunk in driver.send_and_stream(full_text, timeout=120):
+    # P1: resolve model-aware detector budgets from config. Guard against
+    # config=None (some test paths) by falling back to legacy behavior.
+    from .completion_detector import DetectorBudgets
+
+    _budgets = (
+        DetectorBudgets.from_config(config.chatgpt, validated.model)
+        if config is not None
+        else None
+    )
+    async for chunk in driver.send_and_stream(
+        full_text, timeout=120, budgets=_budgets, model=validated.model,
+    ):
         if chunk.delta:
             full_response += chunk.delta
             chunk_count += 1

--- a/src/chatgpt_web2api/turn_anchor.py
+++ b/src/chatgpt_web2api/turn_anchor.py
@@ -171,9 +171,16 @@ class TurnReconciliationError(RuntimeError):
         self.anchor_mode = anchor_mode
         self.last_status = last_status
         self.diagnostic = diagnostic
+        # Include the underlying fetch error in the message string so it's
+        # visible to agents (not just in the diagnostic dict that API paths
+        # don't surface). (ChatGPT review, conv 6a52f0f3.)
+        fetch_detail = ""
+        last_fetch = diagnostic.get("last_fetch_diagnostic") or {}
+        if isinstance(last_fetch, dict) and last_fetch.get("error"):
+            fetch_detail = f", fetch_error={str(last_fetch['error'])[:240]!r}"
         super().__init__(
             f"Turn reconciliation failed for {conversation_id} "
-            f"(mode={anchor_mode}, last_status={last_status})"
+            f"(mode={anchor_mode}, last_status={last_status}{fetch_detail})"
         )
 
 

--- a/tests/test_breaker_failfast.py
+++ b/tests/test_breaker_failfast.py
@@ -75,7 +75,7 @@ def _make_mcp_server_with_open_breaker():
     driver._current_model = None
 
     # If the handler somehow runs, yield a benign chunk (it should NOT).
-    async def _stream(text, timeout=120):
+    async def _stream(text, timeout=120, *, budgets=None, model=None):
         from chatgpt_web2api.cdp_driver import StreamChunk
 
         yield StreamChunk(delta="should-not-reach")
@@ -140,7 +140,7 @@ async def test_mcp_closed_breaker_does_not_fail_fast(monkeypatch):
     driver._current_conv_id = ""
     driver._current_model = None
 
-    async def _stream(text, timeout=120):
+    async def _stream(text, timeout=120, *, budgets=None, model=None):
         from chatgpt_web2api.cdp_driver import StreamChunk
 
         yield StreamChunk(delta="ok")
@@ -200,7 +200,7 @@ async def test_rest_post_lock_check_catches_race(monkeypatch):
     driver.navigate_conversation = AsyncMock()
     driver.ensure_current_conversation = AsyncMock()
 
-    async def _stream(text, timeout=120):
+    async def _stream(text, timeout=120, *, budgets=None, model=None):
         yield MagicMock()
 
     driver.send_and_stream = _stream

--- a/tests/test_business.py
+++ b/tests/test_business.py
@@ -26,7 +26,7 @@ def mock_driver():
     driver.select_model = AsyncMock(return_value=True)
 
     # Wire send_and_stream to yield a simple response
-    async def _stream(text, timeout=120):
+    async def _stream(text, timeout=120, *, budgets=None, model=None):
         yield StreamChunk(delta="Hello!")
         yield StreamChunk(delta="", finish_reason="stop")
 
@@ -497,7 +497,7 @@ async def test_api_message_history_includes_assistant():
 
     captured_text = {}
 
-    async def _stream(text, timeout=120):
+    async def _stream(text, timeout=120, *, budgets=None, model=None):
         captured_text["value"] = text
         yield StreamChunk(delta="Response")
         yield StreamChunk(delta="", finish_reason="stop")
@@ -546,7 +546,7 @@ async def test_api_model_selection_called():
     driver._access_token = "test"
     driver.select_model = AsyncMock(return_value=True)
 
-    async def _stream(text, timeout=120):
+    async def _stream(text, timeout=120, *, budgets=None, model=None):
         yield StreamChunk(delta="OK")
         yield StreamChunk(delta="", finish_reason="stop")
 

--- a/tests/test_composer_verification.py
+++ b/tests/test_composer_verification.py
@@ -1,0 +1,161 @@
+"""Tests: composer text verification round-trip (ChatGPT review, conv 6a52f0f3).
+
+Tests the 4 defects ChatGPT identified by reading the actual code:
+
+1. Complex-newline DOM reconstruction — <br> inside <p> is lost by textContent
+2. Missing NFC normalization — composed/decomposed Unicode sequences differ
+3. Unconditional trailing-newline removal — user's trailing \n is stripped
+4. Fixed 500ms stabilization — needs bounded polling instead
+
+These test the _verify_composer_text method directly, mocking the JS read-back
+to return what the real ProseMirror DOM would produce for each case.
+"""
+
+import asyncio
+import unicodedata
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.chatgpt_dom import ChatGPTDom
+from chatgpt_web2api.cdp_driver import CDPDriver
+
+
+def _make_dom(js_return_value=""):
+    """A ChatGPTDom with a real CDPDriver whose _js_strict returns the given value."""
+    driver = CDPDriver(cdp_port=9222)
+    driver._js_strict = AsyncMock(return_value=js_return_value)
+    driver._js = AsyncMock(return_value=js_return_value)
+    driver._cdp = AsyncMock()
+    driver._breakers = None
+    return ChatGPTDom(driver), driver
+
+
+def _composer_text_with_br():
+    """Simulate what ProseMirror produces for input 'line1\nline2' when it
+    renders as <p>line1<br>line2</p> — textContent gives 'line1line2' (no newline).
+    This is the high-confidence bug: <br> within a <p> is invisible to textContent."""
+    # The JS extractor currently does child.textContent which would return "line1line2"
+    # for <p>line1<br>line2</p>. That's the bug.
+    return "line1line2"
+
+
+def _composer_text_multiline_blocks():
+    """Simulate what the current block-aware extractor returns for a multi-line
+    input. Each top-level <p> child's textContent is joined with \\n.
+    For input 'para1\\npara2\\n\\nblank_line', ProseMirror creates:
+    <p>para1</p><p>para2</p><p><br></p><p>blank_line</p>
+    The extractor joins: 'para1\\npara2\\n\\nblank_line' — correct.
+    But for input with <br> INSIDE a <p>: <p>line1<br>line2</p>
+    textContent = 'line1line2' — WRONG, should be 'line1\\nline2'."""
+    return "para1\npara2\n\nblank_line"
+
+
+class TestComposerVerificationDefects:
+    """Each test reproduces a defect ChatGPT identified by reading the code."""
+
+    @pytest.mark.asyncio
+    async def test_br_inside_paragraph_should_preserve_newline(self):
+        """Defect 1 (high confidence): when ProseMirror renders 'line1\\nline2'
+        as <p>line1<br>line2</p>, the current extractor returns 'line1line2'
+        (textContent of the <p>), losing the <br> newline.
+
+        The fix: the JS extractor must recursively walk nodes, emitting \\n
+        for <br> elements."""
+        # What the CURRENT buggy extractor would return
+        buggy_output = _composer_text_with_br()  # "line1line2"
+        dom, driver = _make_dom(buggy_output)
+        # This should FAIL with the current code (the newline is lost)
+        result = await dom._verify_composer_text(
+            'div[role="textbox"]#prompt-textarea', "line1\nline2"
+        )
+        assert result is False, (
+            "Current extractor loses <br> newlines — this test proves the bug"
+        )
+
+    @pytest.mark.asyncio
+    async def test_multiline_blocks_are_correct(self):
+        """Verify the existing block-aware extraction works for standard
+        multi-paragraph input (each paragraph as a separate <p>)."""
+        correct_output = _composer_text_multiline_blocks()
+        dom, driver = _make_dom(correct_output)
+        result = await dom._verify_composer_text(
+            'div[role="textbox"]#prompt-textarea',
+            "para1\npara2\n\nblank_line"
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_nfc_normalization_for_combining_accents(self):
+        """Defect 3 (confirmed): the verifier doesn't apply NFC normalization.
+        A combining-accent sequence (e.g., é as 'e' + U+0301) should match
+        the precomposed form (é = U+00E9). The turn-anchor matcher already
+        uses NFC; the verifier doesn't."""
+        # Precomposed é (what the user typed)
+        expected = "caf\u00e9"  # café
+        # Decomposed é (what ProseMirror might produce internally)
+        actual = "cafe\u0301"  # cafe + combining acute
+        # Verify they're NOT equal without NFC
+        assert expected != actual, "Precondition: without NFC these differ"
+        # The verifier SHOULD treat them as equal after NFC
+        dom, driver = _make_dom(actual)
+        result = await dom._verify_composer_text(
+            'div[role="textbox"]#prompt-textarea', expected
+        )
+        # With the fix (NFC applied), this should be True
+        assert result is True, (
+            "NFC normalization should make precomposed and decomposed forms equal"
+        )
+
+    @pytest.mark.asyncio
+    async def test_trailing_newline_not_stripped(self):
+        """Defect 4 (definite correctness bug): the OLD JS extractor stripped
+        one trailing \\n unconditionally. A prompt that legitimately ends in \\n
+        failed verification.
+
+        The fix: JS does NOT strip trailing newlines. The Python-side tolerance
+        handles editor-added trailing newlines (accepts actual == expected OR
+        actual == expected + \\n).
+
+        This test simulates what the NEW JS returns for input "hello\\n":
+        ProseMirror renders <p>hello</p><p><br></p>, the recursive extractor
+        returns "hello\\n" (no stripping). The Python comparison accepts it
+        because actual == expected."""
+        # What the FIXED JS returns (no trailing-newline strip)
+        dom, driver = _make_dom("hello\n")
+        result = await dom._verify_composer_text(
+            'div[role="textbox"]#prompt-textarea', "hello\n"
+        )
+        assert result is True, (
+            "User's trailing newline should not cause verification failure"
+        )
+
+    @pytest.mark.asyncio
+    async def test_em_dash_and_curly_quotes_pass(self):
+        """Common agent content: em-dashes (—) and curly quotes (' ' " ")
+        should pass verification. These are NFC-stable so NFC doesn't change
+        them, but they should still round-trip correctly."""
+        text = 'Here\u2019s a test \u2014 with \u201ccurly quotes\u201d and an em-dash.'
+        dom, driver = _make_dom(text)
+        result = await dom._verify_composer_text(
+            'div[role="textbox"]#prompt-textarea', text
+        )
+        assert result is True, (
+            "Em-dashes and curly quotes should pass verification"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bounded_polling_not_fixed_delay(self):
+        """Defect 2 (medium-high confidence): the current code uses a fixed 500ms
+        delay after insertText, then one read. Under load, ProseMirror may not
+        have settled. The fix: poll with bounded retries.
+
+        This test verifies that _verify_composer_text is called AFTER type_message
+        has settled the DOM, not just once after a fixed delay. We test this
+        indirectly by checking that type_message eventually succeeds even when
+        the first read returns stale data."""
+        # We can't directly test the polling in _verify_composer_text (it's a
+        # single-shot read). The fix moves the polling INTO the verifier.
+        # For now, verify the structure: _verify_composer_text should accept
+        # multiple attempts via a polling loop.
+        pass  # Will be addressed when the fix implements polling

--- a/tests/test_composer_verification.py
+++ b/tests/test_composer_verification.py
@@ -7,13 +7,13 @@ Tests the 4 defects ChatGPT identified by reading the actual code:
 3. Unconditional trailing-newline removal — user's trailing \n is stripped
 4. Fixed 500ms stabilization — needs bounded polling instead
 
-These test the _verify_composer_text method directly, mocking the JS read-back
-to return what the real ProseMirror DOM would produce for each case.
+The extractor tests (round 2, ChatGPT review conv 6a52f0f3) use a Python
+reimplementation of the JS DOM walker to verify the extraction logic against
+realistic ProseMirror DOM shapes — not just mocked output strings.
 """
 
-import asyncio
 import unicodedata
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -31,131 +31,176 @@ def _make_dom(js_return_value=""):
     return ChatGPTDom(driver), driver
 
 
-def _composer_text_with_br():
-    """Simulate what ProseMirror produces for input 'line1\nline2' when it
-    renders as <p>line1<br>line2</p> — textContent gives 'line1line2' (no newline).
-    This is the high-confidence bug: <br> within a <p> is invisible to textContent."""
-    # The JS extractor currently does child.textContent which would return "line1line2"
-    # for <p>line1<br>line2</p>. That's the bug.
-    return "line1line2"
+# ── Python reimplementation of the JS extractor ──────────────────────────
+# Mirrors the JS in _verify_composer_text exactly so tests exercise the
+# extraction LOGIC, not just the comparator. If the JS changes, this must
+# change too. (ChatGPT review finding: tests must execute the extractor.)
+
+class _Node:
+    """Minimal DOM node for testing the extractor logic."""
+    def __init__(self, tag=None, text=None, children=None):
+        self.tag = tag  # None = text node
+        self.text = text
+        self.children = children or []
+
+    @property
+    def node_type(self):
+        return 3 if self.tag is None else 1
+
+    @property
+    def node_value(self):
+        return self.text if self.tag is None else None
+
+    @property
+    def first_child(self):
+        return self.children[0] if self.children else None
+
+    @property
+    def child_nodes_length(self):
+        return len(self.children)
 
 
-def _composer_text_multiline_blocks():
-    """Simulate what the current block-aware extractor returns for a multi-line
-    input. Each top-level <p> child's textContent is joined with \\n.
-    For input 'para1\\npara2\\n\\nblank_line', ProseMirror creates:
-    <p>para1</p><p>para2</p><p><br></p><p>blank_line</p>
-    The extractor joins: 'para1\\npara2\\n\\nblank_line' — correct.
-    But for input with <br> INSIDE a <p>: <p>line1<br>line2</p>
-    textContent = 'line1line2' — WRONG, should be 'line1\\nline2'."""
-    return "para1\npara2\n\nblank_line"
+def _is_placeholder_break_block(node):
+    """Python mirror of the JS isPlaceholderBreakBlock function."""
+    return (
+        node.node_type == 1
+        and node.child_nodes_length == 1
+        and node.first_child.node_type == 1
+        and node.first_child.tag == "BR"
+    )
 
 
-class TestComposerVerificationDefects:
-    """Each test reproduces a defect ChatGPT identified by reading the code."""
+def _extract_text(node):
+    """Python mirror of the JS extractText function."""
+    if node.node_type == 3:
+        return (node.text or "").replace("\u00a0", " ")
+    if node.node_type != 1:
+        return ""
+    if node.tag == "BR":
+        return "\n"
+    text = ""
+    for child in node.children:
+        text += _extract_text(child)
+    return text
 
-    @pytest.mark.asyncio
-    async def test_br_inside_paragraph_should_preserve_newline(self):
-        """Defect 1 (high confidence): when ProseMirror renders 'line1\\nline2'
-        as <p>line1<br>line2</p>, the current extractor returns 'line1line2'
-        (textContent of the <p>), losing the <br> newline.
 
-        The fix: the JS extractor must recursively walk nodes, emitting \\n
-        for <br> elements."""
-        # What the CURRENT buggy extractor would return
-        buggy_output = _composer_text_with_br()  # "line1line2"
-        dom, driver = _make_dom(buggy_output)
-        # This should FAIL with the current code (the newline is lost)
-        result = await dom._verify_composer_text(
-            'div[role="textbox"]#prompt-textarea', "line1\nline2"
-        )
-        assert result is False, (
-            "Current extractor loses <br> newlines — this test proves the bug"
-        )
+def _extract_composer(root_children):
+    """Python mirror of the JS root-level extraction loop."""
+    parts = []
+    for child in root_children:
+        if child.node_type == 3:
+            t = (child.text or "").replace("\u00a0", " ")
+            if t:
+                parts.append(t)
+        elif child.node_type == 1:
+            parts.append("" if _is_placeholder_break_block(child) else _extract_text(child))
+    return "\n".join(parts)
 
-    @pytest.mark.asyncio
-    async def test_multiline_blocks_are_correct(self):
-        """Verify the existing block-aware extraction works for standard
-        multi-paragraph input (each paragraph as a separate <p>)."""
-        correct_output = _composer_text_multiline_blocks()
-        dom, driver = _make_dom(correct_output)
-        result = await dom._verify_composer_text(
-            'div[role="textbox"]#prompt-textarea',
-            "para1\npara2\n\nblank_line"
-        )
-        assert result is True
+
+# ── Extractor logic tests (ChatGPT review finding 2) ─────────────────────
+
+
+class TestExtractorLogic:
+    """Tests that execute the extraction logic against realistic ProseMirror
+    DOM shapes. These are NOT mock tests — they run the actual extraction
+    algorithm against constructed DOM trees."""
+
+    def test_br_inside_p_preserves_newline(self):
+        """<p>line1<br>line2</p> should extract as 'line1\\nline2'.
+        This is the core bug — textContent would give 'line1line2'."""
+        p = _Node("P", children=[
+            _Node(text="line1"),
+            _Node("BR"),
+            _Node(text="line2"),
+        ])
+        result = _extract_composer([p])
+        assert result == "line1\nline2", f"Expected 'line1\\nline2', got {result!r}"
+
+    def test_blank_paragraph_in_middle(self):
+        """<p>a</p><p><br></p><p>b</p> should extract as 'a\\n\\nb'.
+        The placeholder <br> block must be treated as empty, not as \\n.
+        (ChatGPT merge blocker: this was producing 'a\\n\\n\\nb'.)"""
+        children = [
+            _Node("P", children=[_Node(text="a")]),
+            _Node("P", children=[_Node("BR")]),  # placeholder
+            _Node("P", children=[_Node(text="b")]),
+        ]
+        result = _extract_composer(children)
+        assert result == "a\n\nb", f"Expected 'a\\n\\nb', got {result!r}"
+
+    def test_trailing_blank_paragraph(self):
+        """<p>hello</p><p><br></p> should extract as 'hello\\n'.
+        The trailing placeholder block becomes empty, joined with \\n."""
+        children = [
+            _Node("P", children=[_Node(text="hello")]),
+            _Node("P", children=[_Node("BR")]),
+        ]
+        result = _extract_composer(children)
+        assert result == "hello\n", f"Expected 'hello\\n', got {result!r}"
+
+    def test_consecutive_blank_paragraphs(self):
+        """<p>a</p><p><br></p><p><br></p><p>b</p> → 'a\\n\\n\\nb'"""
+        children = [
+            _Node("P", children=[_Node(text="a")]),
+            _Node("P", children=[_Node("BR")]),
+            _Node("P", children=[_Node("BR")]),
+            _Node("P", children=[_Node(text="b")]),
+        ]
+        result = _extract_composer(children)
+        assert result == "a\n\n\nb", f"Expected 'a\\n\\n\\nb', got {result!r}"
+
+    def test_inline_nesting_with_br(self):
+        """<p><span>line1</span><br><strong>line2</strong></p> → 'line1\\nline2'.
+        Nested inline wrappers should be handled correctly."""
+        p = _Node("P", children=[
+            _Node("SPAN", children=[_Node(text="line1")]),
+            _Node("BR"),
+            _Node("STRONG", children=[_Node(text="line2")]),
+        ])
+        result = _extract_composer([p])
+        assert result == "line1\nline2", f"Expected 'line1\\nline2', got {result!r}"
+
+    def test_single_line(self):
+        """<p>hello</p> → 'hello'"""
+        children = [_Node("P", children=[_Node(text="hello")])]
+        result = _extract_composer(children)
+        assert result == "hello"
+
+
+# ── Comparator tests (mocked extractor output) ───────────────────────────
+
+
+class TestComparatorDefects:
+    """Tests for the Python-side comparison logic (NFC, trailing newline tolerance)."""
 
     @pytest.mark.asyncio
     async def test_nfc_normalization_for_combining_accents(self):
-        """Defect 3 (confirmed): the verifier doesn't apply NFC normalization.
-        A combining-accent sequence (e.g., é as 'e' + U+0301) should match
-        the precomposed form (é = U+00E9). The turn-anchor matcher already
-        uses NFC; the verifier doesn't."""
-        # Precomposed é (what the user typed)
-        expected = "caf\u00e9"  # café
-        # Decomposed é (what ProseMirror might produce internally)
-        actual = "cafe\u0301"  # cafe + combining acute
-        # Verify they're NOT equal without NFC
+        """NFC: precomposed é (U+00E9) should match decomposed é (e + U+0301)."""
+        expected = "caf\u00e9"
+        actual = "cafe\u0301"
         assert expected != actual, "Precondition: without NFC these differ"
-        # The verifier SHOULD treat them as equal after NFC
         dom, driver = _make_dom(actual)
         result = await dom._verify_composer_text(
             'div[role="textbox"]#prompt-textarea', expected
         )
-        # With the fix (NFC applied), this should be True
-        assert result is True, (
-            "NFC normalization should make precomposed and decomposed forms equal"
-        )
+        assert result is True, "NFC should make precomposed and decomposed equal"
 
     @pytest.mark.asyncio
-    async def test_trailing_newline_not_stripped(self):
-        """Defect 4 (definite correctness bug): the OLD JS extractor stripped
-        one trailing \\n unconditionally. A prompt that legitimately ends in \\n
-        failed verification.
-
-        The fix: JS does NOT strip trailing newlines. The Python-side tolerance
-        handles editor-added trailing newlines (accepts actual == expected OR
-        actual == expected + \\n).
-
-        This test simulates what the NEW JS returns for input "hello\\n":
-        ProseMirror renders <p>hello</p><p><br></p>, the recursive extractor
-        returns "hello\\n" (no stripping). The Python comparison accepts it
-        because actual == expected."""
-        # What the FIXED JS returns (no trailing-newline strip)
+    async def test_trailing_newline_tolerated(self):
+        """A composer that adds one trailing newline (ProseMirror habit)
+        should still match the expected text."""
         dom, driver = _make_dom("hello\n")
         result = await dom._verify_composer_text(
             'div[role="textbox"]#prompt-textarea', "hello\n"
         )
-        assert result is True, (
-            "User's trailing newline should not cause verification failure"
-        )
+        assert result is True
 
     @pytest.mark.asyncio
     async def test_em_dash_and_curly_quotes_pass(self):
-        """Common agent content: em-dashes (—) and curly quotes (' ' " ")
-        should pass verification. These are NFC-stable so NFC doesn't change
-        them, but they should still round-trip correctly."""
+        """Em-dashes and curly quotes should round-trip correctly."""
         text = 'Here\u2019s a test \u2014 with \u201ccurly quotes\u201d and an em-dash.'
         dom, driver = _make_dom(text)
         result = await dom._verify_composer_text(
             'div[role="textbox"]#prompt-textarea', text
         )
-        assert result is True, (
-            "Em-dashes and curly quotes should pass verification"
-        )
-
-    @pytest.mark.asyncio
-    async def test_bounded_polling_not_fixed_delay(self):
-        """Defect 2 (medium-high confidence): the current code uses a fixed 500ms
-        delay after insertText, then one read. Under load, ProseMirror may not
-        have settled. The fix: poll with bounded retries.
-
-        This test verifies that _verify_composer_text is called AFTER type_message
-        has settled the DOM, not just once after a fixed delay. We test this
-        indirectly by checking that type_message eventually succeeds even when
-        the first read returns stale data."""
-        # We can't directly test the polling in _verify_composer_text (it's a
-        # single-shot read). The fix moves the polling INTO the verifier.
-        # For now, verify the structure: _verify_composer_text should accept
-        # multiple attempts via a polling loop.
-        pass  # Will be addressed when the fix implements polling
+        assert result is True

--- a/tests/test_conversation_guard.py
+++ b/tests/test_conversation_guard.py
@@ -311,7 +311,7 @@ async def test_mcp_auto_continue_invokes_ensure_current():
     driver.navigate_new_chat = AsyncMock()
     driver.navigate_conversation = AsyncMock()
 
-    async def _boom(text, timeout=120):
+    async def _boom(text, timeout=120, *, budgets=None, model=None):
         raise AssertionError("reached past the guard")
         yield  # pragma: no cover (generator signature)
     driver.send_and_stream = _boom

--- a/tests/test_conversation_guard.py
+++ b/tests/test_conversation_guard.py
@@ -196,10 +196,13 @@ async def test_navigate_conversation_sets_id_only_on_verified_landing():
     d = CDPDriver(cdp_port=9222)
     cid = "abc-123"
     d._cdp = AsyncMock()  # Page.navigate
-    # _js returns a ready state at the right URL on first poll.
-    d._js = AsyncMock(return_value=json.dumps({
-        "ready": True,
+    # P2: navigate_conversation now uses _js_strict with a staged probe.
+    # Return a ready state at the right URL on first poll.
+    d._js_strict = AsyncMock(return_value=json.dumps({
         "url": f"https://chatgpt.com/c/{cid}",
+        "ready_state": "complete",
+        "app_shell": True,
+        "composer": True,
     }))
     await d.navigate_conversation(cid)
     assert d._current_conv_id == cid
@@ -214,14 +217,20 @@ async def test_navigate_conversation_raises_and_clears_when_never_ready(monkeypa
     cid = "abc-123"
     d._current_conv_id = cid  # pre-existing (possibly stale) state
     d._cdp = AsyncMock()
-    # Composer never ready / never at the right URL.
-    d._js = AsyncMock(return_value=json.dumps({"ready": False, "url": ""}))
+    # P2: staged probe — composer never ready.
+    d._js_strict = AsyncMock(return_value=json.dumps({
+        "url": f"https://chatgpt.com/c/{cid}",
+        "ready_state": "complete",
+        "app_shell": True,
+        "composer": False,  # composer never appears
+    }))
     # Collapse the sleeps so the 30-iteration loop runs fast.
     async def _fast(_s):
         return None
     monkeypatch.setattr("chatgpt_web2api.cdp_driver.asyncio.sleep", _fast)
 
-    with pytest.raises(RuntimeError, match="did not reach a ready composer"):
+    # P2: error message now names the failed stage instead of the old opaque msg.
+    with pytest.raises(RuntimeError, match="composer"):
         await d.navigate_conversation(cid)
     assert d._current_conv_id is None  # stale id cleared, not admitted
 

--- a/tests/test_detector_budgets.py
+++ b/tests/test_detector_budgets.py
@@ -18,7 +18,6 @@ from chatgpt_web2api.completion_detector import (
     classify_model,
 )
 
-
 # ── classify_model ──────────────────────────────────────────────────────
 
 

--- a/tests/test_detector_budgets.py
+++ b/tests/test_detector_budgets.py
@@ -1,0 +1,121 @@
+"""Tests for P1 model-aware detector budgets (stall-aware detector).
+
+Co-designed with ChatGPT (conversation 6a4ebc1e, 2026-07-08). Replaces the
+single PHASE_STALL_SECONDS=90 with a model-aware, phase-substate-aware state
+machine: first-content-wait vs stream-idle, with longer first-content budgets
+for reasoning models that think silently before streaming.
+
+Covers:
+  - classify_model: maps a model slug to "reasoning" | "default"
+  - DetectorConfig: the 5-key config on ChatGPTConfig
+  - DetectorBudgets: resolved per-call budgets from config + model class
+"""
+
+import pytest
+
+from chatgpt_web2api.completion_detector import (
+    DetectorBudgets,
+    classify_model,
+)
+
+
+# ── classify_model ──────────────────────────────────────────────────────
+
+
+class TestClassifyModel:
+    """classify_model maps a ChatGPT web slug to a model class bucket."""
+
+    @pytest.mark.parametrize("slug", [
+        "gpt-5-4-thinking",
+        "gpt-5-5-thinking",
+        "gpt-5-4-t-mini",       # "Thinking Mini"
+        "o3",
+        "research",
+    ])
+    def test_reasoning_models_classified_as_reasoning(self, slug):
+        assert classify_model(slug) == "reasoning"
+
+    @pytest.mark.parametrize("slug", [
+        "gpt-5-5",
+        "gpt-5-5-instant",
+        "gpt-5-3",
+        "gpt-5-mini",
+        "gpt-5-5-mini",
+        "auto",
+        "gpt-5.5-wm",
+    ])
+    def test_non_reasoning_models_classified_as_default(self, slug):
+        assert classify_model(slug) == "default"
+
+    def test_unknown_model_defaults_to_default(self):
+        """An unrecognized slug is conservative — default budgets, not reasoning.
+        Reasoning budgets are longer, so defaulting an unknown model to 'default'
+        fails fast rather than holding a possibly-dead generation too long."""
+        assert classify_model("some-new-model-xyz") == "default"
+
+    def test_none_or_empty_defaults_to_default(self):
+        assert classify_model(None) == "default"
+        assert classify_model("") == "default"
+
+    def test_case_insensitive(self):
+        """Model slugs from the web are lowercase, but be robust."""
+        assert classify_model("GPT-5-5-Thinking") == "reasoning"
+        assert classify_model("O3") == "reasoning"
+
+
+# ── DetectorBudgets ─────────────────────────────────────────────────────
+
+
+class TestDetectorBudgets:
+    """DetectorBudgets holds the resolved per-call timeout values."""
+
+    def test_default_budgets_match_legacy_90s(self):
+        """A default-class model with default config should reproduce the old
+        90s behavior on both first-content and stream-idle — no behavior change
+        for non-reasoning models."""
+        budgets = DetectorBudgets.default()
+        assert budgets.first_content_timeout_seconds == 90
+        assert budgets.stream_idle_timeout_seconds == 90
+        assert budgets.hard_timeout_seconds == 900
+
+    def test_reasoning_budgets_have_longer_first_content(self):
+        """The core P1 fix: reasoning models get a longer first-content window
+        so their silent thinking phase isn't falsely aborted."""
+        budgets = DetectorBudgets.reasoning()
+        assert budgets.first_content_timeout_seconds > 90, (
+            "reasoning first-content must be longer than the legacy 90s"
+        )
+        assert budgets.first_content_timeout_seconds == 300
+
+    def test_reasoning_stream_idle_is_shorter_than_first_content(self):
+        """Once text has started streaming, a long idle IS suspicious — stream-idle
+        should be shorter than first-content for reasoning models."""
+        budgets = DetectorBudgets.reasoning()
+        assert budgets.stream_idle_timeout_seconds < budgets.first_content_timeout_seconds
+
+    def test_hard_cap_is_absolute_for_both_classes(self):
+        """The hard cap bounds total observation time regardless of DOM signals.
+        Both default and reasoning share the same cap."""
+        d = DetectorBudgets.default()
+        r = DetectorBudgets.reasoning()
+        assert d.hard_timeout_seconds == r.hard_timeout_seconds == 900
+
+    def test_from_config_default_model(self):
+        """Building budgets from config + a default-class model yields the
+        default first-content / stream-idle from config."""
+        from chatgpt_web2api.config import ChatGPTConfig
+
+        cfg = ChatGPTConfig()
+        budgets = DetectorBudgets.from_config(cfg, model="gpt-5-5")
+        assert budgets.first_content_timeout_seconds == cfg.detector_default_first_content_timeout_seconds
+        assert budgets.stream_idle_timeout_seconds == cfg.detector_default_stream_idle_timeout_seconds
+
+    def test_from_config_reasoning_model(self):
+        """Building budgets from config + a reasoning model yields the reasoning
+        first-content / stream-idle from config."""
+        from chatgpt_web2api.config import ChatGPTConfig
+
+        cfg = ChatGPTConfig()
+        budgets = DetectorBudgets.from_config(cfg, model="gpt-5-5-thinking")
+        assert budgets.first_content_timeout_seconds == cfg.detector_reasoning_first_content_timeout_seconds
+        assert budgets.stream_idle_timeout_seconds == cfg.detector_reasoning_stream_idle_timeout_seconds

--- a/tests/test_detector_phase2.py
+++ b/tests/test_detector_phase2.py
@@ -1,0 +1,338 @@
+"""Behavioral tests for P1 phase-2 two-state detector machine.
+
+These verify the core co-designed behavior (conversation 6a4ebc1e):
+
+  1. Reasoning first-content wait does NOT fail at the old 90s default — the
+     longer reasoning budget keeps the detector alive during the silent
+     thinking phase.
+  2. Stream-idle (text appeared then stopped) fails with its OWN budget,
+     shorter than first-content.
+  3. Hard cap wins over an active DOM liveness signal — no infinite waits.
+  4. Final reconciliation: if the turn completed in the backend, the detector
+     returns normally instead of raising (generation actually finished).
+  5. Structured error: phase-2 stalls carry stall_kind, model_class, elapsed
+     time, and liveness-signal fields.
+
+Timing is controlled via a fake clock to keep tests deterministic and fast.
+"""
+
+import asyncio
+import json
+import time
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from chatgpt_web2api.completion_detector import (
+    CompletionDetector,
+    DetectorBudgets,
+)
+from chatgpt_web2api.turn_anchor import TurnAnchor, TurnEndResult
+
+
+def _make_detector(budgets=None, conv_id="conv-1"):
+    """Detector backed by a mock driver. budgets defaults to reasoning (the
+    case the P1 fix targets)."""
+    driver = MagicMock()
+    driver._current_conv_id = conv_id
+    driver._js_strict = AsyncMock(return_value="")
+    driver._fetch_end_turn_for_turn = AsyncMock(return_value=TurnEndResult(status="not_ready"))
+    driver._get_live_conversation_id_best_effort = AsyncMock(return_value=conv_id or "")
+    detector = CompletionDetector(driver)
+    if budgets is not None:
+        detector._budgets_override = budgets
+    return detector, driver
+
+
+def _phase2_poll_payload(*, text="", md_text="", is_thinking=False,
+                         has_action=False, html_len=0, child_count=0):
+    """Build the JSON the phase-2 poll JS returns."""
+    return json.dumps({
+        "text": text, "md_text": md_text, "html_len": html_len,
+        "child_count": child_count, "has_action": has_action,
+        "is_thinking": is_thinking,
+    })
+
+
+class _ScriptedPoll:
+    """A scripted _js_strict that returns pre-set payloads per phase.
+
+    - body scan → always empty (no rate limit)
+    - assistant count → always "1" (exceeds initial_count=0, exits phase-1)
+    - phase-2 poll → call next() from a user-provided sequence
+    """
+
+    def __init__(self, poll_sequence):
+        self.scan = '{"text": ""}'
+        self.polls = list(poll_sequence)
+        self._idx = 0
+
+    async def __call__(self, expr):
+        if "getBoundingClientRect" in expr:
+            if self._idx < len(self.polls):
+                return self.polls[self._idx]
+            return self.polls[-1] if self.polls else _phase2_poll_payload()
+        if "innerText" in expr:
+            return self.scan
+        return "1"
+
+
+# ── 1. Reasoning first-content does NOT fail at 90s ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reasoning_first_content_survives_past_90s(monkeypatch):
+    """The core P1 fix: a reasoning model thinking silently for >90s must NOT
+    be falsely aborted. The reasoning first-content budget (300s default) keeps
+    the detector alive. With the old uniform 90s, this would have raised."""
+    budgets = DetectorBudgets.reasoning()  # first_content=300, stream_idle=120
+    detector, driver = _make_detector(budgets=budgets)
+
+    # Simulate: thinking indicator present, no text, for 100 polls (50s of
+    # "thinking" — well past the old 90s ceiling IF the clock were real, but
+    # we control the clock). We just need to confirm no stall raises at the
+    # old threshold. Use a fast-forward clock.
+    thinking_payload = _phase2_poll_payload(is_thinking=True)
+    script = _ScriptedPoll([thinking_payload])
+    driver._js_strict = script
+
+    # Fast-forward clock: control time.monotonic so 100s of "thinking" passes
+    # in real-time milliseconds. This proves the 90s boundary is gone for
+    # reasoning first-content.
+    t = [0.0]
+    original_sleep = asyncio.sleep
+
+    async def fast_sleep(d):
+        t[0] += d  # each 0.5s poll advances simulated time
+        await original_sleep(0)  # don't actually wait
+
+    monkeypatch.setattr(time, "monotonic", lambda: t[0])
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    # timeout is the overall wall-clock — set high enough that it doesn't fire
+    # before the first-content budget.
+    async def drain():
+        async for _ in detector.stream_until_complete(
+            initial_count=0, timeout=500,
+            turn_anchor=TurnAnchor(sent_text="test", mode="fresh_chat"),
+            budgets=budgets,
+        ):
+            pass
+
+    # Run for a bounded number of events then cancel — we just need to confirm
+    # it does NOT raise within the first 100s of simulated thinking. Each poll
+    # advances simulated time by 0.5s; let it run ~200 polls (100s simulated)
+    # via real-time yielding (no actual sleeping — fast_sleep does original_sleep(0)).
+    task = asyncio.create_task(drain())
+    # Let the task run enough event-loop ticks to advance simulated time past 90s.
+    # Each poll = one sleep(0) yield, so we need ~200 polls = ~200 iterations.
+    for _ in range(300):
+        await original_sleep(0)
+        if t[0] > 100:
+            break
+    # If the detector raised, task.exception() will hold it.
+    exc = task.exception() if task.done() else None
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+    if exc and "GenerationStuckError" in type(exc).__name__:
+        pytest.fail(f"Reasoning model falsely aborted during thinking phase: {exc}")
+
+    # Confirm simulated time advanced past the old 90s ceiling without abort
+    assert t[0] > 90, f"Expected simulated time >90s, got {t[0]}"
+
+
+# ── 2. Stream-idle fails with its own (shorter) budget ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_stream_idle_uses_shorter_budget_after_first_content(monkeypatch):
+    """Once text has appeared and then stopped progressing, the stream-idle
+    budget applies — which is shorter than first-content for reasoning models.
+    Verify the stall_kind is 'stream_idle_timeout', not 'first_content_timeout'."""
+    from chatgpt_web2api.cdp_driver import GenerationStuckError
+
+    budgets = DetectorBudgets(
+        first_content_timeout_seconds=300,  # long
+        stream_idle_timeout_seconds=5,       # short — will fire fast
+        hard_timeout_seconds=900,
+    )
+    detector, driver = _make_detector(budgets=budgets)
+
+    # First poll: text appears (exits first-content state). Then: text stops.
+    polls = [
+        _phase2_poll_payload(text="Hello", md_text="Hello"),
+        _phase2_poll_payload(text="Hello", md_text="Hello"),  # no progress
+    ] * 50  # repeat to keep polling
+    script = _ScriptedPoll(polls)
+    driver._js_strict = script
+    driver._fetch_end_turn_for_turn = AsyncMock(
+        return_value=TurnEndResult(status="not_ready")
+    )
+
+    t = [0.0]
+    original_sleep = asyncio.sleep
+
+    async def fast_sleep(d):
+        t[0] += d
+        await original_sleep(0)
+
+    monkeypatch.setattr(time, "monotonic", lambda: t[0])
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    with pytest.raises(GenerationStuckError) as exc_info:
+        async for _ in detector.stream_until_complete(
+            initial_count=0, timeout=500,
+            turn_anchor=TurnAnchor(sent_text="test", mode="fresh_chat"),
+            budgets=budgets,
+        ):
+            pass
+
+    # The stall should be classified as stream_idle (text appeared then stopped)
+    assert exc_info.value.phase == "phase_2_stream"
+    assert getattr(exc_info.value, "stall_kind", None) == "stream_idle_timeout", (
+        f"Expected stall_kind='stream_idle_timeout', got {getattr(exc_info.value, 'stall_kind', None)}"
+    )
+
+
+# ── 3. Hard cap wins over active DOM signal ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hard_cap_wins_over_dom_liveness(monkeypatch):
+    """Even if the DOM shows a thinking/generating indicator forever, the hard
+    cap must eventually fire. No infinite waits."""
+    from chatgpt_web2api.cdp_driver import GenerationStuckError
+
+    budgets = DetectorBudgets(
+        first_content_timeout_seconds=300,
+        stream_idle_timeout_seconds=300,
+        hard_timeout_seconds=10,  # very short hard cap
+    )
+    detector, driver = _make_detector(budgets=budgets)
+
+    # DOM shows thinking indicator forever, never produces text
+    script = _ScriptedPoll([_phase2_poll_payload(is_thinking=True)])
+    driver._js_strict = script
+
+    t = [0.0]
+    original_sleep = asyncio.sleep
+
+    async def fast_sleep(d):
+        t[0] += d
+        await original_sleep(0)
+
+    monkeypatch.setattr(time, "monotonic", lambda: t[0])
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    with pytest.raises(GenerationStuckError):
+        async for _ in detector.stream_until_complete(
+            initial_count=0, timeout=500,
+            turn_anchor=TurnAnchor(sent_text="test", mode="fresh_chat"),
+            budgets=budgets,
+        ):
+            pass
+
+    # The hard cap (10s simulated) should have fired, not the first-content (300s)
+    assert t[0] >= 10, f"Hard cap should have fired around 10s, got t={t[0]}"
+    assert t[0] < 300, "first-content budget should NOT have been the one to fire"
+
+
+# ── 4. Final reconciliation success returns normally ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_final_reconciliation_success_returns_normally(monkeypatch):
+    """When the phase-2 stall fires but final reconciliation finds the turn DID
+    complete in the backend, the detector returns normally instead of raising.
+    This is the field-verified case: 'generation completed after detector gave up.'"""
+    budgets = DetectorBudgets(
+        first_content_timeout_seconds=5,  # short to trigger stall fast
+        stream_idle_timeout_seconds=5,
+        hard_timeout_seconds=900,
+    )
+    detector, driver = _make_detector(budgets=budgets)
+
+    # Phase-2: no text, no thinking indicator → stall fires quickly.
+    script = _ScriptedPoll([_phase2_poll_payload()])
+    driver._js_strict = script
+
+    t = [0.0]
+    original_sleep = asyncio.sleep
+
+    async def fast_sleep(d):
+        t[0] += d
+        await original_sleep(0)
+
+    monkeypatch.setattr(time, "monotonic", lambda: t[0])
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    # Final reconciliation: backend says the turn completed
+    driver._fetch_end_turn_for_turn = AsyncMock(
+        return_value=TurnEndResult(status="matched")
+    )
+
+    chunks = []
+    # This should NOT raise — reconciliation finds the completed turn.
+    async for chunk in detector.stream_until_complete(
+        initial_count=0, timeout=500,
+        turn_anchor=TurnAnchor(sent_text="test", mode="fresh_chat"),
+        budgets=budgets,
+    ):
+        chunks.append(chunk)
+
+    # No exception — the detector returned normally after reconciliation.
+    # (If we got here, the test passes. If reconciliation had failed, a
+    # GenerationStuckError would have been raised.)
+
+
+# ── 5. Structured error fields ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_structured_stall_error_has_diagnostic_fields(monkeypatch):
+    """Phase-2 stall errors carry structured fields for observability:
+    stall_kind, model_class, elapsed_seconds, generation_active_signal."""
+    from chatgpt_web2api.cdp_driver import GenerationStuckError
+
+    budgets = DetectorBudgets(
+        first_content_timeout_seconds=5,
+        stream_idle_timeout_seconds=5,
+        hard_timeout_seconds=900,
+    )
+    detector, driver = _make_detector(budgets=budgets)
+
+    # No text, no thinking, no progress → first_content_timeout stall
+    script = _ScriptedPoll([_phase2_poll_payload()])
+    driver._js_strict = script
+    driver._fetch_end_turn_for_turn = AsyncMock(
+        return_value=TurnEndResult(status="not_ready")
+    )
+
+    t = [0.0]
+    original_sleep = asyncio.sleep
+
+    async def fast_sleep(d):
+        t[0] += d
+        await original_sleep(0)
+
+    monkeypatch.setattr(time, "monotonic", lambda: t[0])
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    with pytest.raises(GenerationStuckError) as exc_info:
+        async for _ in detector.stream_until_complete(
+            initial_count=0, timeout=500,
+            turn_anchor=TurnAnchor(sent_text="test", mode="fresh_chat"),
+            budgets=budgets,
+            model="gpt-5-5-thinking",
+        ):
+            pass
+
+    err = exc_info.value
+    assert err.phase == "phase_2_stream"
+    assert getattr(err, "stall_kind", None) == "first_content_timeout"
+    assert getattr(err, "model_class", None) == "reasoning"
+    assert hasattr(err, "elapsed_seconds"), "error must carry elapsed_seconds"
+    assert hasattr(err, "generation_active_signal"), "error must carry generation_active_signal"

--- a/tests/test_detector_phase2.py
+++ b/tests/test_detector_phase2.py
@@ -19,9 +19,9 @@ Timing is controlled via a fake clock to keep tests deterministic and fast.
 import asyncio
 import json
 import time
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
 
 from chatgpt_web2api.completion_detector import (
     CompletionDetector,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -43,7 +43,7 @@ def make_mock_driver():
     driver.is_connected = True
     driver._access_token = "test-token"
 
-    async def _stream(text, timeout=120):
+    async def _stream(text, timeout=120, *, budgets=None, model=None):
         yield StreamChunk(delta="Mocked ChatGPT response")
         yield StreamChunk(delta="", finish_reason="stop")
 

--- a/tests/test_mcp_rate_limit.py
+++ b/tests/test_mcp_rate_limit.py
@@ -33,7 +33,7 @@ def _make_server_with_raising_driver(raises: Exception | None):
     driver._current_conv_id = ""
     driver._current_model = None
 
-    async def _stream(text, timeout=120):
+    async def _stream(text, timeout=120, *, budgets=None, model=None):
         if raises is not None:
             raise raises
         from chatgpt_web2api.cdp_driver import StreamChunk
@@ -110,7 +110,7 @@ async def test_mcp_chat_transient_rate_limit_retries_transparently(monkeypatch):
 
     attempts = {"n": 0}
 
-    async def _stream(text, timeout=120):
+    async def _stream(text, timeout=120, *, budgets=None, model=None):
         attempts["n"] += 1
         if attempts["n"] == 1:
             raise RateLimitError(retry_after=1)

--- a/tests/test_navigation_readiness.py
+++ b/tests/test_navigation_readiness.py
@@ -219,7 +219,6 @@ async def test_navigate_fast_fails_on_url_displacement(monkeypatch):
 async def test_navigate_waits_for_document_ready(monkeypatch):
     """When readyState='loading', the poll should wait, not count against
     the stall budget. This tests the document.readyState check."""
-    import time
 
     driver = CDPDriver(cdp_port=9222)
     driver._cdp = AsyncMock()

--- a/tests/test_navigation_readiness.py
+++ b/tests/test_navigation_readiness.py
@@ -174,10 +174,13 @@ async def test_navigate_fast_fails_on_url_displacement(monkeypatch):
     driver = CDPDriver(cdp_port=9222)
     driver._cdp = AsyncMock()
 
-    # First poll: URL is correct (still loading). Second poll: URL displaced.
+    # First poll: URL is correct (still loading). Then 2 displaced polls
+    # (debounce requires 2 consecutive wrong polls per ChatGPT review finding B).
     polls = [
         _probe_payload(url="https://chatgpt.com/c/conv-123", ready_state="loading",
                        app_shell=False, composer=False),
+        _probe_payload(url="https://chatgpt.com/c/DIFFERENT",
+                       ready_state="complete", app_shell=True, composer=True),
         _probe_payload(url="https://chatgpt.com/c/DIFFERENT",
                        ready_state="complete", app_shell=True, composer=True),
     ]

--- a/tests/test_navigation_readiness.py
+++ b/tests/test_navigation_readiness.py
@@ -1,0 +1,240 @@
+"""P2: Navigation staged readiness tests.
+
+Replaces the opaque "ready composer" poll with a diagnosable staged probe.
+Co-designed with ChatGPT (vision-alignment cycle, conversation 6a4ebb2a).
+
+The probe splits the readiness check into stages:
+  url_correct → document_ready → app_shell_present → composer_present
+
+Each stage's result is captured so that when the poll fails, the error
+message says WHICH stage failed (instead of the current opaque "did not
+reach a ready composer within the timeout").
+
+Also adds:
+  - Fast-fail on URL displacement (nav_displaced error)
+  - document.readyState check (don't fail while page is still loading)
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.cdp_driver import CDPDriver, NavigationReadinessProbe
+
+
+def _probe_payload(*, url="https://chatgpt.com/c/conv-123",
+                   ready_state="complete", app_shell=True,
+                   composer=True):
+    """Build the JSON the staged probe JS returns."""
+    return json.dumps({
+        "url": url,
+        "ready_state": ready_state,
+        "app_shell": app_shell,
+        "composer": composer,
+    })
+
+
+# ── NavigationReadinessProbe ─────────────────────────────────────────────
+
+
+class TestNavigationReadinessProbe:
+    """The probe dataclass carries all stage results for diagnostics."""
+
+    def test_all_stages_pass_when_everything_ready(self):
+        probe = NavigationReadinessProbe(
+            url="https://chatgpt.com/c/conv-123",
+            ready_state="complete",
+            app_shell_present=True,
+            composer_present=True,
+        )
+        assert probe.is_ready(url_correct=True) is True
+
+    def test_not_ready_when_composer_missing(self):
+        """The key P2 case: URL correct, document loaded, app shell present,
+        but composer selector didn't match (React still hydrating)."""
+        probe = NavigationReadinessProbe(
+            url="https://chatgpt.com/c/conv-123",
+            ready_state="complete",
+            app_shell_present=True,
+            composer_present=False,
+        )
+        assert probe.is_ready(url_correct=True) is False
+
+    def test_not_ready_when_url_wrong(self):
+        probe = NavigationReadinessProbe(
+            url="https://chatgpt.com/c/WRONG",
+            ready_state="complete",
+            app_shell_present=True,
+            composer_present=True,
+        )
+        assert probe.is_ready(url_correct=False) is False
+
+    def test_not_ready_when_document_loading(self):
+        """Page still loading — don't fail, just report not ready."""
+        probe = NavigationReadinessProbe(
+            url="https://chatgpt.com/c/conv-123",
+            ready_state="loading",
+            app_shell_present=False,
+            composer_present=False,
+        )
+        assert probe.is_ready(url_correct=True) is False
+
+    def test_diagnostic_summary_includes_failed_stage(self):
+        """The probe can describe WHICH stage failed for the error message."""
+        probe = NavigationReadinessProbe(
+            url="https://chatgpt.com/c/conv-123",
+            ready_state="complete",
+            app_shell_present=True,
+            composer_present=False,
+        )
+        summary = probe.diagnostic_summary(url_correct=True)
+        assert "composer" in summary.lower(), (
+            f"diagnostic summary should name the failed stage, got: {summary}"
+        )
+
+    def test_diagnostic_summary_when_url_displaced(self):
+        """When the URL moved away from target, the summary names displacement."""
+        probe = NavigationReadinessProbe(
+            url="https://chatgpt.com/c/DIFFERENT",
+            ready_state="complete",
+            app_shell_present=True,
+            composer_present=True,
+        )
+        summary = probe.diagnostic_summary(url_correct=False)
+        assert "url" in summary.lower() or "displac" in summary.lower(), (
+            f"diagnostic summary should flag URL mismatch, got: {summary}"
+        )
+
+
+# ── navigate_conversation uses the staged probe ──────────────────────────
+
+
+def _make_driver():
+    """A CDPDriver with a mock transport for testing."""
+    driver = MagicMock(spec=CDPDriver)
+    driver._cdp = AsyncMock()
+    driver._js_strict = AsyncMock(return_value="{}")
+    driver._js = AsyncMock(return_value="")
+    driver._current_conv_id = None
+    driver._is_url_at_conversation = CDPDriver._is_url_at_conversation
+    return driver
+
+
+@pytest.mark.asyncio
+async def test_navigate_succeeds_when_all_stages_pass(monkeypatch):
+    """When all readiness stages pass, navigate_conversation completes
+    without raising and sets _current_conv_id."""
+    driver = CDPDriver(cdp_port=9222)
+    driver._cdp = AsyncMock()
+    driver._js_strict = AsyncMock(return_value=_probe_payload())
+
+    await driver.navigate_conversation("conv-123")
+    assert driver._current_conv_id == "conv-123"
+
+
+@pytest.mark.asyncio
+async def test_navigate_fails_with_diagnostic_on_composer_missing(monkeypatch):
+    """When the composer is never found but everything else loads, the error
+    message names the failed stage ('composer'), not just 'timeout'."""
+    import time
+
+    driver = CDPDriver(cdp_port=9222)
+    driver._cdp = AsyncMock()
+    # URL correct, doc loaded, app shell present, but composer never appears.
+    driver._js_strict = AsyncMock(return_value=_probe_payload(composer=False))
+
+    t = [0.0]
+
+    _real_sleep = asyncio.sleep
+
+    async def fast_sleep(d):
+        t[0] += d
+        await _real_sleep(0)
+
+    monkeypatch.setattr(time, "monotonic", lambda: t[0])
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await driver.navigate_conversation("conv-123")
+
+    msg = str(exc_info.value)
+    assert "composer" in msg.lower(), (
+        f"error should name the failed stage 'composer', got: {msg}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_navigate_fast_fails_on_url_displacement(monkeypatch):
+    """If the URL moves AWAY from the target mid-poll, fail fast with a
+    distinct error (nav_displaced), don't burn the full 15s."""
+    import time
+
+    driver = CDPDriver(cdp_port=9222)
+    driver._cdp = AsyncMock()
+
+    # First poll: URL is correct (still loading). Second poll: URL displaced.
+    polls = [
+        _probe_payload(url="https://chatgpt.com/c/conv-123", ready_state="loading",
+                       app_shell=False, composer=False),
+        _probe_payload(url="https://chatgpt.com/c/DIFFERENT",
+                       ready_state="complete", app_shell=True, composer=True),
+    ]
+    call_count = {"n": 0}
+
+    async def fake_js(expr, timeout=15):
+        idx = min(call_count["n"], len(polls) - 1)
+        call_count["n"] += 1
+        return polls[idx]
+
+    driver._js_strict = fake_js
+
+    t = [0.0]
+
+    _real_sleep = asyncio.sleep
+
+    async def fast_sleep(d):
+        t[0] += d
+        await _real_sleep(0)
+
+    monkeypatch.setattr(time, "monotonic", lambda: t[0])
+    monkeypatch.setattr(asyncio, "sleep", fast_sleep)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await driver.navigate_conversation("conv-123")
+
+    msg = str(exc_info.value)
+    assert "displac" in msg.lower(), (
+        f"error should mention displacement, got: {msg}"
+    )
+    # Should NOT have burned the full 15s — fast-fail.
+    assert t[0] < 15, f"fast-fail should not wait 15s, got t={t[0]}"
+
+
+@pytest.mark.asyncio
+async def test_navigate_waits_for_document_ready(monkeypatch):
+    """When readyState='loading', the poll should wait, not count against
+    the stall budget. This tests the document.readyState check."""
+    import time
+
+    driver = CDPDriver(cdp_port=9222)
+    driver._cdp = AsyncMock()
+
+    # First 3 polls: loading. Then: complete + composer present.
+    loading = _probe_payload(ready_state="loading", app_shell=False, composer=False)
+    ready = _probe_payload(ready_state="complete", app_shell=True, composer=True)
+    polls = [loading, loading, loading, ready]
+    call_count = {"n": 0}
+
+    async def fake_js(expr, timeout=15):
+        idx = min(call_count["n"], len(polls) - 1)
+        call_count["n"] += 1
+        return polls[idx]
+
+    driver._js_strict = fake_js
+
+    await driver.navigate_conversation("conv-123")
+    assert driver._current_conv_id == "conv-123"
+    # Should have polled at least 4 times (3 loading + 1 ready).
+    assert call_count["n"] >= 4

--- a/tests/test_owned_mode_no_adopt.py
+++ b/tests/test_owned_mode_no_adopt.py
@@ -45,7 +45,7 @@ async def test_connect_owned_mode_does_not_fall_back_to_find_page_ws():
     # Make _create_owned_tab fail
     driver._create_owned_tab = AsyncMock(side_effect=RuntimeError("Chrome refused"))
 
-    with pytest.raises(RuntimeError, match="shared-tab fallback is disabled in owned mode"):
+    with pytest.raises(Exception, match="shared-tab fallback is disabled in owned mode"):
         await driver.connect()
 
     # _find_page_ws must NOT have been called

--- a/tests/test_owned_mode_no_adopt.py
+++ b/tests/test_owned_mode_no_adopt.py
@@ -11,7 +11,6 @@ These tests verify that in owned mode:
   3. adopt mode still falls back (the legacy behavior is preserved)
 """
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/test_owned_mode_no_adopt.py
+++ b/tests/test_owned_mode_no_adopt.py
@@ -1,0 +1,124 @@
+"""Tests: owned-mode never adopts an arbitrary tab.
+
+The adopt fallback (_find_page_ws / _adopt_existing_chatgpt_tab) picks ANY
+chatgpt.com tab from /json/list without checking ownership. In a multi-process
+setup (REST bridge + SSE server), this can steal another process's tab,
+causing two drivers to race on the same DOM.
+
+These tests verify that in owned mode:
+  1. connect() does NOT fall back to _find_page_ws when tab creation fails
+  2. _reconnect() does NOT fall back to _find_page_ws when it can't find/create a tab
+  3. adopt mode still falls back (the legacy behavior is preserved)
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from chatgpt_web2api.cdp_driver import CDPDriver
+
+
+def _make_driver(tab_mode="owned", parallel_tabs=False):
+    """Build a CDPDriver with mocked transport for testing."""
+    driver = CDPDriver(cdp_port=9222, tab_mode=tab_mode, parallel_tabs=parallel_tabs)
+    driver._browser_cdp = AsyncMock()
+    driver._find_page_ws = AsyncMock(return_value="ws://stolen-tab")
+    driver._find_owned_tab_ws = MagicMock(return_value=None)
+    driver._adopt_existing_chatgpt_tab = MagicMock(return_value=None)
+    driver._tab_registry = None  # skip registry reclaim
+    driver._wait_for_chatgpt_ready = AsyncMock(return_value=True)
+    driver._refresh_token = AsyncMock()
+    driver._attach_identity_listener = AsyncMock()
+    driver._breakers = None
+    return driver
+
+
+# ── 1. connect() does not adopt in owned mode ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_connect_owned_mode_does_not_fall_back_to_find_page_ws():
+    """When tab creation fails in owned mode, connect must NOT call _find_page_ws.
+    It should raise instead — never steal another process's tab."""
+    driver = _make_driver(tab_mode="owned")
+    # Make _create_owned_tab fail
+    driver._create_owned_tab = AsyncMock(side_effect=RuntimeError("Chrome refused"))
+
+    with pytest.raises(RuntimeError, match="shared-tab fallback is disabled in owned mode"):
+        await driver.connect()
+
+    # _find_page_ws must NOT have been called
+    driver._find_page_ws.assert_not_called()
+
+
+# ── 2. connect() still falls back in adopt mode ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_connect_adopt_mode_still_falls_back():
+    """Adopt mode preserves the legacy fallback to _find_page_ws."""
+    driver = _make_driver(tab_mode="adopt")
+    driver._create_owned_tab = AsyncMock(side_effect=RuntimeError("Chrome refused"))
+
+    # Should fall back to _find_page_ws, not raise
+    # Need to mock the websocket connect too
+    with patch("chatgpt_web2api.cdp_driver.websockets.connect") as mock_ws:
+        mock_ws.return_value = MagicMock()
+        try:
+            await driver.connect()
+        except Exception:
+            pass  # may fail later in connect, but the key assertion is below
+
+    # _find_page_ws WAS called (the legacy fallback)
+    driver._find_page_ws.assert_called()
+
+
+# ── 3. reconnect does not adopt in owned mode ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconnect_owned_mode_does_not_fall_back_to_find_page_ws():
+    """When reconnect can't find or create a tab in owned mode, it must NOT
+    call _find_page_ws. It should raise instead."""
+    driver = _make_driver(tab_mode="owned")
+    driver._target_id = "OLD-TAB-ID"  # had a tab, now gone
+    driver._ws = None  # no dead socket to close
+    driver._reader_task = None  # no reader to cancel
+    driver._pending = {}  # no pending messages
+    # _find_owned_tab_ws returns None (tab gone) — already set in _make_driver
+    # _create_owned_tab fails
+    driver._create_owned_tab = AsyncMock(side_effect=RuntimeError("Chrome refused"))
+
+    with pytest.raises(Exception, match="shared-tab fallback is disabled in owned mode"):
+        await driver.reconnect()
+
+    driver._find_page_ws.assert_not_called()
+
+
+# ── 4. reconnect creates new tab when owned tab is gone ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconnect_owned_mode_creates_new_tab_when_old_gone():
+    """When the old owned tab is gone, reconnect should create a NEW tab,
+    not adopt an existing one."""
+    driver = _make_driver(tab_mode="owned")
+    driver._target_id = "OLD-TAB-ID"
+    driver._ws = None
+    driver._reader_task = None
+    driver._pending = {}
+    # _find_owned_tab_ws returns None (tab gone)
+    driver._create_owned_tab = AsyncMock(return_value="ws://new-tab")
+
+    with patch("chatgpt_web2api.cdp_driver.websockets.connect") as mock_ws:
+        mock_ws.return_value = MagicMock()
+        try:
+            await driver.reconnect()
+        except Exception:
+            pass
+
+    # _create_owned_tab was called (created a new tab, not adopted)
+    driver._create_owned_tab.assert_called()
+    # _find_page_ws was NOT called
+    driver._find_page_ws.assert_not_called()

--- a/tests/test_pool_closing_slot_race.py
+++ b/tests/test_pool_closing_slot_race.py
@@ -1,0 +1,98 @@
+"""Regression test: closing-slot replacement race (ChatGPT review, conv 6a52a623).
+
+When the idle sweeper is closing a slot and the same session makes a new request
+before the close finishes, the pool creates a replacement slot for the same
+session key. But when the old close finishes, the sweeper unconditionally
+discards the session key from _active_keys — even though the replacement is live.
+
+This test verifies the fix:
+  1. The sweeper only discards _active_keys when the closing slot IS still the
+     current mapping (identity check extends to _active_keys).
+  2. A session that reacquires while its old slot is closing does not lose
+     capacity accounting.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.config import Config
+from chatgpt_web2api.mcp_driver_pool import McpSessionDriverPool
+
+
+def _make_pool(max_size=2, ttl=0.01, sweep_interval=0.1):
+    """Build a pool with a fake driver factory. TTL is very short so the
+    sweeper closes idle slots almost immediately. Sweep interval is short
+    so the sweeper runs quickly."""
+    cfg = Config()
+    cfg.chatgpt.mcp_session_pool_size = max_size
+    cfg.chatgpt.mcp_session_pool_acquire_timeout = 5.0
+    cfg.chatgpt.mcp_session_pool_ttl_seconds = ttl
+    cfg.chatgpt.mcp_session_pool_sweep_interval_seconds = sweep_interval
+
+    close_events = []
+
+    async def fake_factory(config, transport, port, slot):
+        driver = MagicMock()
+        # Make close slow so we can interleave a reacquisition
+        async def slow_close():
+            close_events.append(("close_start", slot.session_key))
+            await asyncio.sleep(0.5)
+            close_events.append(("close_done", slot.session_key))
+
+        driver.close = slow_close
+        driver._current_conv_id = None
+        return driver
+
+    pool = McpSessionDriverPool(cfg, driver_factory=fake_factory)
+    return pool, close_events
+
+
+@pytest.mark.asyncio
+async def test_reacquire_during_close_does_not_lose_capacity():
+    """When a session reacquires while its old slot is closing, the replacement
+    slot must remain in _active_keys after the old close completes.
+
+    ChatGPT found that the sweeper unconditionally discards _active_keys even
+    when the slot is no longer the current mapping. This test reproduces that
+    race: with pool_size=2, session A acquires, goes idle (sweeper starts
+    closing), then reacquires before close finishes. After the old close
+    completes, session A's replacement must still be in _active_keys.
+    """
+    pool, close_events = _make_pool(max_size=2, ttl=0.01)
+
+    try:
+        # Session A acquires a slot.
+        async with pool.acquire("session-A"):
+            pass  # Release immediately → slot goes idle
+
+        # Start the sweeper — it checks every 0.1s, TTL is 0.01s, so the
+        # first sweep at ~0.1s will mark the slot closing and start slow_close.
+        await pool.start_sweeper()
+
+        # Wait long enough for the sweeper to mark the slot closing AND start
+        # the slow driver.close() (which takes 0.5s).
+        await asyncio.sleep(0.2)
+
+        # At this point the old slot should be closing=True and driver.close()
+        # should be in progress. Session A reacquires.
+        async with pool.acquire("session-A") as lease:
+            assert lease is not None
+            # While holding the replacement, wait for the old close to finish.
+            await asyncio.sleep(1.0)
+
+        # After the old close is done, session-A's replacement must still be
+        # tracked in _active_keys. If the sweeper discarded it unconditionally
+        # (the bug), _active_keys would be empty and capacity accounting is wrong.
+        assert "session-A" in pool._active_keys, (
+            "Replacement slot lost from _active_keys after old close completed — "
+            "the sweeper discarded it unconditionally (the race ChatGPT found)"
+        )
+
+        # Verify capacity is correct: the replacement should count against the cap.
+        # A new session should still be able to acquire (pool_size=2, one slot used).
+        async with pool.acquire("session-B"):
+            assert "session-B" in pool._active_keys
+    finally:
+        await pool.close_all()

--- a/tests/test_pool_closing_slot_race.py
+++ b/tests/test_pool_closing_slot_race.py
@@ -13,7 +13,7 @@ This test verifies the fix:
 """
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_pool_lease_accounting.py
+++ b/tests/test_pool_lease_accounting.py
@@ -1,0 +1,169 @@
+"""P1.5: Pool lease accounting instrumentation.
+
+Purely additive diagnostics — no behavioral change to pool logic. Tracks
+each lease's lifecycle (acquire → release) so the next field session and the
+pool-exhaustion RCA have attributable data.
+
+Verifies:
+  1. Lease acquire creates a record with lease_id, session_key, timestamp.
+  2. Lease release records duration + release_reason (normal/exception/cancel).
+  3. PoolExhaustedError includes an active-lease dump.
+  4. Double-release is detected and logged (not silently swallowed).
+  5. status() includes lease accounting summary.
+"""
+
+import asyncio
+import logging
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.config import Config
+from chatgpt_web2api.mcp_driver_pool import (
+    McpSessionDriverPool,
+    PoolExhaustedError,
+)
+
+
+def _make_pool(max_size=2, **overrides):
+    """Build a pool with a fake driver factory for fast tests."""
+    cfg = Config()
+    cfg.chatgpt.mcp_session_pool_size = max_size
+    cfg.chatgpt.mcp_session_pool_acquire_timeout = 2.0
+    for k, v in overrides.items():
+        setattr(cfg.chatgpt, k, v)
+
+    async def fake_factory(config, transport, port, slot):
+        driver = MagicMock()
+        driver.close = AsyncMock()
+        driver._current_conv_id = None
+        return driver
+
+    pool = McpSessionDriverPool(cfg, driver_factory=fake_factory)
+    return pool
+
+
+# ── 1. Lease acquire creates a record ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_acquire_creates_lease_record():
+    """Acquiring a lease creates a record with lease_id, session_key, timestamp."""
+    pool = _make_pool(max_size=2)
+    try:
+        async with pool.acquire("session-1") as lease:
+            # The pool should have exactly one active lease record.
+            assert len(pool.active_leases) == 1, (
+                f"expected 1 active lease, got {len(pool.active_leases)}"
+            )
+            record = list(pool.active_leases.values())[0]
+            assert record.session_key == "session-1"
+            assert record.lease_id  # non-empty ID
+            assert record.acquired_at > 0
+    finally:
+        await pool.close_all()
+
+
+# ── 2. Lease release records duration + reason ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_release_records_duration_and_normal_reason():
+    """On normal release, the record has released_at set and reason='normal'."""
+    pool = _make_pool()
+    try:
+        async with pool.acquire("session-1"):
+            pass  # normal exit
+        # Lease was released; active_leases should be empty.
+        assert len(pool.active_leases) == 0
+        # History should have the released record.
+        assert len(pool.lease_history) >= 1
+        rec = pool.lease_history[-1]
+        assert rec.released_at is not None
+        assert rec.release_reason == "normal"
+        assert rec.hold_duration_s is not None
+        assert rec.hold_duration_s >= 0
+    finally:
+        await pool.close_all()
+
+
+@pytest.mark.asyncio
+async def test_release_records_exception_reason():
+    """On exception exit, the release reason is 'exception', not 'normal'."""
+    pool = _make_pool()
+    try:
+        with pytest.raises(ValueError):
+            async with pool.acquire("session-1"):
+                raise ValueError("test error")
+        rec = pool.lease_history[-1]
+        assert rec.release_reason == "exception"
+    finally:
+        await pool.close_all()
+
+
+# ── 3. PoolExhaustedError includes active-lease dump ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_includes_active_lease_dump():
+    """When the pool is exhausted, the error message includes info about
+    what leases are currently active (session keys, hold durations, in_flight)."""
+    pool = _make_pool(max_size=1)
+    try:
+        # Hold one lease to fill the pool.
+        async with pool.acquire("session-1"):
+            # Try to acquire a second — should exhaust.
+            with pytest.raises(PoolExhaustedError) as exc_info:
+                async with pool.acquire("session-2"):
+                    pass
+            msg = str(exc_info.value)
+            # The error should mention the active session holding the slot.
+            assert "session-1" in msg, (
+                f"exhaustion error should include active lease dump, got: {msg}"
+            )
+    finally:
+        await pool.close_all()
+
+
+# ── 4. Double-release detection ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_double_release_detected(caplog):
+    """Releasing a lease that's already released logs a warning (double-release bug)."""
+    pool = _make_pool()
+    try:
+        lease_ctx = pool.acquire("session-1")
+        async with lease_ctx as lease:
+            pass  # normal release
+        # Manually call _release again on the same slot with the same lease_id
+        # (simulates a double-release bug where the lease is released twice).
+        with caplog.at_level(logging.WARNING):
+            await pool._release(lease.slot, lease_id=lease.lease_id, release_reason="normal")
+        assert any("double" in r.message.lower() or "already released" in r.message.lower()
+                      for r in caplog.records), (
+            "double-release should log a warning"
+        )
+    finally:
+        await pool.close_all()
+
+
+# ── 5. status() includes lease summary ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_status_includes_lease_accounting():
+    """status() should include lease counts (active + history)."""
+    pool = _make_pool()
+    try:
+        async with pool.acquire("session-1"):
+            pass
+        s = pool.status()
+        assert "leases" in s, "status() should include lease accounting"
+        lease_info = s["leases"]
+        assert "active_count" in lease_info
+        assert "history_count" in lease_info
+        assert lease_info["history_count"] >= 1
+    finally:
+        await pool.close_all()

--- a/tests/test_pool_lease_accounting.py
+++ b/tests/test_pool_lease_accounting.py
@@ -12,9 +12,7 @@ Verifies:
   5. status() includes lease accounting summary.
 """
 
-import asyncio
 import logging
-import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -52,7 +50,7 @@ async def test_acquire_creates_lease_record():
     """Acquiring a lease creates a record with lease_id, session_key, timestamp."""
     pool = _make_pool(max_size=2)
     try:
-        async with pool.acquire("session-1") as lease:
+        async with pool.acquire("session-1"):
             # The pool should have exactly one active lease record.
             assert len(pool.active_leases) == 1, (
                 f"expected 1 active lease, got {len(pool.active_leases)}"

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -27,7 +27,7 @@ def _streaming_driver(deltas):
     driver.navigate_conversation = AsyncMock()
     driver.navigate_gpt = AsyncMock()
 
-    async def _stream(text, timeout=120):
+    async def _stream(text, timeout=120, *, budgets=None, model=None):
         for d in deltas:
             yield StreamChunk(delta=d)
         yield StreamChunk(delta="", finish_reason="stop")

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -765,7 +765,7 @@ async def test_mcp_auth_expired_returns_error_result():
     drv.navigate_new_chat = AsyncMock()
 
     # send_and_stream must be an async GENERATOR that raises on iteration.
-    async def _raising_stream(text, timeout=120):
+    async def _raising_stream(text, timeout=120, *, budgets=None, model=None):
         raise AuthExpiredError()
         yield  # unreachable, makes this a generator
 

--- a/tests/test_send_acknowledgment.py
+++ b/tests/test_send_acknowledgment.py
@@ -171,3 +171,45 @@ def test_turn_reconciliation_error_preserves_diagnostic():
     assert "execution context destroyed" in msg, (
         f"Error string must include the fetch error, got: {msg}"
     )
+
+
+# ── 3. Missing-composer regression (ChatGPT review finding C) ────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_composer_returns_none_not_false():
+    """When the composer is missing on every poll (navigation, selector drift),
+    the acknowledgment probe should return None (inconclusive) not False (blocking).
+
+    ChatGPT found that valid_probe_seen was set BEFORE the composerPresent
+    check, so an all-missing-composer run incorrectly returned False."""
+    driver = _make_driver()
+    driver._pre_send_user_count = 0
+
+    async def fake_js_strict(expr, timeout=15):
+        # Every probe returns valid JSON but composer is missing
+        if "userCount" in expr and "composerEmpty" in expr:
+            return json.dumps({"userCount": 1, "composerPresent": False, "composerEmpty": False})
+        return "0"
+
+    driver._js_strict = fake_js_strict
+
+    import time as _time
+    import chatgpt_web2api.cdp_driver as cdp_mod
+    _t = [0.0]
+    _real_sleep = asyncio.sleep
+
+    async def fast_sleep(d):
+        _t[0] += d
+        await _real_sleep(0)
+
+    # Patch sleep + monotonic to make the 3s poll window instant
+    original_monotonic = _time.monotonic
+    driver_module = cdp_mod
+    # Can't easily monkeypatch the import inside the method — test directly
+    result = await driver._verify_send_acknowledged()
+
+    # Should be None (inconclusive), not False (blocking)
+    assert result is None, (
+        f"Missing composer should return None (inconclusive), got {result!r}"
+    )

--- a/tests/test_send_acknowledgment.py
+++ b/tests/test_send_acknowledgment.py
@@ -194,19 +194,8 @@ async def test_missing_composer_returns_none_not_false():
 
     driver._js_strict = fake_js_strict
 
-    import time as _time
-    import chatgpt_web2api.cdp_driver as cdp_mod
-    _t = [0.0]
-    _real_sleep = asyncio.sleep
-
-    async def fast_sleep(d):
-        _t[0] += d
-        await _real_sleep(0)
-
-    # Patch sleep + monotonic to make the 3s poll window instant
-    original_monotonic = _time.monotonic
-    driver_module = cdp_mod
-    # Can't easily monkeypatch the import inside the method — test directly
+    # The 3s polling window uses real asyncio.sleep, so this test takes ~3s.
+    # Acceptable for a regression test that verifies a critical safety path.
     result = await driver._verify_send_acknowledged()
 
     # Should be None (inconclusive), not False (blocking)

--- a/tests/test_send_acknowledgment.py
+++ b/tests/test_send_acknowledgment.py
@@ -1,0 +1,165 @@
+"""Tests: send acknowledgment + diagnostic preservation.
+
+ChatGPT code review (conv 6a52f0f3) found two defects:
+
+1. click_send dispatches events but doesn't verify React accepted the
+   submission. If the page is overloaded, the click fires but no message
+   is sent. The bridge silently enters completion detection which finds
+   nothing → reconciliation failure with no diagnostic.
+
+2. TurnReconciliationError discards the underlying fetch_failed diagnostic.
+   The actual error (CDP timeout, destroyed context, HTTP error) is lost.
+
+Fix 1: after click_send + UUID wait, verify at least one acknowledgment:
+  - UUID captured, OR
+  - user-message DOM count increased AND composer cleared
+  If none → raise SendNotAcknowledgedError before entering completion detection.
+
+Fix 2: include last_result.diagnostic in TurnReconciliationError.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.cdp_driver import CDPDriver, SendReadinessError
+from chatgpt_web2api.turn_anchor import TurnReconciliationError, TurnTextResult
+
+
+def _make_driver():
+    """A CDPDriver with mocked transport for testing."""
+    driver = CDPDriver(cdp_port=9222)
+    driver._cdp = AsyncMock()
+    driver._js_strict = AsyncMock(return_value="1")
+    driver._js = AsyncMock(return_value="1")
+    driver._breakers = None
+    driver._current_conv_id = None
+    driver._target_id = "test-target"
+    driver._owns_target = True
+    return driver
+
+
+# ── 1. Send acknowledgment ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_not_acknowledged_raises_when_no_signals(monkeypatch):
+    """When click_send fires but no acknowledgment appears (no UUID, no DOM
+    count increase, composer not cleared), the bridge must raise a typed error
+    instead of silently entering completion detection."""
+    from chatgpt_web2api.cdp_driver import CDPDriver
+
+    driver = _make_driver()
+    # Mock the send path
+    driver.type_message = AsyncMock()
+    driver.click_send = AsyncMock()
+    driver._read_assistant_count_baseline = AsyncMock(return_value=0)
+    driver._identity_listener = None  # no UUID capture possible
+    driver._capture_pre_send_fallback_anchor = AsyncMock(return_value=MagicMock())
+    driver._assert_owned_tab_required = MagicMock()
+
+    # After send: user count stays 0 (message didn't land), composer not cleared
+    call_count = {"n": 0}
+
+    async def fake_js_strict(expr, timeout=15):
+        call_count["n"] += 1
+        # Send acknowledgment probe: user count stays 0, composer NOT empty
+        if "userCount" in expr and "composerEmpty" in expr:
+            return json.dumps({"userCount": 0, "composerEmpty": False})
+        if "assistant" in expr and "length" in expr:
+            return "0"  # no new assistant messages
+        if "prompt-textarea" in expr or "ProseMirror" in expr:
+            # Composer still has text (not cleared)
+            return json.dumps({"text": "the message that should have been sent"})
+        return "0"
+
+    driver._js_strict = fake_js_strict
+
+    # The send_and_stream should raise before entering completion detection
+    with pytest.raises(Exception) as exc_info:
+        async for _ in driver.send_and_stream("test message", timeout=10):
+            pass
+
+    # Should be a SendNotAcknowledged-style error, not a timeout
+    assert "acknowledge" in str(exc_info.value).lower() or "not acknowledged" in str(exc_info.value).lower(), (
+        f"Expected send-acknowledgment error, got: {exc_info.value}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_acknowledged_when_user_count_increases(monkeypatch):
+    """When the user-message count increases after send, the message landed.
+    The bridge should proceed to completion detection normally."""
+    driver = _make_driver()
+    driver.type_message = AsyncMock()
+    driver.click_send = AsyncMock()
+    driver._read_assistant_count_baseline = AsyncMock(return_value=0)
+    driver._identity_listener = None
+    driver._assert_owned_tab_required = MagicMock()
+
+    # Mock the anchor + fallback
+    from chatgpt_web2api.turn_anchor import TurnAnchor
+    anchor = TurnAnchor(sent_text="test", mode="fresh_chat")
+    driver._capture_pre_send_fallback_anchor = AsyncMock(return_value=anchor)
+
+    # After send: user count goes from 0 to 1 (message landed)
+    poll_count = {"n": 0}
+
+    async def fake_js_strict(expr, timeout=15):
+        # Send acknowledgment check: user count + composer empty
+        if "userCount" in expr and "composerEmpty" in expr:
+            return json.dumps({"userCount": 1, "composerEmpty": True})
+        if "assistant" in expr and "length" in expr:
+            return "1"  # assistant appeared too (completion)
+        if "prompt-textarea" in expr or "ProseMirror" in expr:
+            return json.dumps({"text": ""})  # composer cleared
+        # Phase-2 poll: completed
+        if "getBoundingClientRect" in expr:
+            return json.dumps({"text": "ok", "md_text": "ok", "html_len": 60,
+                              "child_count": 1, "has_action": False, "is_thinking": False})
+        return "1"
+
+    driver._js_strict = fake_js_strict
+
+    # Mock the detector to return immediately
+    from chatgpt_web2api.completion_detector import CompletionDetector
+    driver._completion = MagicMock()
+    driver._completion.stream_until_complete = MagicMock()
+
+    async def fake_stream(**kwargs):
+        from chatgpt_web2api.cdp_driver import StreamChunk
+        yield StreamChunk(delta="ok")
+    driver._completion.stream_until_complete = fake_stream
+    driver._completion.last_dom_text = "ok"
+    driver._completion.had_non_text_content = False
+
+    # Should NOT raise — message was acknowledged
+    chunks = []
+    async for chunk in driver.send_and_stream("test message", timeout=10):
+        chunks.append(chunk)
+    assert len(chunks) > 0
+
+
+# ── 2. Diagnostic preservation in TurnReconciliationError ────────────────
+
+
+def test_turn_reconciliation_error_preserves_diagnostic():
+    """TurnReconciliationError must include the last fetch result's diagnostic
+    so operators can distinguish CDP timeout from HTTP error from projection failure."""
+    err = TurnReconciliationError(
+        conversation_id="conv-123",
+        anchor_mode="fresh_chat",
+        last_status="fetch_failed",
+        diagnostic={
+            "captured_id": "uuid-abc",
+            "had_non_text_content": False,
+            "last_fetch_error": "CDP timeout: Runtime.evaluate",
+            "last_fetch_diagnostic": {"error": "execution context destroyed"},
+        },
+    )
+    msg = str(err)
+    diag = err.diagnostic
+    assert "last_fetch_error" in diag, "Diagnostic must include the underlying fetch error"
+    assert "last_fetch_diagnostic" in diag, "Diagnostic must include the fetch result diagnostic"

--- a/tests/test_send_acknowledgment.py
+++ b/tests/test_send_acknowledgment.py
@@ -59,19 +59,20 @@ async def test_send_not_acknowledged_raises_when_no_signals(monkeypatch):
     driver._identity_listener = None  # no UUID capture possible
     driver._capture_pre_send_fallback_anchor = AsyncMock(return_value=MagicMock())
     driver._assert_owned_tab_required = MagicMock()
+    # Set pre-send user count baseline so the delta check works
+    driver._pre_send_user_count = 2  # existing conversation with 2 user msgs
 
-    # After send: user count stays 0 (message didn't land), composer not cleared
+    # After send: user count stays 2 (message didn't land), composer NOT cleared
     call_count = {"n": 0}
 
     async def fake_js_strict(expr, timeout=15):
         call_count["n"] += 1
-        # Send acknowledgment probe: user count stays 0, composer NOT empty
+        # Send acknowledgment probe: count stays at 2 (no increase), composer present but NOT empty
         if "userCount" in expr and "composerEmpty" in expr:
-            return json.dumps({"userCount": 0, "composerEmpty": False})
+            return json.dumps({"userCount": 2, "composerPresent": True, "composerEmpty": False})
         if "assistant" in expr and "length" in expr:
             return "0"  # no new assistant messages
         if "prompt-textarea" in expr or "ProseMirror" in expr:
-            # Composer still has text (not cleared)
             return json.dumps({"text": "the message that should have been sent"})
         return "0"
 
@@ -98,6 +99,7 @@ async def test_send_acknowledged_when_user_count_increases(monkeypatch):
     driver._read_assistant_count_baseline = AsyncMock(return_value=0)
     driver._identity_listener = None
     driver._assert_owned_tab_required = MagicMock()
+    driver._pre_send_user_count = 0  # fresh chat, no prior user messages
 
     # Mock the anchor + fallback
     from chatgpt_web2api.turn_anchor import TurnAnchor
@@ -108,9 +110,9 @@ async def test_send_acknowledged_when_user_count_increases(monkeypatch):
     poll_count = {"n": 0}
 
     async def fake_js_strict(expr, timeout=15):
-        # Send acknowledgment check: user count + composer empty
+        # Send acknowledgment check: user count + composer present + empty
         if "userCount" in expr and "composerEmpty" in expr:
-            return json.dumps({"userCount": 1, "composerEmpty": True})
+            return json.dumps({"userCount": 1, "composerPresent": True, "composerEmpty": True})
         if "assistant" in expr and "length" in expr:
             return "1"  # assistant appeared too (completion)
         if "prompt-textarea" in expr or "ProseMirror" in expr:
@@ -147,7 +149,10 @@ async def test_send_acknowledged_when_user_count_increases(monkeypatch):
 
 def test_turn_reconciliation_error_preserves_diagnostic():
     """TurnReconciliationError must include the last fetch result's diagnostic
-    so operators can distinguish CDP timeout from HTTP error from projection failure."""
+    so operators can distinguish CDP timeout from HTTP error from projection failure.
+
+    The diagnostic must be in BOTH the .diagnostic dict AND the error string
+    (ChatGPT review: agents only see str(exc) via the API)."""
     err = TurnReconciliationError(
         conversation_id="conv-123",
         anchor_mode="fresh_chat",
@@ -155,11 +160,14 @@ def test_turn_reconciliation_error_preserves_diagnostic():
         diagnostic={
             "captured_id": "uuid-abc",
             "had_non_text_content": False,
-            "last_fetch_error": "CDP timeout: Runtime.evaluate",
             "last_fetch_diagnostic": {"error": "execution context destroyed"},
         },
     )
     msg = str(err)
     diag = err.diagnostic
-    assert "last_fetch_error" in diag, "Diagnostic must include the underlying fetch error"
-    assert "last_fetch_diagnostic" in diag, "Diagnostic must include the fetch result diagnostic"
+    # Diagnostic dict must include the underlying fetch error
+    assert "last_fetch_diagnostic" in diag, "Diagnostic dict must include the fetch diagnostic"
+    # Error string must also include it (agents see str(exc), not .diagnostic)
+    assert "execution context destroyed" in msg, (
+        f"Error string must include the fetch error, got: {msg}"
+    )

--- a/tests/test_send_readiness.py
+++ b/tests/test_send_readiness.py
@@ -1,0 +1,207 @@
+"""P2.5: Send-readiness selector hardening tests.
+
+Addresses error #4 — "Send failed: no send button" (button_count:142). A
+fully-loaded ChatGPT page where neither SEND_BUTTON_SELECTOR nor
+SEND_BUTTON_FALLBACK_SELECTOR matched. Co-designed with ChatGPT (vision-
+alignment cycle, conversation 6a4ebb2a).
+
+P2.5 scope:
+  1. Richer diagnostic snapshot (composer_text_length, send_candidates,
+     enabled candidates, stop_button_present, generating_indicator_present).
+  2. Broader send-button fallback selector (type=submit, not just aria-label).
+  3. Distinguish 'composer injection failed' from 'send button missing'.
+"""
+
+import asyncio
+import json
+import logging
+import time as _time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from chatgpt_web2api.chatgpt_dom import ChatGPTDom
+from chatgpt_web2api.cdp_driver import CDPDriver, SendReadinessError
+
+
+@pytest.fixture(autouse=True)
+def _fast_poll(monkeypatch):
+    """Collapse the send-button poll loop so tests run instantly.
+    Patches both asyncio.sleep (the poll interval) and time.monotonic
+    (the deadline check) in the chatgpt_dom module."""
+    _real_sleep = asyncio.sleep
+    _t = [0.0]
+
+    async def _instant(_d):
+        _t[0] += _d  # advance simulated time by the sleep duration
+        await _real_sleep(0)
+
+    monkeypatch.setattr("chatgpt_web2api.chatgpt_dom.asyncio.sleep", _instant)
+    monkeypatch.setattr("chatgpt_web2api.chatgpt_dom.time.monotonic", lambda: _t[0])
+
+
+def _make_dom(diag_json=None):
+    """A ChatGPTDom backed by a real CDPDriver with mocked transport.
+    Using a real driver (not spec mock) so _capture_selector_diagnostic runs
+    the real code path that P2.5 enhances.
+
+    diag_json: the JSON string the diagnostic _js_strict call should return.
+    If None, returns a minimal old-style snapshot (button_count only).
+    """
+    driver = CDPDriver(cdp_port=9222)
+    driver._js = AsyncMock(return_value="")
+    # The diagnostic JS is the only _js_strict call from click_send.
+    # Return the diag payload (or old-style minimal if not provided).
+    driver._js_strict = AsyncMock(return_value=diag_json or json.dumps({
+        "url": "https://chatgpt.com/c/conv-1",
+        "title": "Test",
+        "body_preview": "",
+        "button_count": 142,
+        "textarea_count": 1,
+    }))
+    driver._cdp = AsyncMock()
+    driver._breakers = None
+    driver._current_conv_id = "conv-1"
+    return ChatGPTDom(driver), driver
+
+
+def _make_scripted_js(*, poll_result="no", send_result="no send button"):
+    """Build a fake _js that discriminates by expression content.
+    - The button poll contains 'disabled' (checking btn.disabled)
+    - The send JS contains 'no send button' (the failure return string)
+    """
+    async def fake_js(expr, timeout=15):
+        if "no send button" in expr:
+            return send_result
+        # Button poll (or any other _js call)
+        return poll_result
+    return fake_js
+
+
+def _diag_json(**overrides):
+    """Build the diagnostic snapshot JSON with defaults."""
+    data = {
+        "url": "https://chatgpt.com/c/conv-1",
+        "title": "Test",
+        "body_preview": "Skip to content",
+        "button_count": 142,
+        "textarea_count": 1,
+        "composer_found": True,
+        "composer_text_length": 50,
+        "composer_enabled": True,
+        "send_candidates_count": 0,
+        "enabled_send_candidates_count": 0,
+        "stop_button_present": False,
+        "generating_indicator_present": False,
+    }
+    data.update(overrides)
+    return json.dumps(data)
+
+
+# ── 1. Richer diagnostic snapshot ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_diagnostic_probes_composer_and_send_state(caplog):
+    """When click_send fails, the diagnostic JS should probe send-readiness
+    fields: composer_text_length, send_candidates_count, enabled_send_candidates,
+    stop_button_present, generating_indicator_present — not just button_count.
+
+    This test captures the ACTUAL diagnostic JS expression and verifies it
+    requests the P2.5 fields. The mock returns rich data; the assertion is
+    that the JS expression itself contains the new probes."""
+    captured_js = []
+    dom, driver = _make_dom()
+
+    async def capturing_js_strict(expr, timeout=15):
+        captured_js.append(expr)
+        return _diag_json(send_candidates_count=3, enabled_send_candidates_count=1)
+
+    driver._js = _make_scripted_js(poll_result="no", send_result="no send button")
+    driver._js_strict = capturing_js_strict
+
+    with pytest.raises(SendReadinessError):
+        await dom.click_send()
+
+    # The diagnostic JS should have been called and should probe the new fields.
+    assert len(captured_js) >= 1, "diagnostic _js_strict should have been called"
+    diag_expr = captured_js[-1]
+    assert "send_candidates" in diag_expr or "composer_text" in diag_expr, (
+        f"diagnostic JS should probe send_candidates/composer_text, got: {diag_expr[:120]}"
+    )
+    assert "stop_button" in diag_expr or "stop-button" in diag_expr, (
+        f"diagnostic JS should probe stop_button state, got: {diag_expr[:120]}"
+    )
+
+
+# ── 2. Broader send-button fallback (type=submit) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_succeeds_with_submit_type_fallback():
+    """If the aria-label selector fails but a type=submit button exists inside
+    the composer form, the broader fallback should find it."""
+    dom, driver = _make_dom()
+
+    driver._js = _make_scripted_js(poll_result="yes", send_result="sent")
+    await dom.click_send()  # should NOT raise
+
+
+# ── 3. Distinguish injection-failed from send-button-missing ────────────
+
+
+@pytest.mark.asyncio
+async def test_error_distinguishes_empty_composer_from_missing_button(caplog):
+    """When the send button is missing AND the composer is empty, the error
+    should indicate the composer is empty (injection failed), not just 'no
+    send button'. This distinguishes hypothesis #6 (input injection failed)
+    from hypothesis #1 (selector drift)."""
+    dom, driver = _make_dom()
+
+    driver._js = _make_scripted_js(poll_result="no", send_result="no send button")
+    driver._js_strict = AsyncMock(return_value=_diag_json(
+        composer_text_length=0,  # EMPTY — injection failed!
+    ))
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(SendReadinessError) as exc_info:
+            await dom.click_send()
+
+    msg = str(exc_info.value)
+    all_logs = " ".join(r.message for r in caplog.records)
+    combined = msg + " " + all_logs
+    # The diagnostic should show composer_text_length=0 so a human can
+    # distinguish "text didn't land" from "selector drifted".
+    assert "composer_text_length" in combined, (
+        f"diagnostic should include composer_text_length to distinguish "
+        f"injection failure, got: {combined[:200]}"
+    )
+
+
+# ── 4. Stop-button-present diagnostic ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_diagnostic_captures_stop_button_when_generating(caplog):
+    """When the send button is missing because a generation is in progress
+    (stop button visible), the diagnostic should capture stop_button_present=True."""
+    dom, driver = _make_dom()
+
+    driver._js = _make_scripted_js(poll_result="no", send_result="no send button")
+    driver._js_strict = AsyncMock(return_value=_diag_json(
+        stop_button_present=True,
+        generating_indicator_present=True,
+        composer_enabled=False,
+    ))
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(SendReadinessError):
+            await dom.click_send()
+
+    diag_logs = [r for r in caplog.records if "diagnostic" in r.message.lower()
+                 or "selector" in r.message.lower()]
+    assert len(diag_logs) >= 1
+    log_msg = diag_logs[0].message
+    assert "stop_button_present" in log_msg, (
+        f"diagnostic should capture stop_button state, got: {log_msg}"
+    )

--- a/tests/test_send_readiness.py
+++ b/tests/test_send_readiness.py
@@ -15,13 +15,12 @@ P2.5 scope:
 import asyncio
 import json
 import logging
-import time as _time
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
-from chatgpt_web2api.chatgpt_dom import ChatGPTDom
 from chatgpt_web2api.cdp_driver import CDPDriver, SendReadinessError
+from chatgpt_web2api.chatgpt_dom import ChatGPTDom
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_tab_isolation.py
+++ b/tests/test_tab_isolation.py
@@ -142,7 +142,7 @@ async def test_connect_owned_mode_fails_closed_on_tab_creation_failure():
     d._refresh_token = AsyncMock()
     mock_connect, fake_ws = _mock_ws_connect()
     with patch("chatgpt_web2api.cdp_driver.websockets.connect", mock_connect):
-        with pytest.raises(RuntimeError, match="shared-tab fallback is disabled in owned mode"):
+        with pytest.raises(Exception, match="shared-tab fallback is disabled in owned mode"):
             await d.connect()
 
     # _find_page_ws must NOT have been called — no tab theft

--- a/tests/test_tab_isolation.py
+++ b/tests/test_tab_isolation.py
@@ -120,31 +120,33 @@ async def test_close_closes_owned_tab():
 # ── 3. Fallback to shared tab when createTarget fails ─────────────────
 
 @pytest.mark.asyncio
-async def test_connect_falls_back_to_shared_tab():
-    """When _browser_cdp raises, connect() falls back to _find_page_ws()."""
+async def test_connect_owned_mode_fails_closed_on_tab_creation_failure():
+    """When _create_owned_tab fails in owned mode, connect() must NOT fall
+    back to _find_page_ws. It raises — never steals another process's tab.
+
+    (Previously connect fell back to a shared tab; that was removed because
+    it could adopt another process's tab, causing two drivers to race on
+    the same DOM. See ChatGPT design review, conv 6a507b4c.)
+    """
     d = _make_driver()
 
-    # Mock _browser_cdp to fail
+    # Mock _browser_cdp to fail (Target.createTarget fails)
     async def failing_browser_cdp(method, params=None, timeout=10):
         raise ConnectionError("browser WS unavailable")
     d._browser_cdp = failing_browser_cdp
 
-    # Mock _find_page_ws to succeed
-    async def fake_find_page_ws():
-        return "ws://fake/shared-tab"
-    d._find_page_ws = fake_find_page_ws
-    # No tab to adopt — forces the createTarget path, which fails and falls
-    # back to shared-tab mode.
+    # Mock _find_page_ws — it should NOT be called
+    d._find_page_ws = AsyncMock(return_value="ws://fake/shared-tab")
     d._adopt_existing_chatgpt_tab = lambda: None
-    d._wait_for_chatgpt_ready = AsyncMock()  # see test_connect_creates_owned_tab
+    d._wait_for_chatgpt_ready = AsyncMock()
     d._refresh_token = AsyncMock()
     mock_connect, fake_ws = _mock_ws_connect()
     with patch("chatgpt_web2api.cdp_driver.websockets.connect", mock_connect):
-        await d.connect()
+        with pytest.raises(RuntimeError, match="shared-tab fallback is disabled in owned mode"):
+            await d.connect()
 
-    assert d._target_id is None  # no owned tab — using shared
-    assert d._owns_target is False
-    assert d._ws is not None
+    # _find_page_ws must NOT have been called — no tab theft
+    d._find_page_ws.assert_not_called()
 
 
 # ── 4. close does NOT call closeTarget without an owned tab ───────────


### PR DESCRIPTION
## Summary

17 commits addressing bridge reliability across multi-session usage.

### Fixes
- **P0** — Empty MCP error messages (PoolExhaustedError/PoolShuttingDownError now carry context)
- **P1** — Model-aware stall detector (reasoning models get 300s first-content budget vs 90s)
- **P1.5** — Pool lease instrumentation (hold duration, release reason, double-release detection)
- **P2** — Staged navigation readiness probe (diagnostic error messages naming the failing stage)
- **P2.5** — Send-readiness selector hardening (rich diagnostics + broader composer-scoped selector)
- **non_text fix** — Reconciliation race: non_text status was treated as terminal (fixed, e2e verified 3/3)
- **URL parsing** — _is_url_at_conversation didn't handle project-scoped URLs (/g/{gizmo}/c/{id})
- **Adopt fallback removal** — Owned mode no longer steals another process's tab during reconnect
- **Recovery hook** — ZCode SessionStart hook runs ensure for bridge auto-recovery after reboot

### Test coverage
678 unit tests (was 628). All passing.

### Co-development
Designed and reviewed with ChatGPT across 4 review cycles. 7 bugs caught in review.